### PR TITLE
Improve statement cache

### DIFF
--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -9,3 +9,18 @@ pub(crate) use small_cstr::SmallCString;
 mod sqlite_string;
 #[cfg(any(feature = "modern_sqlite", feature = "vtab"))]
 pub(crate) use sqlite_string::SqliteMallocString;
+
+#[inline]
+pub(crate) fn get_cached<T, F>(cache: &std::cell::Cell<Option<T>>, lookup: F) -> T
+where
+    T: Copy,
+    F: FnOnce() -> T,
+{
+    if let Some(v) = cache.get() {
+        v
+    } else {
+        let cb = lookup();
+        cache.set(Some(cb));
+        cb
+    }
+}

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -9,18 +9,3 @@ pub(crate) use small_cstr::SmallCString;
 mod sqlite_string;
 #[cfg(any(feature = "modern_sqlite", feature = "vtab"))]
 pub(crate) use sqlite_string::SqliteMallocString;
-
-#[inline]
-pub(crate) fn get_cached<T, F>(cache: &std::cell::Cell<Option<T>>, lookup: F) -> T
-where
-    T: Copy,
-    F: FnOnce() -> T,
-{
-    if let Some(v) = cache.get() {
-        v
-    } else {
-        let cb = lookup();
-        cache.set(Some(cb));
-        cb
-    }
-}


### PR DESCRIPTION
Arc<str> has a little overhead (really way less than people think...) but far less than cloning the string every time. This way we never need to clone it.