### PR TITLE
Add `must_use` attribute to iterators

### DIFF
--- a/src/row.rs
+++ b/src/row.rs
@@ -6,6 +6,7 @@ use super::{Error, Result, Statement};
 use crate::types::{FromSql, FromSqlError, ValueRef};
 
 /// An handle for the resulting rows of a query.
+#[must_use = "Rows is lazy and will do nothing unless consumed"]
 pub struct Rows<'stmt> {
     pub(crate) stmt: Option<&'stmt Statement<'stmt>>,
     row: Option<Row<'stmt>>,
@@ -96,6 +97,7 @@ impl Drop for Rows<'_> {
 }
 
 /// `F` is used to tranform the _streaming_ iterator into a _fallible_ iterator.
+#[must_use = "iterators are lazy and do nothing unless consumed"]
 pub struct Map<'stmt, F> {
     rows: Rows<'stmt>,
     f: F,
@@ -119,6 +121,7 @@ where
 /// An iterator over the mapped resulting rows of a query.
 ///
 /// `F` is used to tranform the _streaming_ iterator into a _standard_ iterator.
+#[must_use = "iterators are lazy and do nothing unless consumed"]
 pub struct MappedRows<'stmt, F> {
     rows: Rows<'stmt>,
     map: F,
@@ -150,6 +153,7 @@ where
 
 /// An iterator over the mapped resulting rows of a query, with an Error type
 /// unifying with Error.
+#[must_use = "iterators are lazy and do nothing unless consumed"]
 pub struct AndThenRows<'stmt, F> {
     rows: Rows<'stmt>,
     map: F,


### PR DESCRIPTION
I got bitten by the laziness of `query_and_then` recently, so figured I'd try to make it safer for the next person trying to write iterators in a hurry :sweat_smile:

Now if you forget to consume an iterator like `AndRowsThen`, you get a warning:

```
warning: unused `rusqlite::AndThenRows` that must be used
   --> some_project/src/lib.rs:689:9
    |
689 | /         txn.prepare(
690 | |             "SELECT a, b, c
691 | |              FROM x, y
692 | |              WHERE x.a = y.a",
...   |
703 | |             Ok(())
704 | |         })?;
    | |____________^
    |
    = note: `#[warn(unused_must_use)]` on by default
    = note: iterators are lazy and do nothing unless consumed
```