### PR TITLE
Reduce required lifetime in create_scalar_function

### DIFF
--- a/src/functions.rs
+++ b/src/functions.rs
@@ -334,15 +334,15 @@ impl Connection {
     /// # Failure
     ///
     /// Will return Err if the function could not be attached to the connection.
-    pub fn create_scalar_function<F, T>(
-        &self,
+    pub fn create_scalar_function<'a, F, T>(
+        &'a self,
         fn_name: &str,
         n_arg: c_int,
         flags: FunctionFlags,
         x_func: F,
     ) -> Result<()>
     where
-        F: FnMut(&Context<'_>) -> Result<T> + Send + UnwindSafe + 'static,
+        F: FnMut(&Context<'_>) -> Result<T> + Send + UnwindSafe + 'a,
         T: ToSql,
     {
         self.db
@@ -411,15 +411,15 @@ impl Connection {
 }
 
 impl InnerConnection {
-    fn create_scalar_function<F, T>(
-        &mut self,
+    fn create_scalar_function<'a, F, T>(
+        &'a mut self,
         fn_name: &str,
         n_arg: c_int,
         flags: FunctionFlags,
         x_func: F,
     ) -> Result<()>
     where
-        F: FnMut(&Context<'_>) -> Result<T> + Send + UnwindSafe + 'static,
+        F: FnMut(&Context<'_>) -> Result<T> + Send + UnwindSafe + 'a,
         T: ToSql,
     {
         unsafe extern "C" fn call_boxed_closure<F, T>(


### PR DESCRIPTION
The docs explicitly say the function only exists for the duration of the connection. Reducing the lifetime requirement makes it possible to pass in a sufficiently long-lived closure that captures additional context to the function