### PR TITLE
Prepare release 0.24.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rusqlite"
-version = "0.24.0"
+version = "0.24.1"
 authors = ["The rusqlite developers"]
 edition = "2018"
 description = "Ergonomic wrapper for SQLite"

--- a/README.md
+++ b/README.md
@@ -119,11 +119,11 @@ You can adjust this behavior in a number of ways:
 * If you use the `bundled` feature, `libsqlite3-sys` will use the
   [cc](https://crates.io/crates/cc) crate to compile SQLite from source and
   link against that. This source is embedded in the `libsqlite3-sys` crate and
-  is currently SQLite 3.33.0 (as of `rusqlite` 0.24.0 / `libsqlite3-sys`
+  is currently SQLite 3.33.0 (as of `rusqlite` 0.24.1 / `libsqlite3-sys`
   0.20.0).  This is probably the simplest solution to any build problems. You can enable this by adding the following in your `Cargo.toml` file:
   ```toml
   [dependencies.rusqlite]
-  version = "0.24.0"
+  version = "0.24.1"
   features = ["bundled"]
   ```
 * You can set the `SQLITE3_LIB_DIR` to point to directory containing the SQLite


### PR DESCRIPTION
This is just for #811, and even then because it causes crashes for firefox when built with nightly rust.

@eoger / @mhammond / @rfk after this release is cut, can someone update the vendored rusqlite in m-c? I don't want to set up a m-c dev env. (Sorry for pinging all three of you, but IDK who still is on the team responsible for this)