### PR TITLE
Don't implement Into<RawStatement> for Statement

### DIFF
--- a/src/cache.rs
+++ b/src/cache.rs
@@ -84,7 +84,7 @@ impl Drop for CachedStatement<'_> {
     #[allow(unused_must_use)]
     fn drop(&mut self) {
         if let Some(stmt) = self.stmt.take() {
-            self.cache.cache_stmt(stmt.into());
+            self.cache.cache_stmt(unsafe { stmt.into_raw() });
         }
     }
 }

--- a/src/raw_statement.rs
+++ b/src/raw_statement.rs
@@ -153,7 +153,7 @@ impl RawStatement {
         r
     }
 
-    #[cfg(feature = "modern_sqlite")] // 3.7.4
+    #[cfg(all(feature = "extra_check", feature = "modern_sqlite"))] // 3.7.4
     pub fn readonly(&self) -> bool {
         unsafe { ffi::sqlite3_stmt_readonly(self.ptr) != 0 }
     }
@@ -168,6 +168,7 @@ impl RawStatement {
         unsafe { ffi::sqlite3_stmt_status(self.ptr, status as i32, reset as i32) }
     }
 
+    #[cfg(feature = "extra_check")]
     pub fn has_tail(&self) -> bool {
         self.tail
     }

--- a/src/statement.rs
+++ b/src/statement.rs
@@ -702,11 +702,12 @@ impl Statement<'_> {
     pub(crate) fn check_no_tail(&self) -> Result<()> {
         Ok(())
     }
-}
 
-impl Into<RawStatement> for Statement<'_> {
-    fn into(mut self) -> RawStatement {
-        let mut stmt = unsafe { RawStatement::new(ptr::null_mut(), false) };
+    /// Safety: This is unsafe, because using `sqlite3_stmt` after the
+    /// connection has closed is illegal, but `RawStatement` does not enforce
+    /// this, as it loses our protective `'conn` lifetime bound.
+    pub(crate) unsafe fn into_raw(mut self) -> RawStatement {
+        let mut stmt = RawStatement::new(ptr::null_mut(), false);
         mem::swap(&mut stmt, &mut self.stmt);
         stmt
     }


### PR DESCRIPTION
Our usage of this function is sound, and RawStatement is entirely internal at the moment so it doesn't really matter, but this should be unsafe as RawStatement loses the protection we get from the `&'conn` reference.