### PR TITLE
pragma_update fails with ExecuteReturnedResults

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -451,7 +451,8 @@ impl Connection {
         let mut sql = sql;
         while !sql.is_empty() {
             let stmt = self.prepare(sql)?;
-            if !stmt.stmt.is_null() && stmt.step()? {
+            if !stmt.stmt.is_null() && stmt.step()? && cfg!(feature = "extra_check") {
+                // Some PRAGMA may return rows
                 return Err(Error::ExecuteReturnedResults);
             }
             let tail = stmt.stmt.tail();

--- a/src/pragma.rs
+++ b/src/pragma.rs
@@ -430,4 +430,15 @@ mod test {
         sql.push_string_literal("value'; --");
         assert_eq!("'value''; --'", sql.as_str());
     }
+
+    #[test]
+    fn locking_mode() {
+        let db = Connection::open_in_memory().unwrap();
+        let r = db.pragma_update(None, "locking_mode", &"exclusive");
+        if cfg!(feature = "extra_check") {
+            r.unwrap_err();
+        } else {
+            r.unwrap();
+        }
+    }
 }


### PR DESCRIPTION
Ideally, while executing a batch, we should fail if it contains a SELECT
statement. But currently there is no way to make the distinction between
a SELECT and a PRAGMA which both updates and returns a row.
So we fail only when `extra_check` feature is activated.