### PR TITLE
Fix order of parameters in InvalidParameterCount message

### DIFF
--- a/src/statement.rs
+++ b/src/statement.rs
@@ -454,7 +454,7 @@ impl Statement<'_> {
             self.bind_parameter(&p, index)?;
         }
         if index != expected {
-            Err(Error::InvalidParameterCount(expected, index))
+            Err(Error::InvalidParameterCount(index, expected))
         } else {
             Ok(())
         }


### PR DESCRIPTION
This prints a message like `Error: Wrong number of parameters passed to query. Got 7, needed 8`, but the numbers were the wrong way around - i.e. it should have printed `Got 8, needed 7` in this case.

Untested but it's pretty trivial.