### PR TITLE
Add support for linking to winsqlite3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,6 +61,7 @@ bundled-windows = ["libsqlite3-sys/bundled-windows"]
 with-asan = ["libsqlite3-sys/with-asan"]
 column_decltype = []
 wasm32-wasi-vfs = ["libsqlite3-sys/wasm32-wasi-vfs"]
+winsqlite3 = ["libsqlite3-sys/winsqlite3"]
 
 # Helper feature for enabling both `bundled` and most non-build-related optional
 # features or dependencies. This is useful for running tests / clippy / etc. New

--- a/libsqlite3-sys/Cargo.toml
+++ b/libsqlite3-sys/Cargo.toml
@@ -33,6 +33,8 @@ session = ["preupdate_hook", "buildtime_bindgen"]
 in_gecko = []
 with-asan = []
 wasm32-wasi-vfs = []
+# lowest version shipped with Windows 10.0.10586 was 3.8.8.3
+winsqlite3 = ["min_sqlite_version_3_7_16"]
 
 [build-dependencies]
 bindgen = { version = "0.54", optional = true, default-features = false, features = ["runtime"] }

--- a/libsqlite3-sys/build.rs
+++ b/libsqlite3-sys/build.rs
@@ -245,6 +245,11 @@ mod build_linked {
         // on is available, for example.
         println!("cargo:link-target={}", link_lib);
 
+        if cfg!(all(windows, feature = "winsqlite3")) {
+            println!("cargo:rustc-link-lib=dylib={}", link_lib);
+            return HeaderLocation::Wrapper;
+        }
+
         // Allow users to specify where to find SQLite.
         if let Ok(dir) = env::var(format!("{}_LIB_DIR", env_prefix())) {
             // Try to use pkg-config to determine link commands
@@ -306,6 +311,8 @@ mod build_linked {
     fn link_lib() -> &'static str {
         if cfg!(feature = "sqlcipher") {
             "sqlcipher"
+        } else if cfg!(all(windows, feature = "winsqlite3")) {
+            "winsqlite3"
         } else {
             "sqlite3"
         }
@@ -385,6 +392,36 @@ mod bindings {
         }
         if cfg!(feature = "session") {
             bindings = bindings.clang_arg("-DSQLITE_ENABLE_SESSION");
+        }
+        if cfg!(all(windows, feature = "winsqlite3")) {
+            bindings = bindings
+                .clang_arg("-DBINDGEN_USE_WINSQLITE3")
+                .blacklist_item("NTDDI_.+")
+                .blacklist_item("WINAPI_FAMILY.*")
+                .blacklist_item("_WIN32_.+")
+                .blacklist_item("_VCRT_COMPILER_PREPROCESSOR")
+                .blacklist_item("_SAL_VERSION")
+                .blacklist_item("__SAL_H_VERSION")
+                .blacklist_item("_USE_DECLSPECS_FOR_SAL")
+                .blacklist_item("_USE_ATTRIBUTES_FOR_SAL")
+                .blacklist_item("_CRT_PACKING")
+                .blacklist_item("_HAS_EXCEPTIONS")
+                .blacklist_item("_STL_LANG")
+                .blacklist_item("_HAS_CXX17")
+                .blacklist_item("_HAS_CXX20")
+                .blacklist_item("_HAS_NODISCARD")
+                .blacklist_item("WDK_NTDDI_VERSION")
+                .blacklist_item("OSVERSION_MASK")
+                .blacklist_item("SPVERSION_MASK")
+                .blacklist_item("SUBVERSION_MASK")
+                .blacklist_item("WINVER")
+                .blacklist_item("__security_cookie")
+                .blacklist_type("size_t")
+                .blacklist_type("__vcrt_bool")
+                .blacklist_type("wchar_t")
+                .blacklist_function("__security_init_cookie")
+                .blacklist_function("__report_gsfailure")
+                .blacklist_function("__va_start");
         }
 
         // When cross compiling unless effort is taken to fix the issue, bindgen

--- a/libsqlite3-sys/wrapper.h
+++ b/libsqlite3-sys/wrapper.h
@@ -1,1 +1,5 @@
+#ifdef BINDGEN_USE_WINSQLITE3
+#include <winsqlite/winsqlite3.h>
+#else
 #include "sqlite3.h"
+#endif


### PR DESCRIPTION
There is system sqlite library on Windows 10 machines since Anniversary Update https://blogs.windows.com/windowsdeveloper/2017/02/06/using-sqlite-databases-uwp-apps/

Not sure if using `wrapper.h` is a good idea, otherwise I need to figure out full path to Windows SDK