### PR TITLE
Replace lru-cache with hashlink

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -98,7 +98,7 @@ bundled-full = [
 [dependencies]
 time = { version = "0.2", optional = true }
 bitflags = "1.2"
-lru-cache = "0.1"
+hashlink = "0.5"
 chrono = { version = "0.4", optional = true }
 serde_json = { version = "1.0", optional = true }
 csv = { version = "1.1", optional = true }

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -2,7 +2,7 @@
 
 use crate::raw_statement::RawStatement;
 use crate::{Connection, Result, Statement};
-use lru_cache::LruCache;
+use hashlink::LruCache;
 use std::cell::RefCell;
 use std::ops::{Deref, DerefMut};
 use std::sync::Arc;
@@ -54,7 +54,7 @@ impl Connection {
 }
 
 /// Prepared statements LRU cache.
-#[derive(Debug)]
+// #[derive(Debug)] // FIXME: https://github.com/kyren/hashlink/pull/4
 pub struct StatementCache(RefCell<LruCache<Arc<str>, RawStatement>>);
 
 /// Cacheable statement.


### PR DESCRIPTION
Fixes #810, although hashlink is kinda a heavyweight dep (pulls in hashbrown). Oh well, probably doesn't matter that much, I didn't notice it taking much longer to compile anyway.

We should be able to simplify some of the nonsense with the source `Arc<str>` we do too, since hashlink supports raw_entry. I'll do that some time in the future, maybe.

If https://github.com/kyren/hashlink/pull/4 will land soon then we should probably wait for that, since as it is `hashlink::LruCache` doesn't impl Debug, and our StatementCache does. IDR if StatementCache is public, but either way.

