### PR TITLE
VTabCursor lifetime should be bound to VTab lifetime

### DIFF
--- a/src/vtab/csvtab.rs
+++ b/src/vtab/csvtab.rs
@@ -22,6 +22,7 @@
 //! }
 //! ```
 use std::fs::File;
+use std::marker::PhantomData;
 use std::os::raw::c_int;
 use std::path::Path;
 use std::str;
@@ -95,9 +96,9 @@ impl CSVTab {
     }
 }
 
-unsafe impl VTab for CSVTab {
+unsafe impl<'vtab> VTab<'vtab> for CSVTab {
     type Aux = ();
-    type Cursor = CSVTabCursor;
+    type Cursor = CSVTabCursor<'vtab>;
 
     fn connect(
         _: &mut VTabConnection,
@@ -258,16 +259,16 @@ unsafe impl VTab for CSVTab {
         Ok(())
     }
 
-    fn open(&self) -> Result<CSVTabCursor> {
+    fn open(&'vtab self) -> Result<CSVTabCursor<'vtab>> {
         Ok(CSVTabCursor::new(self.reader()?))
     }
 }
 
-impl CreateVTab for CSVTab {}
+impl CreateVTab<'_> for CSVTab {}
 
 /// A cursor for the CSV virtual table
 #[repr(C)]
-struct CSVTabCursor {
+struct CSVTabCursor<'vtab> {
     /// Base class. Must be first
     base: ffi::sqlite3_vtab_cursor,
     /// The CSV reader object
@@ -277,16 +278,18 @@ struct CSVTabCursor {
     /// Values of the current row
     cols: csv::StringRecord,
     eof: bool,
+    phantom: PhantomData<&'vtab CSVTab>,
 }
 
-impl CSVTabCursor {
-    fn new(reader: csv::Reader<File>) -> CSVTabCursor {
+impl CSVTabCursor<'_> {
+    fn new<'vtab>(reader: csv::Reader<File>) -> CSVTabCursor<'vtab> {
         CSVTabCursor {
             base: ffi::sqlite3_vtab_cursor::default(),
             reader,
             row_number: 0,
             cols: csv::StringRecord::new(),
             eof: false,
+            phantom: PhantomData,
         }
     }
 
@@ -296,7 +299,7 @@ impl CSVTabCursor {
     }
 }
 
-unsafe impl VTabCursor for CSVTabCursor {
+unsafe impl VTabCursor for CSVTabCursor<'_> {
     // Only a full table scan is supported.  So `filter` simply rewinds to
     // the beginning.
     fn filter(


### PR DESCRIPTION
```c
struct sqlite3_vtab_cursor {
  sqlite3_vtab *pVtab;      /* Virtual table of this cursor */
```
It seems that we need to introduce a lifetime on `VTab` trait
to express such constraint:
https://users.rust-lang.org/t/associated-type-with-lifetime-bound/7256
But there may be another/new way to do it.