### PR TITLE
Fix cross-compilation with mingw with `bundled` feature

### DIFF
--- a/libsqlite3-sys/build.rs
+++ b/libsqlite3-sys/build.rs
@@ -79,6 +79,7 @@ mod build_bundled {
             .flag("-DSQLITE_THREADSAFE=1")
             .flag("-DSQLITE_USE_URI")
             .flag("-DHAVE_USLEEP=1")
+            .flag("-D_POSIX_THREAD_SAFE_FUNCTIONS") // cross compile with MinGW
             .warnings(false);
 
         if cfg!(feature = "with-asan") {


### PR DESCRIPTION
Hi there. My host OS is archlinux, and I couldn't compile sqlite to Windows with MingGW. So, I've found [solution](https://stackoverflow.com/questions/18551409/localtime-r-support-on-mingw#comment102194285_18551984).

Before fix:
```  = note: /usr/lib/gcc/x86_64-w64-mingw32/10.1.0/../../../../x86_64-w64-mingw32/bin/ld: /home/duckerman/Games_64/Rust/dber/target/x86_64-pc-windows-gnu/release/deps/liblibsqlite3_sys-1a4844c5c876a50f.rlib(sqlite3.o):sqlite3.c:(.text$localtimeOffset+0x453): undefined reference to `localtime_r' ```

Thanks to @berkus from Rust chat :)