### PR TITLE
Upgrade to time v0.2 and put it behind a feature flag

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -82,6 +82,9 @@ bundled-full = [
     "load_extension",
     "serde_json",
     "series",
+    # time v0.2 does not work with tarpaulin v0.14.0. See time-rs/time#265.
+    # Re-enable when time v0.3 is released with the fix.
+    # "time",
     "trace",
     "unlock_notify",
     "url",
@@ -91,7 +94,7 @@ bundled-full = [
 ]
 
 [dependencies]
-time = "0.1.0"
+time = { version = "0.2", optional = true }
 bitflags = "1.0"
 lru-cache = "0.1"
 chrono = { version = "0.4", optional = true }
@@ -140,7 +143,7 @@ name = "exec"
 harness = false
 
 [package.metadata.docs.rs]
-features = [ "backup", "blob", "chrono", "collation", "functions", "limits", "load_extension", "serde_json", "trace", "url", "vtab", "window", "modern_sqlite", "column_decltype" ]
+features = [ "backup", "blob", "chrono", "collation", "functions", "limits", "load_extension", "serde_json", "time", "trace", "url", "vtab", "window", "modern_sqlite", "column_decltype" ]
 all-features = false
 no-default-features = true
 default-target = "x86_64-unknown-linux-gnu"

--- a/README.md
+++ b/README.md
@@ -91,6 +91,9 @@ features](https://doc.rust-lang.org/cargo/reference/manifest.html#the-features-s
 * `serde_json` implements [`FromSql`](https://docs.rs/rusqlite/~0/rusqlite/types/trait.FromSql.html)
   and [`ToSql`](https://docs.rs/rusqlite/~0/rusqlite/types/trait.ToSql.html) for the
   `Value` type from the [`serde_json` crate](https://crates.io/crates/serde_json).
+* `time` implements [`FromSql`](https://docs.rs/rusqlite/~0/rusqlite/types/trait.FromSql.html)
+   and [`ToSql`](https://docs.rs/rusqlite/~0/rusqlite/types/trait.ToSql.html) for the
+   `time::OffsetDateTime` type from the [`time` crate](https://crates.io/crates/time).
 * `url` implements [`FromSql`](https://docs.rs/rusqlite/~0/rusqlite/types/trait.FromSql.html)
   and [`ToSql`](https://docs.rs/rusqlite/~0/rusqlite/types/trait.ToSql.html) for the
   `Url` type from the [`url` crate](https://crates.io/crates/url).
@@ -109,7 +112,7 @@ features](https://doc.rust-lang.org/cargo/reference/manifest.html#the-features-s
 
 `libsqlite3-sys` is a separate crate from `rusqlite` that provides the Rust
 declarations for SQLite's C API. By default, `libsqlite3-sys` attempts to find a SQLite library that already exists on your system using pkg-config, or a
-[Vcpkg](https://github.com/Microsoft/vcpkg) installation for MSVC ABI builds. 
+[Vcpkg](https://github.com/Microsoft/vcpkg) installation for MSVC ABI builds.
 
 You can adjust this behavior in a number of ways:
 
@@ -131,7 +134,7 @@ You can adjust this behavior in a number of ways:
   options. The default when using vcpkg is to dynamically link,
   which must be enabled by setting `VCPKGRS_DYNAMIC=1` environment variable before build.
   `vcpkg install sqlite3:x64-windows` will install the required library.
-  
+
 ### Binding generation
 
 We use [bindgen](https://crates.io/crates/bindgen) to generate the Rust

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,13 +3,11 @@
 //!
 //! ```rust
 //! use rusqlite::{params, Connection, Result};
-//! use time::Timespec;
 //!
 //! #[derive(Debug)]
 //! struct Person {
 //!     id: i32,
 //!     name: String,
-//!     time_created: Timespec,
 //!     data: Option<Vec<u8>>,
 //! }
 //!
@@ -20,7 +18,6 @@
 //!         "CREATE TABLE person (
 //!                   id              INTEGER PRIMARY KEY,
 //!                   name            TEXT NOT NULL,
-//!                   time_created    TEXT NOT NULL,
 //!                   data            BLOB
 //!                   )",
 //!         params![],
@@ -28,22 +25,19 @@
 //!     let me = Person {
 //!         id: 0,
 //!         name: "Steven".to_string(),
-//!         time_created: time::get_time(),
 //!         data: None,
 //!     };
 //!     conn.execute(
-//!         "INSERT INTO person (name, time_created, data)
-//!                   VALUES (?1, ?2, ?3)",
-//!         params![me.name, me.time_created, me.data],
+//!         "INSERT INTO person (name, data) VALUES (?1, ?2)",
+//!         params![me.name, me.data],
 //!     )?;
 //!
-//!     let mut stmt = conn.prepare("SELECT id, name, time_created, data FROM person")?;
+//!     let mut stmt = conn.prepare("SELECT id, name, data FROM person")?;
 //!     let person_iter = stmt.query_map(params![], |row| {
 //!         Ok(Person {
 //!             id: row.get(0)?,
 //!             name: row.get(1)?,
-//!             time_created: row.get(2)?,
-//!             data: row.get(3)?,
+//!             data: row.get(2)?,
 //!         })
 //!     })?;
 //!

--- a/src/types/time.rs
+++ b/src/types/time.rs
@@ -1,40 +1,40 @@
+//! `ToSql` and `FromSql` implementation for [`time::OffsetDateTime`].
 use crate::types::{FromSql, FromSqlError, FromSqlResult, ToSql, ToSqlOutput, ValueRef};
 use crate::Result;
+use time::{OffsetDateTime, PrimitiveDateTime, UtcOffset};
 
 const CURRENT_TIMESTAMP_FMT: &str = "%Y-%m-%d %H:%M:%S";
-const SQLITE_DATETIME_FMT: &str = "%Y-%m-%dT%H:%M:%S.%fZ";
-const SQLITE_DATETIME_FMT_LEGACY: &str = "%Y-%m-%d %H:%M:%S:%f %Z";
+const SQLITE_DATETIME_FMT: &str = "%Y-%m-%dT%H:%M:%S.%NZ";
+const SQLITE_DATETIME_FMT_LEGACY: &str = "%Y-%m-%d %H:%M:%S:%N %z";
 
-impl ToSql for time::Timespec {
+impl ToSql for OffsetDateTime {
     fn to_sql(&self) -> Result<ToSqlOutput<'_>> {
-        let time_string = time::at_utc(*self)
-            .strftime(SQLITE_DATETIME_FMT)
-            .unwrap()
-            .to_string();
+        let time_string = self.to_offset(UtcOffset::UTC).format(SQLITE_DATETIME_FMT);
         Ok(ToSqlOutput::from(time_string))
     }
 }
 
-impl FromSql for time::Timespec {
+impl FromSql for OffsetDateTime {
     fn column_result(value: ValueRef<'_>) -> FromSqlResult<Self> {
-        value
-            .as_str()
-            .and_then(|s| {
-                match s.len() {
-                    19 => time::strptime(s, CURRENT_TIMESTAMP_FMT),
-                    _ => time::strptime(s, SQLITE_DATETIME_FMT).or_else(|err| {
-                        time::strptime(s, SQLITE_DATETIME_FMT_LEGACY).map_err(|_| err)
+        value.as_str().and_then(|s| {
+            match s.len() {
+                19 => PrimitiveDateTime::parse(s, CURRENT_TIMESTAMP_FMT).map(|d| d.assume_utc()),
+                _ => PrimitiveDateTime::parse(s, SQLITE_DATETIME_FMT)
+                    .map(|d| d.assume_utc())
+                    .or_else(|err| {
+                        OffsetDateTime::parse(s, SQLITE_DATETIME_FMT_LEGACY).map_err(|_| err)
                     }),
-                }
-                .map_err(|err| FromSqlError::Other(Box::new(err)))
-            })
-            .map(|tm| tm.to_timespec())
+            }
+            .map_err(|err| FromSqlError::Other(Box::new(err)))
+        })
     }
 }
 
 #[cfg(test)]
 mod test {
     use crate::{Connection, Result, NO_PARAMS};
+    use std::time::Duration;
+    use time::OffsetDateTime;
 
     fn checked_memory_handle() -> Connection {
         let db = Connection::open_in_memory().unwrap();
@@ -44,22 +44,25 @@ mod test {
     }
 
     #[test]
-    fn test_timespec() {
+    fn test_offset_date_time() {
         let db = checked_memory_handle();
 
         let mut ts_vec = vec![];
 
-        ts_vec.push(time::Timespec::new(10_000, 0)); //January 1, 1970 2:46:40 AM
-        ts_vec.push(time::Timespec::new(10_000, 1000)); //January 1, 1970 2:46:40 AM (and one microsecond)
-        ts_vec.push(time::Timespec::new(1_500_391_124, 1_000_000)); //July 18, 2017
-        ts_vec.push(time::Timespec::new(2_000_000_000, 2_000_000)); //May 18, 2033
-        ts_vec.push(time::Timespec::new(3_000_000_000, 999_999_999)); //January 24, 2065
-        ts_vec.push(time::Timespec::new(10_000_000_000, 0)); //November 20, 2286
+        let make_datetime =
+            |secs, nanos| OffsetDateTime::from_unix_timestamp(secs) + Duration::from_nanos(nanos);
+
+        ts_vec.push(make_datetime(10_000, 0)); //January 1, 1970 2:46:40 AM
+        ts_vec.push(make_datetime(10_000, 1000)); //January 1, 1970 2:46:40 AM (and one microsecond)
+        ts_vec.push(make_datetime(1_500_391_124, 1_000_000)); //July 18, 2017
+        ts_vec.push(make_datetime(2_000_000_000, 2_000_000)); //May 18, 2033
+        ts_vec.push(make_datetime(3_000_000_000, 999_999_999)); //January 24, 2065
+        ts_vec.push(make_datetime(10_000_000_000, 0)); //November 20, 2286
 
         for ts in ts_vec {
             db.execute("INSERT INTO foo(t) VALUES (?)", &[&ts]).unwrap();
 
-            let from: time::Timespec = db
+            let from: OffsetDateTime = db
                 .query_row("SELECT t FROM foo", NO_PARAMS, |r| r.get(0))
                 .unwrap();
 
@@ -72,7 +75,7 @@ mod test {
     #[test]
     fn test_sqlite_functions() {
         let db = checked_memory_handle();
-        let result: Result<time::Timespec> =
+        let result: Result<OffsetDateTime> =
             db.query_row("SELECT CURRENT_TIMESTAMP", NO_PARAMS, |r| r.get(0));
         assert!(result.is_ok());
     }


### PR DESCRIPTION
This also removes the usage of time in the crate's top-level
documentation example, as was done for the README in #625.

Fix #653.