### PR TITLE
Overhaul parameter API

### DIFF
--- a/benches/exec.rs
+++ b/benches/exec.rs
@@ -1,10 +1,10 @@
 use bencher::{benchmark_group, benchmark_main, Bencher};
-use rusqlite::{Connection, NO_PARAMS};
+use rusqlite::Connection;
 
 fn bench_execute(b: &mut Bencher) {
     let db = Connection::open_in_memory().unwrap();
     let sql = "PRAGMA user_version=1";
-    b.iter(|| db.execute(sql, NO_PARAMS).unwrap());
+    b.iter(|| db.execute(sql, []).unwrap());
 }
 
 fn bench_execute_batch(b: &mut Bencher) {

--- a/src/backup.rs
+++ b/src/backup.rs
@@ -306,7 +306,7 @@ impl Drop for Backup<'_, '_> {
 #[cfg(test)]
 mod test {
     use super::Backup;
-    use crate::{Connection, DatabaseName, NO_PARAMS};
+    use crate::{Connection, DatabaseName};
     use std::time::Duration;
 
     #[test]
@@ -326,7 +326,7 @@ mod test {
         }
 
         let the_answer: i64 = dst
-            .query_row("SELECT x FROM foo", NO_PARAMS, |r| r.get(0))
+            .query_row("SELECT x FROM foo", [], |r| r.get(0))
             .unwrap();
         assert_eq!(42, the_answer);
 
@@ -340,7 +340,7 @@ mod test {
         }
 
         let the_answer: i64 = dst
-            .query_row("SELECT SUM(x) FROM foo", NO_PARAMS, |r| r.get(0))
+            .query_row("SELECT SUM(x) FROM foo", [], |r| r.get(0))
             .unwrap();
         assert_eq!(42 + 43, the_answer);
     }
@@ -364,7 +364,7 @@ mod test {
         }
 
         let the_answer: i64 = dst
-            .query_row("SELECT x FROM foo", NO_PARAMS, |r| r.get(0))
+            .query_row("SELECT x FROM foo", [], |r| r.get(0))
             .unwrap();
         assert_eq!(42, the_answer);
 
@@ -380,7 +380,7 @@ mod test {
         }
 
         let the_answer: i64 = dst
-            .query_row("SELECT SUM(x) FROM foo", NO_PARAMS, |r| r.get(0))
+            .query_row("SELECT SUM(x) FROM foo", [], |r| r.get(0))
             .unwrap();
         assert_eq!(42 + 43, the_answer);
     }
@@ -409,7 +409,7 @@ mod test {
         }
 
         let the_answer: i64 = dst
-            .query_row("SELECT x FROM foo", NO_PARAMS, |r| r.get(0))
+            .query_row("SELECT x FROM foo", [], |r| r.get(0))
             .unwrap();
         assert_eq!(42, the_answer);
 
@@ -429,7 +429,7 @@ mod test {
         }
 
         let the_answer: i64 = dst
-            .query_row("SELECT SUM(x) FROM foo", NO_PARAMS, |r| r.get(0))
+            .query_row("SELECT SUM(x) FROM foo", [], |r| r.get(0))
             .unwrap();
         assert_eq!(42 + 43, the_answer);
     }

--- a/src/blob/mod.rs
+++ b/src/blob/mod.rs
@@ -111,10 +111,7 @@
 //! // Insert a BLOB into the `content` column of `test_table`. Note that the Blob
 //! // I/O API provides no way of inserting or resizing BLOBs in the DB -- this
 //! // must be done via SQL.
-//! db.execute(
-//!     "INSERT INTO test_table (content) VALUES (ZEROBLOB(10))",
-//!     [],
-//! )?;
+//! db.execute("INSERT INTO test_table (content) VALUES (ZEROBLOB(10))", [])?;
 //!
 //! // Get the row id off the BLOB we just inserted.
 //! let rowid = db.last_insert_rowid();
@@ -162,10 +159,7 @@
 //! // Insert a blob into the `content` column of `test_table`. Note that the Blob
 //! // I/O API provides no way of inserting or resizing blobs in the DB -- this
 //! // must be done via SQL.
-//! db.execute(
-//!     "INSERT INTO test_table (content) VALUES (ZEROBLOB(10))",
-//!     [],
-//! )?;
+//! db.execute("INSERT INTO test_table (content) VALUES (ZEROBLOB(10))", [])?;
 //! // Get the row id off the blob we just inserted.
 //! let rowid = db.last_insert_rowid();
 //! // Open the blob we just inserted for IO.

--- a/src/blob/mod.rs
+++ b/src/blob/mod.rs
@@ -138,7 +138,7 @@
 //! // rust (potentially with a dynamic size).
 //! db.execute(
 //!     "INSERT INTO test_table (content) VALUES (?)",
-//!     &[ZeroBlob(64)],
+//!     [ZeroBlob(64)],
 //! )?;
 //!
 //! // given a new row ID, we can reopen the blob on that row
@@ -182,7 +182,7 @@
 //! // rust (potentially with a dynamic size).
 //! db.execute(
 //!     "INSERT INTO test_table (content) VALUES (?)",
-//!     &[ZeroBlob(64)],
+//!     [ZeroBlob(64)],
 //! )?;
 //!
 //! // given a new row ID, we can reopen the blob on that row

--- a/src/blob/mod.rs
+++ b/src/blob/mod.rs
@@ -101,7 +101,7 @@
 //!
 //! ```rust
 //! # use rusqlite::blob::ZeroBlob;
-//! # use rusqlite::{Connection, DatabaseName, NO_PARAMS};
+//! # use rusqlite::{Connection, DatabaseName};
 //! # use std::error::Error;
 //! # use std::io::{Read, Seek, SeekFrom, Write};
 //! # fn main() -> Result<(), Box<dyn Error>> {
@@ -113,7 +113,7 @@
 //! // must be done via SQL.
 //! db.execute(
 //!     "INSERT INTO test_table (content) VALUES (ZEROBLOB(10))",
-//!     NO_PARAMS,
+//!     [],
 //! )?;
 //!
 //! // Get the row id off the BLOB we just inserted.
@@ -154,7 +154,7 @@
 //!
 //! ```rust
 //! # use rusqlite::blob::ZeroBlob;
-//! # use rusqlite::{Connection, DatabaseName, NO_PARAMS};
+//! # use rusqlite::{Connection, DatabaseName};
 //! # use std::error::Error;
 //! # fn main() -> Result<(), Box<dyn Error>> {
 //! let db = Connection::open_in_memory()?;
@@ -164,7 +164,7 @@
 //! // must be done via SQL.
 //! db.execute(
 //!     "INSERT INTO test_table (content) VALUES (ZEROBLOB(10))",
-//!     NO_PARAMS,
+//!     [],
 //! )?;
 //! // Get the row id off the blob we just inserted.
 //! let rowid = db.last_insert_rowid();

--- a/src/blob/pos_io.rs
+++ b/src/blob/pos_io.rs
@@ -194,7 +194,7 @@ impl<'conn> Blob<'conn> {
 
 #[cfg(test)]
 mod test {
-    use crate::{Connection, DatabaseName, NO_PARAMS};
+    use crate::{Connection, DatabaseName};
     // to ensure we don't modify seek pos
     use std::io::Seek as _;
 
@@ -203,11 +203,8 @@ mod test {
         let db = Connection::open_in_memory().unwrap();
         db.execute_batch("CREATE TABLE test_table(content BLOB);")
             .unwrap();
-        db.execute(
-            "INSERT INTO test_table(content) VALUES (ZEROBLOB(10))",
-            NO_PARAMS,
-        )
-        .unwrap();
+        db.execute("INSERT INTO test_table(content) VALUES (ZEROBLOB(10))", [])
+            .unwrap();
 
         let rowid = db.last_insert_rowid();
         let mut blob = db

--- a/src/busy.rs
+++ b/src/busy.rs
@@ -82,7 +82,7 @@ mod test {
     use std::thread;
     use std::time::Duration;
 
-    use crate::{Connection, Error, ErrorCode, Result, TransactionBehavior, NO_PARAMS};
+    use crate::{Connection, Error, ErrorCode, Result, TransactionBehavior};
 
     #[test]
     fn test_default_busy() {
@@ -94,7 +94,7 @@ mod test {
             .transaction_with_behavior(TransactionBehavior::Exclusive)
             .unwrap();
         let db2 = Connection::open(&path).unwrap();
-        let r: Result<()> = db2.query_row("PRAGMA schema_version", NO_PARAMS, |_| unreachable!());
+        let r: Result<()> = db2.query_row("PRAGMA schema_version", [], |_| unreachable!());
         match r.unwrap_err() {
             Error::SqliteFailure(err, _) => {
                 assert_eq!(err.code, ErrorCode::DatabaseBusy);
@@ -126,9 +126,7 @@ mod test {
 
         assert_eq!(tx.recv().unwrap(), 1);
         let _ = db2
-            .query_row("PRAGMA schema_version", NO_PARAMS, |row| {
-                row.get::<_, i32>(0)
-            })
+            .query_row("PRAGMA schema_version", [], |row| row.get::<_, i32>(0))
             .expect("unexpected error");
 
         child.join().unwrap();
@@ -163,9 +161,7 @@ mod test {
 
         assert_eq!(tx.recv().unwrap(), 1);
         let _ = db2
-            .query_row("PRAGMA schema_version", NO_PARAMS, |row| {
-                row.get::<_, i32>(0)
-            })
+            .query_row("PRAGMA schema_version", [], |row| row.get::<_, i32>(0))
             .expect("unexpected error");
         assert_eq!(CALLED.load(Ordering::Relaxed), true);
 

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -164,7 +164,7 @@ impl StatementCache {
 #[cfg(test)]
 mod test {
     use super::StatementCache;
-    use crate::{Connection, NO_PARAMS};
+    use crate::Connection;
     use fallible_iterator::FallibleIterator;
 
     impl StatementCache {
@@ -193,20 +193,14 @@ mod test {
         {
             let mut stmt = db.prepare_cached(sql).unwrap();
             assert_eq!(0, cache.len());
-            assert_eq!(
-                0,
-                stmt.query_row(NO_PARAMS, |r| r.get::<_, i64>(0)).unwrap()
-            );
+            assert_eq!(0, stmt.query_row([], |r| r.get::<_, i64>(0)).unwrap());
         }
         assert_eq!(1, cache.len());
 
         {
             let mut stmt = db.prepare_cached(sql).unwrap();
             assert_eq!(0, cache.len());
-            assert_eq!(
-                0,
-                stmt.query_row(NO_PARAMS, |r| r.get::<_, i64>(0)).unwrap()
-            );
+            assert_eq!(0, stmt.query_row([], |r| r.get::<_, i64>(0)).unwrap());
         }
         assert_eq!(1, cache.len());
 
@@ -224,10 +218,7 @@ mod test {
         {
             let mut stmt = db.prepare_cached(sql).unwrap();
             assert_eq!(0, cache.len());
-            assert_eq!(
-                0,
-                stmt.query_row(NO_PARAMS, |r| r.get::<_, i64>(0)).unwrap()
-            );
+            assert_eq!(0, stmt.query_row([], |r| r.get::<_, i64>(0)).unwrap());
         }
         assert_eq!(1, cache.len());
 
@@ -237,10 +228,7 @@ mod test {
         {
             let mut stmt = db.prepare_cached(sql).unwrap();
             assert_eq!(0, cache.len());
-            assert_eq!(
-                0,
-                stmt.query_row(NO_PARAMS, |r| r.get::<_, i64>(0)).unwrap()
-            );
+            assert_eq!(0, stmt.query_row([], |r| r.get::<_, i64>(0)).unwrap());
         }
         assert_eq!(0, cache.len());
 
@@ -248,10 +236,7 @@ mod test {
         {
             let mut stmt = db.prepare_cached(sql).unwrap();
             assert_eq!(0, cache.len());
-            assert_eq!(
-                0,
-                stmt.query_row(NO_PARAMS, |r| r.get::<_, i64>(0)).unwrap()
-            );
+            assert_eq!(0, stmt.query_row([], |r| r.get::<_, i64>(0)).unwrap());
         }
         assert_eq!(1, cache.len());
     }
@@ -265,10 +250,7 @@ mod test {
         {
             let mut stmt = db.prepare_cached(sql).unwrap();
             assert_eq!(0, cache.len());
-            assert_eq!(
-                0,
-                stmt.query_row(NO_PARAMS, |r| r.get::<_, i64>(0)).unwrap()
-            );
+            assert_eq!(0, stmt.query_row([], |r| r.get::<_, i64>(0)).unwrap());
             stmt.discard();
         }
         assert_eq!(0, cache.len());
@@ -291,7 +273,7 @@ mod test {
             let mut stmt = db.prepare_cached(sql).unwrap();
             assert_eq!(
                 Ok(Some(1i32)),
-                stmt.query(NO_PARAMS).unwrap().map(|r| r.get(0)).next()
+                stmt.query([]).unwrap().map(|r| r.get(0)).next()
             );
         }
 
@@ -307,7 +289,7 @@ mod test {
             let mut stmt = db.prepare_cached(sql).unwrap();
             assert_eq!(
                 Ok(Some((1i32, 2i32))),
-                stmt.query(NO_PARAMS)
+                stmt.query([])
                     .unwrap()
                     .map(|r| Ok((r.get(0)?, r.get(1)?)))
                     .next()
@@ -334,20 +316,14 @@ mod test {
         {
             let mut stmt = db.prepare_cached(sql).unwrap();
             assert_eq!(0, cache.len());
-            assert_eq!(
-                0,
-                stmt.query_row(NO_PARAMS, |r| r.get::<_, i64>(0)).unwrap()
-            );
+            assert_eq!(0, stmt.query_row([], |r| r.get::<_, i64>(0)).unwrap());
         }
         assert_eq!(1, cache.len());
 
         {
             let mut stmt = db.prepare_cached(sql).unwrap();
             assert_eq!(0, cache.len());
-            assert_eq!(
-                0,
-                stmt.query_row(NO_PARAMS, |r| r.get::<_, i64>(0)).unwrap()
-            );
+            assert_eq!(0, stmt.query_row([], |r| r.get::<_, i64>(0)).unwrap());
         }
         assert_eq!(1, cache.len());
     }

--- a/src/collation.rs
+++ b/src/collation.rs
@@ -157,7 +157,7 @@ impl InnerConnection {
 
 #[cfg(test)]
 mod test {
-    use crate::{Connection, Result, NO_PARAMS};
+    use crate::{Connection, Result};
     use fallible_streaming_iterator::FallibleStreamingIterator;
     use std::cmp::Ordering;
     use unicase::UniCase;
@@ -185,7 +185,7 @@ mod test {
         let mut stmt = db
             .prepare("SELECT DISTINCT bar COLLATE unicase FROM foo ORDER BY 1")
             .unwrap();
-        let rows = stmt.query(NO_PARAMS).unwrap();
+        let rows = stmt.query([]).unwrap();
         assert_eq!(rows.count().unwrap(), 1);
     }
 

--- a/src/column.rs
+++ b/src/column.rs
@@ -194,7 +194,7 @@ mod test {
         )
         .unwrap();
         let mut stmt = db.prepare("SELECT x as renamed, y FROM foo").unwrap();
-        let mut rows = stmt.query(crate::NO_PARAMS).unwrap();
+        let mut rows = stmt.query([]).unwrap();
         let row = rows.next().unwrap().unwrap();
         match row.get::<_, String>(0).unwrap_err() {
             Error::InvalidColumnType(idx, name, ty) => {

--- a/src/functions.rs
+++ b/src/functions.rs
@@ -43,11 +43,10 @@
 //!     let db = Connection::open_in_memory()?;
 //!     add_regexp_function(&db)?;
 //!
-//!     let is_match: bool = db.query_row(
-//!         "SELECT regexp('[aeiou]*', 'aaaaeeeiii')",
-//!         [],
-//!         |row| row.get(0),
-//!     )?;
+//!     let is_match: bool =
+//!         db.query_row("SELECT regexp('[aeiou]*', 'aaaaeeeiii')", [], |row| {
+//!             row.get(0)
+//!         })?;
 //!
 //!     assert!(is_match);
 //!     Ok(())

--- a/src/functions.rs
+++ b/src/functions.rs
@@ -45,7 +45,7 @@
 //!
 //!     let is_match: bool = db.query_row(
 //!         "SELECT regexp('[aeiou]*', 'aaaaeeeiii')",
-//!         NO_PARAMS,
+//!         [],
 //!         |row| row.get(0),
 //!     )?;
 //!
@@ -311,7 +311,7 @@ impl Connection {
     /// # Example
     ///
     /// ```rust
-    /// # use rusqlite::{Connection, Result, NO_PARAMS};
+    /// # use rusqlite::{Connection, Result};
     /// # use rusqlite::functions::FunctionFlags;
     /// fn scalar_function_example(db: Connection) -> Result<()> {
     ///     db.create_scalar_function(
@@ -324,7 +324,7 @@ impl Connection {
     ///         },
     ///     )?;
     ///
-    ///     let six_halved: f64 = db.query_row("SELECT halve(6)", NO_PARAMS, |r| r.get(0))?;
+    ///     let six_halved: f64 = db.query_row("SELECT halve(6)", [], |r| r.get(0))?;
     ///     assert_eq!(six_halved, 3f64);
     ///     Ok(())
     /// }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -133,12 +133,8 @@ const STATEMENT_CACHE_DEFAULT_CAPACITY: usize = 16;
 ///
 /// [sqlite-varparam]: https://sqlite.org/lang_expr.html#varparam
 ///
-/// Note that for most uses this is no longer necessary, and an empty array
-/// should be used instead.
-///
-/// That is, in previous rusqlite releases you would need to do
-/// `conn.execute(rusqlite::NO_PARAMS)`, however you can now do
-/// `conn.execute([])` which is equivalent.
+/// This is deprecated in favor of using an empty array literal.
+#[deprecated = "Use an empty array instead; `stmt.execute(NO_PARAMS)` => `stmt.execute([])`"]
 pub const NO_PARAMS: &[&dyn ToSql] = &[];
 
 /// A macro making it more convenient to pass heterogeneous or long lists of
@@ -165,7 +161,7 @@ pub const NO_PARAMS: &[&dyn ToSql] = &[];
 #[macro_export]
 macro_rules! params {
     () => {
-        $crate::NO_PARAMS
+        (&[] as &[&dyn $crate::ToSql])
     };
     ($($param:expr),+ $(,)?) => {
         &[$(&$param as &dyn $crate::ToSql),+] as &[&dyn $crate::ToSql]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -187,7 +187,7 @@ macro_rules! params {
 /// }
 ///
 /// fn add_person(conn: &Connection, person: &Person) -> Result<()> {
-///     conn.execute_named(
+///     conn.execute(
 ///         "INSERT INTO person (name, age_in_years, data)
 ///          VALUES (:name, :age, :data)",
 ///         named_params!{
@@ -511,7 +511,7 @@ impl Connection {
     /// ```rust,no_run
     /// # use rusqlite::{Connection, Result};
     /// fn insert(conn: &Connection) -> Result<usize> {
-    ///     conn.execute_named(
+    ///     conn.execute(
     ///         "INSERT INTO test (name) VALUES (:name)",
     ///         rusqlite::named_params!{ ":name": "one" },
     ///     )

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -161,7 +161,7 @@ pub const NO_PARAMS: &[&dyn ToSql] = &[];
 #[macro_export]
 macro_rules! params {
     () => {
-        (&[] as &[&dyn $crate::ToSql])
+        &[] as &[&dyn $crate::ToSql]
     };
     ($($param:expr),+ $(,)?) => {
         &[$(&$param as &dyn $crate::ToSql),+] as &[&dyn $crate::ToSql]
@@ -198,12 +198,12 @@ macro_rules! params {
 #[macro_export]
 macro_rules! named_params {
     () => {
-        (&[] as &[(&str, &dyn $crate::ToSql)])
+        &[] as &[(&str, &dyn $crate::ToSql)]
     };
     // Note: It's a lot more work to support this as part of the same macro as
     // `params!`, unfortunately.
     ($($param_name:literal: $param_val:expr),+ $(,)?) => {
-        (&[$(($param_name, &$param_val as &dyn $crate::ToSql)),+] as &[(&str, &dyn $crate::ToSql)])
+        &[$(($param_name, &$param_val as &dyn $crate::ToSql)),+] as &[(&str, &dyn $crate::ToSql)]
     };
 }
 

--- a/src/params.rs
+++ b/src/params.rs
@@ -5,16 +5,162 @@ mod sealed {
     /// that are allowed are ones in this crate.
     pub trait Sealed {}
 }
-// must not be `pub use`.
 use sealed::Sealed;
 
-/// Trait used for parameter sets passed into SQL statements/queries.
+/// Trait used for [sets of parameter][params] passed into SQL
+/// statements/queries.
 ///
-/// Currently, this trait can only be implemented inside this crate.
+/// [params]: https://www.sqlite.org/c3ref/bind_blob.html
+///
+/// Note: Currently, this trait can only be implemented inside this crate.
+/// Additionally, it's methods (which are `doc(hidden)`) should currently not be
+/// considered part of the stable API, although it's possible they will
+/// stabilize in the future.
+///
+/// # Passing parameters to SQLite
+///
+/// Many functions in this library let you pass parameters to SQLite. Doing this
+/// lets you avoid any risk of SQL injection, and is simpler than escaping
+/// things manually. Aside from deprecated functions and a few helpers, this is
+/// indicated by the function taking a generic argument that implements `Params`
+/// (this trait).
+///
+/// ## Positional parameters
+///
+/// For cases where you want to pass a list of parameters where the number of
+/// parameters is known at compile time, this can be done in one of the
+/// following ways:
+///
+/// - Using the [`rusqlite::params!`](crate::params!) macro, e.g.
+///   `thing.query(rusqlite::params![1, "foo", bar])`. This is mostly useful for
+///   heterogeneous lists of parameters, or lists where the number of parameters
+///   exceeds 32.
+///
+/// - For small heterogeneous lists of parameters, they can either be passed as:
+///
+///     - an array, as in `thing.query([1i32, 2, 3, 4])` or `thing.query(["foo",
+///       "bar", "baz"])`.
+///
+///     - a reference to an array of references, as in `thing.query(&["foo",
+///       "bar", "baz"])` or `thing.query(&[&1i32, &2, &3])`.
+///
+///         (Note: in this case we don't implement this for slices for coherence
+///         reasons, so it really is only for the "reference to array" types —
+///         hence why the number of parameters must be <= 32 or you need to
+///         reach for `rusqlite::params!`)
+///
+///     Unfortunately, in the current design it's not possible to allow this for
+///     references to arrays of non-references (e.g. `&[1i32, 2, 3]`). Code like
+///     this should instead either use `params!`, an array literal, a `&[&dyn
+///     ToSql]` or if none of those work, [`ParamsFromIter`].
+///
+/// - As a slice of `ToSql` trait object references, e.g. `&[&dyn ToSql]`. This
+///   is mostly useful for passing parameter lists around as arguments without
+///   having every function take a generic `P: Params`.
+///
+/// ### Example (positional)
+///
+/// ```rust,no_run
+/// # use rusqlite::{Connection, Result, params};
+/// fn update_rows(conn: &Connection) -> Result<()> {
+///     let mut stmt = conn.prepare("INSERT INTO test (a, b) VALUES (?, ?)")?;
+///
+///     // Using `rusqlite::params!`:
+///     stmt.execute(params![1i32, "blah"])?;
+///
+///     // array literal — non-references
+///     stmt.execute([2i32, 3i32])?;
+///
+///     // array literal — references
+///     stmt.execute(["foo", "bar"])?;
+///
+///     // Slice literal, references:
+///     stmt.execute(&[&2i32, &3i32])?;
+///
+///     // Note: The types behind the references don't have to be `Sized`
+///     stmt.execute(&["foo", "bar"])?;
+///
+///     // However, this doesn't work (see above):
+///     // stmt.execute(&[1i32, 2i32])?;
+///     Ok(())
+/// }
+/// ```
+///
+/// ## Named parameters
+///
+/// SQLite lets you name parameters using a number of conventions (":foo",
+/// "@foo", "$foo"). You can pass named parameters in to SQLite using rusqlite
+/// in a few ways:
+///
+/// - Using the [`rusqlite::named_params!`](crate::named_params!) macro, as in
+///   `stmt.execute(named_params!{ ":name": "foo", ":age": 99 })`. Similar to
+///   the `params` macro, this is most useful for heterogeneous lists of
+///   parameters, or lists where the number of parameters exceeds 32.
+///
+/// - As a slice of `&[(&str, &dyn ToSql)]`. This is what essentially all of
+///   these boil down to in the end, conceptually at least. In theory you can
+///   pass this as `stmt.
+///
+/// - As array references, similar to the positional params. This looks like
+///   `thing.query(&[(":foo", &1i32), (":bar", &2i32)])` or
+///   `thing.query(&[(":foo", "abc"), (":bar", "def")])`.
+///
+/// Note: Unbound named parameters will be left to the value they previously
+/// were bound with, falling back to `NULL` for parameters which have never been
+/// bound.
+///
+/// ### Example (named)
+///
+/// ```rust,no_run
+/// # use rusqlite::{Connection, Result, named_params};
+/// fn insert(conn: &Connection) -> Result<()> {
+///     let mut stmt = conn.prepare("INSERT INTO test (key, value) VALUES (:key, :value)")?;
+///     // Using `rusqlite::params!`:
+///     stmt.execute(named_params!{ ":key": "one", ":val": 2 })?;
+///     // Alternatively:
+///     stmt.execute(&[(":key", "three"), (":val", "four")])?;
+///     // Or:
+///     stmt.execute(&[(":key", &100), (":val", &200)])?;
+///     Ok(())
+/// }
+/// ```
+///
+/// ## No parameters
+///
+/// You can just use an empty array literal for no params. The
+/// `rusqlite::NO_PARAMS` constant which was so common in previous versions of
+/// this library is no longer needed.
+///
+/// ### Example (no parameters)
+///
+/// ```rust,no_run
+/// # use rusqlite::{Connection, Result, params};
+/// fn delete_all_users(conn: &Connection) -> Result<()> {
+///     // Just use an empty array (e.g. `[]`) for no params.
+///     conn.execute("DELETE FROM users", [])?;
+///     Ok(())
+/// }
+/// ```
+///
+/// ## Dynamic parameter list
+///
+/// If you have a number of parameters which is unknown at compile time (for
+/// example, building a dynamic query at runtime), you have two choices:
+///
+/// - Use a `&[&dyn ToSql]`, which is nice if you have one otherwise might be
+///   annoying.
+/// - Use the [`ParamsFromIter`] type. This essentially lets you wrap an
+///   iterator some `T: ToSql` with something that implements `Params`.
+///
+/// A lot of the considerations here are similar either way, so you should see
+/// the [`ParamsFromIter`] documentation for more info / examples.
 pub trait Params: Sealed {
-    /// Binds the parameters to the statement. It is unlikely calling this
-    /// explicitly will do what you want. Please use `Statement::query` or
-    /// similar directly.
+    // XXX not public api, might not need to expose.
+    //
+    // Binds the parameters to the statement. It is unlikely calling this
+    // explicitly will do what you want. Please use `Statement::query` or
+    // similar directly.
+    //
     // For now, just hide the function in the docs...
     #[doc(hidden)]
     fn bind_in(self, stmt: &mut Statement<'_>) -> Result<()>;
@@ -69,6 +215,10 @@ macro_rules! impl_for_array_ref {
         }
     )+};
 }
+
+// Following libstd/libcore's (old) lead, implement this for arrays up to `[_;
+// 32]`. Note `[_; 0]` is intentionally omitted for coherence reasons, see the
+// note above the impl of `[&dyn ToSql; 0]` for more information.
 impl_for_array_ref!(
     1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17
     18 19 20 21 22 23 24 25 26 27 29 30 31 32
@@ -154,17 +304,21 @@ impl_for_array_ref!(
 /// production-ready:
 ///
 /// - production code should ensure `usernames` isn't so large that it will
-///   surpass [`conn.limit(Limit::SQLITE_LIMIT_VARIABLE_NUMBER)`][limits])
-///   (chunking if too large).
+///   surpass [`conn.limit(Limit::SQLITE_LIMIT_VARIABLE_NUMBER)`][limits]),
+///   chunking if too large. (Note that the limits api requires rusqlite to have
+///   the "limits" feature).
 ///
 /// - `repeat_vars` can be implemented in a way that avoids needing to allocate
 ///   a String.
+///
+/// - Etc...
 ///
 /// [limits]: crate::Connection::limit
 ///
 /// This complexity reflects the fact that `ParamsFromIter` is mainly intended
 /// for advanced use cases — most of the time you should know how many
-/// parameters you have statically.
+/// parameters you have statically (and if you don't, you're either doing
+/// something tricky, or should take a moment to think about the design).
 #[derive(Clone, Debug)]
 pub struct ParamsFromIter<I>(I);
 

--- a/src/params.rs
+++ b/src/params.rs
@@ -264,8 +264,8 @@ impl_for_array_ref!(
 ///
 /// ## Realistic use case
 ///
-/// Here's how you'd use `ParamsFromIter` to call a function with no `_iter`
-/// equivalent, e.g. [`Statement::exists`].
+/// Here's how you'd use `ParamsFromIter` to call [`Statement::exists`] with a
+/// dynamic number of parameters.
 ///
 /// ```rust,no_run
 /// use rusqlite::{Connection, Result};

--- a/src/params.rs
+++ b/src/params.rs
@@ -172,8 +172,11 @@ pub trait Params: Sealed {
 impl Sealed for [&dyn ToSql; 0] {}
 impl Params for [&dyn ToSql; 0] {
     #[inline]
-    fn bind_in(self, _: &mut Statement<'_>) -> Result<()> {
-        Ok(())
+    fn bind_in(self, stmt: &mut Statement<'_>) -> Result<()> {
+        // Note: Can't just return `Ok(())` — `Statement::bind_parameters`
+        // checks that the right number of params were passed too.
+        // TODO: we should have tests for `Error::InvalidParameterCount`...
+        stmt.bind_parameters(crate::params![])
     }
 }
 

--- a/src/params.rs
+++ b/src/params.rs
@@ -129,7 +129,7 @@ use sealed::Sealed;
 ///
 /// You can just use an empty array literal for no params. The
 /// `rusqlite::NO_PARAMS` constant which was so common in previous versions of
-/// this library is no longer needed.
+/// this library is no longer needed (and is now deprecated).
 ///
 /// ### Example (no parameters)
 ///

--- a/src/params.rs
+++ b/src/params.rs
@@ -1,0 +1,198 @@
+use crate::{Result, Statement, ToSql};
+
+mod sealed {
+    /// This trait exists just to ensure that the only impls of `trait Params`
+    /// that are allowed are ones in this crate.
+    pub trait Sealed {}
+}
+// must not be `pub use`.
+use sealed::Sealed;
+
+/// Trait used for parameter sets passed into SQL statements/queries.
+///
+/// Currently, this trait can only be implemented inside this crate.
+pub trait Params: Sealed {
+    /// Binds the parameters to the statement. It is unlikely calling this
+    /// explicitly will do what you want. Please use `Statement::query` or
+    /// similar directly.
+    // For now, just hide the function in the docs...
+    #[doc(hidden)]
+    fn bind_in(self, stmt: &mut Statement<'_>) -> Result<()>;
+}
+
+// Explicitly impl for empty array. Critically, for `conn.execute([])` to be
+// unambiguous, this must be the *only* implementation for an empty array. This
+// avoids `NO_PARAMS` being a necessary part of the API.
+impl Sealed for [&dyn ToSql; 0] {}
+impl Params for [&dyn ToSql; 0] {
+    #[inline]
+    fn bind_in(self, _: &mut Statement<'_>) -> Result<()> {
+        Ok(())
+    }
+}
+
+impl Sealed for &[&dyn ToSql] {}
+impl Params for &[&dyn ToSql] {
+    #[inline]
+    fn bind_in(self, stmt: &mut Statement<'_>) -> Result<()> {
+        stmt.bind_parameters(self)
+    }
+}
+
+impl Sealed for &[(&str, &dyn ToSql)] {}
+impl Params for &[(&str, &dyn ToSql)] {
+    #[inline]
+    fn bind_in(self, stmt: &mut Statement<'_>) -> Result<()> {
+        stmt.bind_parameters_named(self)
+    }
+}
+
+macro_rules! impl_for_array_ref {
+    ($($N:literal)+) => {$(
+        impl<T: ToSql + ?Sized> Sealed for &[&T; $N] {}
+        impl<T: ToSql + ?Sized> Params for &[&T; $N] {
+            fn bind_in(self, stmt: &mut Statement<'_>) -> Result<()> {
+                stmt.bind_parameters(self)
+            }
+        }
+        impl<T: ToSql + ?Sized> Sealed for &[(&str, &T); $N] {}
+        impl<T: ToSql + ?Sized> Params for &[(&str, &T); $N] {
+            fn bind_in(self, stmt: &mut Statement<'_>) -> Result<()> {
+                stmt.bind_parameters_named(self)
+            }
+        }
+        impl<T: ToSql> Sealed for [T; $N] {}
+        impl<T: ToSql> Params for [T; $N] {
+            fn bind_in(self, stmt: &mut Statement<'_>) -> Result<()> {
+                stmt.bind_parameters(&self)
+            }
+        }
+    )+};
+}
+impl_for_array_ref!(
+    1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17
+    18 19 20 21 22 23 24 25 26 27 29 30 31 32
+);
+
+/// Adapter type which allows any iterator over [`ToSql`] values to implement
+/// [`Params`].
+///
+/// This struct is created by the [`params_from_iter`] function.
+///
+/// This can be useful if you have something like an `&[String]` (of unknown
+/// length), and you want to use them with an API that wants something
+/// implementing `Params`. This way, you can avoid having to allocate storage
+/// for something like a `&[&dyn ToSql]`.
+///
+/// This essentially is only ever actually needed when dynamically generating
+/// SQL — static SQL (by definition) has the number of parameters known
+/// statically. As dynamically generating SQL is itself pretty advanced, this
+/// API is itself for advanced use cases (See "Realistic use case" in the
+/// examples).
+///
+/// # Example
+///
+/// ## Basic usage
+///
+/// ```rust,no_run
+/// use rusqlite::{Connection, Result, params_from_iter};
+/// use std::collections::BTreeSet;
+///
+/// fn query(conn: &Connection, ids: &BTreeSet<String>) -> Result<()> {
+///     assert_eq!(ids.len(), 3, "Unrealistic sample code");
+///
+///     let mut stmt = conn.prepare("SELECT * FROM users WHERE id IN (?, ?, ?)")?;
+///     let _rows = stmt.query(params_from_iter(ids.iter()))?;
+///
+///     // use _rows...
+///     Ok(())
+/// }
+/// ```
+///
+/// ## Realistic use case
+///
+/// Here's how you'd use `ParamsFromIter` to call a function with no `_iter`
+/// equivalent, e.g. [`Statement::exists`].
+///
+/// ```rust,no_run
+/// use rusqlite::{Connection, Result};
+///
+/// pub fn any_active_users(conn: &Connection, usernames: &[String]) -> Result<bool> {
+///     if usernames.is_empty() {
+///         return Ok(false);
+///     }
+///
+///     // Note: `repeat_vars` never returns anything attacker-controlled, so
+///     // it's fine to use it in a dynamically-built SQL string.
+///     let vars = repeat_vars(usernames.len());
+///
+///     let sql = format!(
+///         // In practice this would probably be better as an `EXISTS` query.
+///         "SELECT 1 FROM user WHERE is_active AND name IN ({}) LIMIT 1",
+///         vars,
+///     );
+///     let mut stmt = conn.prepare(&sql)?;
+///     stmt.exists(rusqlite::params_from_iter(usernames))
+/// }
+///
+/// // Helper function to return a comma-separated sequence of `?`.
+/// // - `repeat_vars(0) => panic!(...)`
+/// // - `repeat_vars(1) => "?"`
+/// // - `repeat_vars(2) => "?,?"`
+/// // - `repeat_vars(3) => "?,?,?"`
+/// // - ...
+/// fn repeat_vars(count: usize) -> String {
+///     assert_ne!(count, 0);
+///     let mut s = "?,".repeat(count);
+///     // Remove trailing comma
+///     s.pop();
+///     s
+/// }
+/// ```
+///
+/// That is fairly complex, and even so would need even more work to be fully
+/// production-ready:
+///
+/// - production code should ensure `usernames` isn't so large that it will
+///   surpass [`conn.limit(Limit::SQLITE_LIMIT_VARIABLE_NUMBER)`][limits])
+///   (chunking if too large).
+///
+/// - `repeat_vars` can be implemented in a way that avoids needing to allocate
+///   a String.
+///
+/// [limits]: crate::Connection::limit
+///
+/// This complexity reflects the fact that `ParamsFromIter` is mainly intended
+/// for advanced use cases — most of the time you should know how many
+/// parameters you have statically.
+#[derive(Clone, Debug)]
+pub struct ParamsFromIter<I>(I);
+
+/// Constructor function for a [`ParamsFromIter`]. See its documentation for
+/// more.
+#[inline]
+pub fn params_from_iter<I>(iter: I) -> ParamsFromIter<I>
+where
+    I: IntoIterator,
+    I::Item: ToSql,
+{
+    ParamsFromIter(iter)
+}
+
+impl<I> Sealed for ParamsFromIter<I>
+where
+    I: IntoIterator,
+    I::Item: ToSql,
+{
+}
+
+impl<I> Params for ParamsFromIter<I>
+where
+    I: IntoIterator,
+    I::Item: ToSql,
+{
+    #[inline]
+    fn bind_in(self, stmt: &mut Statement<'_>) -> Result<()> {
+        stmt.bind_parameters(self.0)
+    }
+}

--- a/src/row.rs
+++ b/src/row.rs
@@ -40,9 +40,9 @@ impl<'stmt> Rows<'stmt> {
     /// implements `FallibleIterator`.
     /// ```rust,no_run
     /// use fallible_iterator::FallibleIterator;
-    /// # use rusqlite::{Result, Statement, NO_PARAMS};
+    /// # use rusqlite::{Result, Statement};
     /// fn query(stmt: &mut Statement) -> Result<Vec<i64>> {
-    ///     let rows = stmt.query(NO_PARAMS)?;
+    ///     let rows = stmt.query([])?;
     ///     rows.map(|r| r.get(0)).collect()
     /// }
     /// ```
@@ -193,9 +193,9 @@ where
 /// While these iterators cannot be used with Rust `for` loops, `while let`
 /// loops offer a similar level of ergonomics:
 /// ```rust,no_run
-/// # use rusqlite::{Result, Statement, NO_PARAMS};
+/// # use rusqlite::{Result, Statement};
 /// fn query(stmt: &mut Statement) -> Result<()> {
-///     let mut rows = stmt.query(NO_PARAMS)?;
+///     let mut rows = stmt.query([])?;
 ///     while let Some(row) = rows.next()? {
 ///         // scan columns value
 ///     }

--- a/src/row.rs
+++ b/src/row.rs
@@ -427,65 +427,44 @@ mod tests {
         let conn = Connection::open_in_memory().expect("failed to create in-memoory database");
         conn.execute(
             "CREATE TABLE test (a INTEGER)",
-            std::iter::empty::<&dyn ToSql>(),
+            crate::params_from_iter(std::iter::empty::<&dyn ToSql>()),
         )
         .expect("failed to create table");
-        conn.execute(
-            "INSERT INTO test VALUES (42)",
-            std::iter::empty::<&dyn ToSql>(),
-        )
-        .expect("failed to insert value");
+        conn.execute("INSERT INTO test VALUES (42)", [])
+            .expect("failed to insert value");
         let val = conn
-            .query_row(
-                "SELECT a FROM test",
-                std::iter::empty::<&dyn ToSql>(),
-                |row| <(u32,)>::try_from(row),
-            )
+            .query_row("SELECT a FROM test", [], |row| <(u32,)>::try_from(row))
             .expect("failed to query row");
         assert_eq!(val, (42,));
-        let fail = conn.query_row(
-            "SELECT a FROM test",
-            std::iter::empty::<&dyn ToSql>(),
-            |row| <(u32, u32)>::try_from(row),
-        );
+        let fail = conn.query_row("SELECT a FROM test", [], |row| <(u32, u32)>::try_from(row));
         assert!(fail.is_err());
     }
 
     #[test]
     fn test_try_from_row_for_tuple_2() {
-        use crate::{Connection, ToSql};
+        use crate::Connection;
         use std::convert::TryFrom;
 
         let conn = Connection::open_in_memory().expect("failed to create in-memoory database");
-        conn.execute(
-            "CREATE TABLE test (a INTEGER, b INTEGER)",
-            std::iter::empty::<&dyn ToSql>(),
-        )
-        .expect("failed to create table");
-        conn.execute(
-            "INSERT INTO test VALUES (42, 47)",
-            std::iter::empty::<&dyn ToSql>(),
-        )
-        .expect("failed to insert value");
+        conn.execute("CREATE TABLE test (a INTEGER, b INTEGER)", [])
+            .expect("failed to create table");
+        conn.execute("INSERT INTO test VALUES (42, 47)", [])
+            .expect("failed to insert value");
         let val = conn
-            .query_row(
-                "SELECT a, b FROM test",
-                std::iter::empty::<&dyn ToSql>(),
-                |row| <(u32, u32)>::try_from(row),
-            )
+            .query_row("SELECT a, b FROM test", [], |row| {
+                <(u32, u32)>::try_from(row)
+            })
             .expect("failed to query row");
         assert_eq!(val, (42, 47));
-        let fail = conn.query_row(
-            "SELECT a, b FROM test",
-            std::iter::empty::<&dyn ToSql>(),
-            |row| <(u32, u32, u32)>::try_from(row),
-        );
+        let fail = conn.query_row("SELECT a, b FROM test", [], |row| {
+            <(u32, u32, u32)>::try_from(row)
+        });
         assert!(fail.is_err());
     }
 
     #[test]
     fn test_try_from_row_for_tuple_16() {
-        use crate::{Connection, ToSql};
+        use crate::Connection;
         use std::convert::TryFrom;
 
         let create_table = "CREATE TABLE test (
@@ -546,16 +525,12 @@ mod tests {
         );
 
         let conn = Connection::open_in_memory().expect("failed to create in-memoory database");
-        conn.execute(create_table, std::iter::empty::<&dyn ToSql>())
+        conn.execute(create_table, [])
             .expect("failed to create table");
-        conn.execute(insert_values, std::iter::empty::<&dyn ToSql>())
+        conn.execute(insert_values, [])
             .expect("failed to insert value");
         let val = conn
-            .query_row(
-                "SELECT * FROM test",
-                std::iter::empty::<&dyn ToSql>(),
-                |row| BigTuple::try_from(row),
-            )
+            .query_row("SELECT * FROM test", [], |row| BigTuple::try_from(row))
             .expect("failed to query row");
         // Debug is not implemented for tuples of 16
         assert_eq!(val.0, 0);

--- a/src/row.rs
+++ b/src/row.rs
@@ -346,8 +346,18 @@ impl<'stmt> Row<'stmt> {
     }
 }
 
+mod sealed {
+    /// This trait exists just to ensure that the only impls of `trait Params`
+    /// that are allowed are ones in this crate.
+    pub trait Sealed {}
+    impl Sealed for usize {}
+    impl Sealed for &str {}
+}
+
 /// A trait implemented by types that can index into columns of a row.
-pub trait RowIndex {
+///
+/// It is only implemented for `usize` and `&str`.
+pub trait RowIndex: sealed::Sealed {
     /// Returns the index of the appropriate column, or `None` if no such
     /// column exists.
     fn idx(&self, stmt: &Statement<'_>) -> Result<usize>;

--- a/src/statement.rs
+++ b/src/statement.rs
@@ -34,11 +34,14 @@ impl Statement<'_> {
     /// # use rusqlite::{Connection, Result, params};
     /// fn update_rows(conn: &Connection) -> Result<()> {
     ///     let mut stmt = conn.prepare("UPDATE foo SET bar = 'baz' WHERE qux = ?")?;
-    ///
+    ///     // The `rusqlite::params!` macro is mostly useful when the parameters do not
+    ///     // all have the same type, or if there are more than 32 parameters
+    ///     // at once.
     ///     stmt.execute(params![1i32])?;
-    ///     // Similarly...
+    ///     // However, it's not required, many cases are fine as:
     ///     stmt.execute(&[&2i32])?;
-    ///
+    ///     // Or even:
+    ///     stmt.execute([2i32])?;
     ///     Ok(())
     /// }
     /// ```
@@ -46,21 +49,18 @@ impl Statement<'_> {
     /// ### Use with named parameters
     ///
     /// ```rust,no_run
-    /// # use rusqlite::{Connection, Result};
-    /// fn insert(conn: &Connection) -> Result<usize> {
-    ///     let mut stmt = conn.prepare("INSERT INTO test (name) VALUES (:name)")?;
-    ///     stmt.execute(&[(":name", &"one")])
-    /// }
-    /// ```
-    ///
-    /// Note, the `named_params` macro is provided for syntactic convenience,
-    /// and so the above example could also be written as:
-    ///
-    /// ```rust,no_run
     /// # use rusqlite::{Connection, Result, named_params};
-    /// fn insert(conn: &Connection) -> Result<usize> {
-    ///     let mut stmt = conn.prepare("INSERT INTO test (name) VALUES (:name)")?;
-    ///     stmt.execute(named_params!{":name": "one"})
+    /// fn insert(conn: &Connection) -> Result<()> {
+    ///     let mut stmt = conn.prepare("INSERT INTO test (key, value) VALUES (:key, :value)")?;
+    ///     // The `rusqlite::named_params!` macro (like `params!`) is useful for heterogeneous
+    ///     // sets of parameters (where all parameters are not the same type), or for queries
+    ///     // with many (more than 32) statically known parameters.
+    ///     stmt.execute(named_params!{ ":key": "one", ":val": 2 })?;
+    ///     // However, named parameters can also be passed like:
+    ///     stmt.execute(&[(":key", "three"), (":val", "four")])?;
+    ///     // Or even: (note that a &T is required for the value type, currently)
+    ///     stmt.execute(&[(":key", &100), (":val", &200)])?;
+    ///     Ok(())
     /// }
     /// ```
     ///

--- a/src/statement.rs
+++ b/src/statement.rs
@@ -909,7 +909,7 @@ pub enum StatementStatus {
 #[cfg(test)]
 mod test {
     use crate::types::ToSql;
-    use crate::{params_from_iter, Connection, Error, Result, NO_PARAMS};
+    use crate::{params_from_iter, Connection, Error, Result};
 
     #[test]
     #[allow(deprecated)]
@@ -1188,9 +1188,7 @@ mod test {
         stmt.execute(&[(":y", &"two")]).unwrap();
 
         let result: String = db
-            .query_row("SELECT x FROM test WHERE y = 'two'", NO_PARAMS, |row| {
-                row.get(0)
-            })
+            .query_row("SELECT x FROM test WHERE y = 'two'", [], |row| row.get(0))
             .unwrap();
         assert_eq!(result, "one");
     }
@@ -1297,7 +1295,7 @@ mod test {
                    END;";
         db.execute_batch(sql).unwrap();
         let mut stmt = db.prepare("SELECT y as Y FROM foo").unwrap();
-        let y: Result<i64> = stmt.query_row(NO_PARAMS, |r| r.get("y"));
+        let y: Result<i64> = stmt.query_row([], |r| r.get("y"));
         assert_eq!(3i64, y.unwrap());
     }
 
@@ -1366,7 +1364,7 @@ mod test {
         assert!(stmt.parameter_index("test").is_ok());
         assert!(stmt.step().is_err());
         stmt.reset();
-        assert!(stmt.execute(NO_PARAMS).is_err());
+        assert!(stmt.execute([]).is_err());
     }
 
     #[test]
@@ -1402,7 +1400,7 @@ mod test {
         db.execute("INSERT INTO foo(x) VALUES (?)", &[&expected])
             .unwrap();
         let actual: String = db
-            .query_row("SELECT x FROM foo", NO_PARAMS, |row| row.get(0))
+            .query_row("SELECT x FROM foo", [], |row| row.get(0))
             .unwrap();
         assert_eq!(expected, actual);
     }

--- a/src/statement.rs
+++ b/src/statement.rs
@@ -8,7 +8,7 @@ use std::{convert, fmt, mem, ptr, str};
 use super::ffi;
 use super::{len_as_c_int, str_for_sqlite};
 use super::{
-    AndThenRows, Connection, Error, MappedRows, RawStatement, Result, Row, Rows, ValueRef,
+    AndThenRows, Connection, Error, MappedRows, Params, RawStatement, Result, Row, Rows, ValueRef,
 };
 use crate::types::{ToSql, ToSqlOutput};
 #[cfg(feature = "array")]
@@ -28,48 +28,28 @@ impl Statement<'_> {
     ///
     /// ## Example
     ///
+    /// ### Use with positional parameters
+    ///
     /// ```rust,no_run
-    /// # use rusqlite::{Connection, Result};
+    /// # use rusqlite::{Connection, Result, params};
     /// fn update_rows(conn: &Connection) -> Result<()> {
     ///     let mut stmt = conn.prepare("UPDATE foo SET bar = 'baz' WHERE qux = ?")?;
     ///
-    ///     stmt.execute(&[1i32])?;
-    ///     stmt.execute(&[2i32])?;
+    ///     stmt.execute(params![1i32])?;
+    ///     // Similarly...
+    ///     stmt.execute(&[&2i32])?;
     ///
     ///     Ok(())
     /// }
     /// ```
     ///
-    /// # Failure
-    ///
-    /// Will return `Err` if binding parameters fails, the executed statement
-    /// returns rows (in which case `query` should be used instead), or the
-    /// underlying SQLite call fails.
-    pub fn execute<P>(&mut self, params: P) -> Result<usize>
-    where
-        P: IntoIterator,
-        P::Item: ToSql,
-    {
-        self.bind_parameters(params)?;
-        self.execute_with_bound_parameters()
-    }
-
-    /// Execute the prepared statement with named parameter(s). If any
-    /// parameters that were in the prepared statement are not included in
-    /// `params`, they will continue to use the most-recently bound value
-    /// from a previous call to `execute_named`, or `NULL` if they have
-    /// never been bound.
-    ///
-    /// On success, returns the number of rows that were changed or inserted or
-    /// deleted (via `sqlite3_changes`).
-    ///
-    /// ## Example
+    /// ### Use with named parameters
     ///
     /// ```rust,no_run
     /// # use rusqlite::{Connection, Result};
     /// fn insert(conn: &Connection) -> Result<usize> {
     ///     let mut stmt = conn.prepare("INSERT INTO test (name) VALUES (:name)")?;
-    ///     stmt.execute_named(&[(":name", &"one")])
+    ///     stmt.execute(&[(":name", &"one")])
     /// }
     /// ```
     ///
@@ -80,7 +60,18 @@ impl Statement<'_> {
     /// # use rusqlite::{Connection, Result, named_params};
     /// fn insert(conn: &Connection) -> Result<usize> {
     ///     let mut stmt = conn.prepare("INSERT INTO test (name) VALUES (:name)")?;
-    ///     stmt.execute_named(named_params!{":name": "one"})
+    ///     stmt.execute(named_params!{":name": "one"})
+    /// }
+    /// ```
+    ///
+    /// ### Use without parameters
+    ///
+    /// ```rust,no_run
+    /// # use rusqlite::{Connection, Result, params};
+    /// fn delete_all(conn: &Connection) -> Result<()> {
+    ///     let mut stmt = conn.prepare("DELETE FROM users")?;
+    ///     stmt.execute([])?;
+    ///     Ok(())
     /// }
     /// ```
     ///
@@ -89,9 +80,32 @@ impl Statement<'_> {
     /// Will return `Err` if binding parameters fails, the executed statement
     /// returns rows (in which case `query` should be used instead), or the
     /// underlying SQLite call fails.
-    pub fn execute_named(&mut self, params: &[(&str, &dyn ToSql)]) -> Result<usize> {
-        self.bind_parameters_named(params)?;
+    pub fn execute<P: Params>(&mut self, params: P) -> Result<usize> {
+        params.bind_in(self)?;
         self.execute_with_bound_parameters()
+    }
+
+    /// Execute the prepared statement with named parameter(s).
+    ///
+    /// Note: This function is deprecated in favor of [`Statement::execute`],
+    /// which can now take named parameters directly.
+    ///
+    /// If any parameters that were in the prepared statement are not included
+    /// in `params`, they will continue to use the most-recently bound value
+    /// from a previous call to `execute_named`, or `NULL` if they have never
+    /// been bound.
+    ///
+    /// On success, returns the number of rows that were changed or inserted or
+    /// deleted (via `sqlite3_changes`).
+    ///
+    /// # Failure
+    ///
+    /// Will return `Err` if binding parameters fails, the executed statement
+    /// returns rows (in which case `query` should be used instead), or the
+    /// underlying SQLite call fails.
+    #[deprecated = "You can use `execute` with named params now."]
+    pub fn execute_named(&mut self, params: &[(&str, &dyn ToSql)]) -> Result<usize> {
+        self.execute(params)
     }
 
     /// Execute an INSERT and return the ROWID.
@@ -107,11 +121,7 @@ impl Statement<'_> {
     /// # Failure
     ///
     /// Will return `Err` if no row is inserted or many rows are inserted.
-    pub fn insert<P>(&mut self, params: P) -> Result<i64>
-    where
-        P: IntoIterator,
-        P::Item: ToSql,
-    {
+    pub fn insert<P: Params>(&mut self, params: P) -> Result<i64> {
         let changes = self.execute(params)?;
         match changes {
             1 => Ok(self.conn.last_insert_rowid()),
@@ -128,11 +138,13 @@ impl Statement<'_> {
     ///
     /// ## Example
     ///
+    /// ### Use without parameters
+    ///
     /// ```rust,no_run
-    /// # use rusqlite::{Connection, Result, NO_PARAMS};
+    /// # use rusqlite::{Connection, Result};
     /// fn get_names(conn: &Connection) -> Result<Vec<String>> {
     ///     let mut stmt = conn.prepare("SELECT name FROM people")?;
-    ///     let mut rows = stmt.query(NO_PARAMS)?;
+    ///     let mut rows = stmt.query([])?;
     ///
     ///     let mut names = Vec::new();
     ///     while let Some(row) = rows.next()? {
@@ -143,32 +155,41 @@ impl Statement<'_> {
     /// }
     /// ```
     ///
-    /// ## Failure
+    /// ### Use with positional parameters
     ///
-    /// Will return `Err` if binding parameters fails.
-    pub fn query<P>(&mut self, params: P) -> Result<Rows<'_>>
-    where
-        P: IntoIterator,
-        P::Item: ToSql,
-    {
-        self.check_readonly()?;
-        self.bind_parameters(params)?;
-        Ok(Rows::new(self))
-    }
-
-    /// Execute the prepared statement with named parameter(s), returning a
-    /// handle for the resulting rows. If any parameters that were in the
-    /// prepared statement are not included in `params`, they will continue
-    /// to use the most-recently bound value from a previous
-    /// call to `query_named`, or `NULL` if they have never been bound.
+    /// ```rust,no_run
+    /// # use rusqlite::{Connection, Result};
+    /// fn query(conn: &Connection, name: &str) -> Result<()> {
+    ///     let mut stmt = conn.prepare("SELECT * FROM test where name = ?")?;
+    ///     let mut rows = stmt.query(rusqlite::params![name])?;
+    ///     while let Some(row) = rows.next()? {
+    ///         // ...
+    ///     }
+    ///     Ok(())
+    /// }
+    /// ```
     ///
-    /// ## Example
+    /// Or, equivalently (but without the [`params!`] macro).
+    ///
+    /// ```rust,no_run
+    /// # use rusqlite::{Connection, Result};
+    /// fn query(conn: &Connection, name: &str) -> Result<()> {
+    ///     let mut stmt = conn.prepare("SELECT * FROM test where name = ?")?;
+    ///     let mut rows = stmt.query(&[name])?;
+    ///     while let Some(row) = rows.next()? {
+    ///         // ...
+    ///     }
+    ///     Ok(())
+    /// }
+    /// ```
+    ///
+    /// ### Use with named parameters
     ///
     /// ```rust,no_run
     /// # use rusqlite::{Connection, Result};
     /// fn query(conn: &Connection) -> Result<()> {
     ///     let mut stmt = conn.prepare("SELECT * FROM test where name = :name")?;
-    ///     let mut rows = stmt.query_named(&[(":name", &"one")])?;
+    ///     let mut rows = stmt.query(&[(":name", &"one")])?;
     ///     while let Some(row) = rows.next()? {
     ///         // ...
     ///     }
@@ -183,7 +204,7 @@ impl Statement<'_> {
     /// # use rusqlite::{Connection, Result, named_params};
     /// fn query(conn: &Connection) -> Result<()> {
     ///     let mut stmt = conn.prepare("SELECT * FROM test where name = :name")?;
-    ///     let mut rows = stmt.query_named(named_params!{ ":name": "one" })?;
+    ///     let mut rows = stmt.query(named_params!{ ":name": "one" })?;
     ///     while let Some(row) = rows.next()? {
     ///         // ...
     ///     }
@@ -191,25 +212,49 @@ impl Statement<'_> {
     /// }
     /// ```
     ///
+    /// ## Failure
+    ///
+    /// Will return `Err` if binding parameters fails.
+    pub fn query<P: Params>(&mut self, params: P) -> Result<Rows<'_>> {
+        self.check_readonly()?;
+        params.bind_in(self)?;
+        Ok(Rows::new(self))
+    }
+
+    /// Execute the prepared statement with named parameter(s), returning a
+    /// handle for the resulting rows.
+    ///
+    /// Note: This function is deprecated in favor of [`Statement::query`],
+    /// which can now take named parameters directly.
+    ///
+    /// If any parameters that were in the prepared statement are not included
+    /// in `params`, they will continue to use the most-recently bound value
+    /// from a previous call to `query_named`, or `NULL` if they have never been
+    /// bound.
+    ///
     /// # Failure
     ///
     /// Will return `Err` if binding parameters fails.
+    #[deprecated = "You can use `query` with named params now."]
     pub fn query_named(&mut self, params: &[(&str, &dyn ToSql)]) -> Result<Rows<'_>> {
-        self.check_readonly()?;
-        self.bind_parameters_named(params)?;
-        Ok(Rows::new(self))
+        self.query(params)
     }
 
     /// Executes the prepared statement and maps a function over the resulting
     /// rows, returning an iterator over the mapped function results.
     ///
+    /// `f` is used to tranform the _streaming_ iterator into a _standard_
+    /// iterator.
+    ///
     /// ## Example
     ///
+    /// ### Use with positional params
+    ///
     /// ```rust,no_run
-    /// # use rusqlite::{Connection, Result, NO_PARAMS};
+    /// # use rusqlite::{Connection, Result};
     /// fn get_names(conn: &Connection) -> Result<Vec<String>> {
     ///     let mut stmt = conn.prepare("SELECT name FROM people")?;
-    ///     let rows = stmt.query_map(NO_PARAMS, |row| row.get(0))?;
+    ///     let rows = stmt.query_map([], |row| row.get(0))?;
     ///
     ///     let mut names = Vec::new();
     ///     for name_result in rows {
@@ -219,16 +264,29 @@ impl Statement<'_> {
     ///     Ok(names)
     /// }
     /// ```
-    /// `f` is used to tranform the _streaming_ iterator into a _standard_
-    /// iterator.
     ///
+    /// ### Use with named params
+    ///
+    /// ```rust,no_run
+    /// # use rusqlite::{Connection, Result};
+    /// fn get_names(conn: &Connection) -> Result<Vec<String>> {
+    ///     let mut stmt = conn.prepare("SELECT name FROM people WHERE id = :id")?;
+    ///     let rows = stmt.query_map(&[(":id", &"one")], |row| row.get(0))?;
+    ///
+    ///     let mut names = Vec::new();
+    ///     for name_result in rows {
+    ///         names.push(name_result?);
+    ///     }
+    ///
+    ///     Ok(names)
+    /// }
+    /// ```
     /// ## Failure
     ///
     /// Will return `Err` if binding parameters fails.
     pub fn query_map<T, P, F>(&mut self, params: P, f: F) -> Result<MappedRows<'_, F>>
     where
-        P: IntoIterator,
-        P::Item: ToSql,
+        P: Params,
         F: FnMut(&Row<'_>) -> Result<T>,
     {
         let rows = self.query(params)?;
@@ -237,33 +295,23 @@ impl Statement<'_> {
 
     /// Execute the prepared statement with named parameter(s), returning an
     /// iterator over the result of calling the mapping function over the
-    /// query's rows. If any parameters that were in the prepared statement
+    /// query's rows.
+    ///
+    /// Note: This function is deprecated in favor of [`Statement::query_map`],
+    /// which can now take named parameters directly.
+    ///
+    /// If any parameters that were in the prepared statement
     /// are not included in `params`, they will continue to use the
     /// most-recently bound value from a previous call to `query_named`,
     /// or `NULL` if they have never been bound.
     ///
-    /// ## Example
-    ///
-    /// ```rust,no_run
-    /// # use rusqlite::{Connection, Result};
-    /// fn get_names(conn: &Connection) -> Result<Vec<String>> {
-    ///     let mut stmt = conn.prepare("SELECT name FROM people WHERE id = :id")?;
-    ///     let rows = stmt.query_map_named(&[(":id", &"one")], |row| row.get(0))?;
-    ///
-    ///     let mut names = Vec::new();
-    ///     for name_result in rows {
-    ///         names.push(name_result?);
-    ///     }
-    ///
-    ///     Ok(names)
-    /// }
-    /// ```
     /// `f` is used to tranform the _streaming_ iterator into a _standard_
     /// iterator.
     ///
     /// ## Failure
     ///
     /// Will return `Err` if binding parameters fails.
+    #[deprecated = "You can use `query_map` with named params now."]
     pub fn query_map_named<T, F>(
         &mut self,
         params: &[(&str, &dyn ToSql)],
@@ -272,37 +320,16 @@ impl Statement<'_> {
     where
         F: FnMut(&Row<'_>) -> Result<T>,
     {
-        let rows = self.query_named(params)?;
-        Ok(MappedRows::new(rows, f))
+        self.query_map(params, f)
     }
 
     /// Executes the prepared statement and maps a function over the resulting
     /// rows, where the function returns a `Result` with `Error` type
     /// implementing `std::convert::From<Error>` (so errors can be unified).
     ///
-    /// # Failure
-    ///
-    /// Will return `Err` if binding parameters fails.
-    pub fn query_and_then<T, E, P, F>(&mut self, params: P, f: F) -> Result<AndThenRows<'_, F>>
-    where
-        P: IntoIterator,
-        P::Item: ToSql,
-        E: convert::From<Error>,
-        F: FnMut(&Row<'_>) -> Result<T, E>,
-    {
-        let rows = self.query(params)?;
-        Ok(AndThenRows::new(rows, f))
-    }
-
-    /// Execute the prepared statement with named parameter(s), returning an
-    /// iterator over the result of calling the mapping function over the
-    /// query's rows. If any parameters that were in the prepared statement
-    /// are not included in
-    /// `params`, they will
-    /// continue to use the most-recently bound value from a previous call
-    /// to `query_named`, or `NULL` if they have never been bound.
-    ///
     /// ## Example
+    ///
+    /// ### Use with named params
     ///
     /// ```rust,no_run
     /// # use rusqlite::{Connection, Result};
@@ -318,7 +345,7 @@ impl Statement<'_> {
     /// fn get_names(conn: &Connection) -> Result<Vec<Person>> {
     ///     let mut stmt = conn.prepare("SELECT name FROM people WHERE id = :id")?;
     ///     let rows =
-    ///         stmt.query_and_then_named(&[(":id", &"one")], |row| name_to_person(row.get(0)?))?;
+    ///         stmt.query_and_then(&[(":id", &"one")], |row| name_to_person(row.get(0)?))?;
     ///
     ///     let mut persons = Vec::new();
     ///     for person_result in rows {
@@ -329,9 +356,52 @@ impl Statement<'_> {
     /// }
     /// ```
     ///
+    /// ### Use with positional params
+    ///
+    /// ```rust,no_run
+    /// # use rusqlite::{Connection, Result};
+    /// fn get_names(conn: &Connection) -> Result<Vec<String>> {
+    ///     let mut stmt = conn.prepare("SELECT name FROM people WHERE id = ?")?;
+    ///     let rows = stmt.query_and_then(&["one"], |row| row.get::<_, String>(0))?;
+    ///
+    ///     let mut persons = Vec::new();
+    ///     for person_result in rows {
+    ///         persons.push(person_result?);
+    ///     }
+    ///
+    ///     Ok(persons)
+    /// }
+    /// ```
+    ///
+    /// # Failure
+    ///
+    /// Will return `Err` if binding parameters fails.
+    pub fn query_and_then<T, E, P, F>(&mut self, params: P, f: F) -> Result<AndThenRows<'_, F>>
+    where
+        P: Params,
+        E: convert::From<Error>,
+        F: FnMut(&Row<'_>) -> Result<T, E>,
+    {
+        let rows = self.query(params)?;
+        Ok(AndThenRows::new(rows, f))
+    }
+
+    /// Execute the prepared statement with named parameter(s), returning an
+    /// iterator over the result of calling the mapping function over the
+    /// query's rows.
+    ///
+    /// Note: This function is deprecated in favor of [`Statement::query_and_then`],
+    /// which can now take named parameters directly.
+    ///
+    /// If any parameters that were in the prepared statement are not included
+    /// in `params`, they will continue to use the most-recently bound value
+    /// from a previous call to `query_named`, or `NULL` if they have never been
+    /// bound.
+    ///
     /// ## Failure
     ///
     /// Will return `Err` if binding parameters fails.
+    #[deprecated = "You can use `query_and_then` with named params now."]
     pub fn query_and_then_named<T, E, F>(
         &mut self,
         params: &[(&str, &dyn ToSql)],
@@ -341,17 +411,12 @@ impl Statement<'_> {
         E: convert::From<Error>,
         F: FnMut(&Row<'_>) -> Result<T, E>,
     {
-        let rows = self.query_named(params)?;
-        Ok(AndThenRows::new(rows, f))
+        self.query_and_then(params, f)
     }
 
     /// Return `true` if a query in the SQL statement it executes returns one
     /// or more rows and `false` if the SQL returns an empty set.
-    pub fn exists<P>(&mut self, params: P) -> Result<bool>
-    where
-        P: IntoIterator,
-        P::Item: ToSql,
-    {
+    pub fn exists<P: Params>(&mut self, params: P) -> Result<bool> {
         let mut rows = self.query(params)?;
         let exists = rows.next()?.is_some();
         Ok(exists)
@@ -372,8 +437,7 @@ impl Statement<'_> {
     /// Will return `Err` if the underlying SQLite call fails.
     pub fn query_row<T, P, F>(&mut self, params: P, f: F) -> Result<T>
     where
-        P: IntoIterator,
-        P::Item: ToSql,
+        P: Params,
         F: FnOnce(&Row<'_>) -> Result<T>,
     {
         let mut rows = self.query(params)?;
@@ -383,6 +447,9 @@ impl Statement<'_> {
 
     /// Convenience method to execute a query with named parameter(s) that is
     /// expected to return a single row.
+    ///
+    /// Note: This function is deprecated in favor of [`Statement::query_and_then`],
+    /// which can now take named parameters directly.
     ///
     /// If the query returns more than one row, all rows except the first are
     /// ignored.
@@ -395,13 +462,12 @@ impl Statement<'_> {
     ///
     /// Will return `Err` if `sql` cannot be converted to a C-compatible string
     /// or if the underlying SQLite call fails.
+    #[deprecated = "You can use `query_row` with named params now."]
     pub fn query_row_named<T, F>(&mut self, params: &[(&str, &dyn ToSql)], f: F) -> Result<T>
     where
         F: FnOnce(&Row<'_>) -> Result<T>,
     {
-        let mut rows = self.query_named(params)?;
-
-        rows.get_expected_row().and_then(|r| f(&r))
+        self.query_row(params, f)
     }
 
     /// Consumes the statement.
@@ -439,7 +505,7 @@ impl Statement<'_> {
         Ok(self.stmt.bind_parameter_index(name))
     }
 
-    fn bind_parameters<P>(&mut self, params: P) -> Result<()>
+    pub(crate) fn bind_parameters<P>(&mut self, params: P) -> Result<()>
     where
         P: IntoIterator,
         P::Item: ToSql,
@@ -460,10 +526,14 @@ impl Statement<'_> {
         }
     }
 
-    fn bind_parameters_named(&mut self, params: &[(&str, &dyn ToSql)]) -> Result<()> {
+    pub(crate) fn bind_parameters_named<T: ?Sized + ToSql>(
+        &mut self,
+        params: &[(&str, &T)],
+    ) -> Result<()> {
         for &(name, value) in params {
             if let Some(i) = self.parameter_index(name)? {
-                self.bind_parameter(value, i)?;
+                let ts: &dyn ToSql = &value;
+                self.bind_parameter(ts, i)?;
             } else {
                 return Err(Error::InvalidParameterName(name.into()));
             }
@@ -839,9 +909,10 @@ pub enum StatementStatus {
 #[cfg(test)]
 mod test {
     use crate::types::ToSql;
-    use crate::{Connection, Error, Result, NO_PARAMS};
+    use crate::{params_from_iter, Connection, Error, Result, NO_PARAMS};
 
     #[test]
+    #[allow(deprecated)]
     fn test_execute_named() {
         let db = Connection::open_in_memory().unwrap();
         db.execute_batch("CREATE TABLE foo(x INTEGER)").unwrap();
@@ -852,13 +923,21 @@ mod test {
             1
         );
         assert_eq!(
-            db.execute_named("INSERT INTO foo(x) VALUES (:x)", &[(":x", &2i32)])
+            db.execute("INSERT INTO foo(x) VALUES (:x)", &[(":x", &2i32)])
                 .unwrap(),
+            1
+        );
+        assert_eq!(
+            db.execute(
+                "INSERT INTO foo(x) VALUES (:x)",
+                crate::named_params! {":x": 3i32}
+            )
+            .unwrap(),
             1
         );
 
         assert_eq!(
-            3i32,
+            6i32,
             db.query_row_named::<i32, _>(
                 "SELECT SUM(x) FROM foo WHERE x > :x",
                 &[(":x", &0i32)],
@@ -866,9 +945,19 @@ mod test {
             )
             .unwrap()
         );
+        assert_eq!(
+            5i32,
+            db.query_row::<i32, _, _>(
+                "SELECT SUM(x) FROM foo WHERE x > :x",
+                &[(":x", &1i32)],
+                |r| r.get(0)
+            )
+            .unwrap()
+        );
     }
 
     #[test]
+    #[allow(deprecated)]
     fn test_stmt_execute_named() {
         let db = Connection::open_in_memory().unwrap();
         let sql = "CREATE TABLE test (id INTEGER PRIMARY KEY NOT NULL, name TEXT NOT NULL, flag \
@@ -888,9 +977,15 @@ mod test {
             stmt.query_row_named::<i32, _>(&[(":name", &"one")], |r| r.get(0))
                 .unwrap()
         );
+        assert_eq!(
+            1i32,
+            stmt.query_row::<i32, _, _>(&[(":name", &"one")], |r| r.get(0))
+                .unwrap()
+        );
     }
 
     #[test]
+    #[allow(deprecated)]
     fn test_query_named() {
         let db = Connection::open_in_memory().unwrap();
         let sql = r#"
@@ -902,13 +997,23 @@ mod test {
         let mut stmt = db
             .prepare("SELECT id FROM test where name = :name")
             .unwrap();
-        let mut rows = stmt.query_named(&[(":name", &"one")]).unwrap();
+        // legacy `_named` api
+        {
+            let mut rows = stmt.query_named(&[(":name", &"one")]).unwrap();
+            let id: Result<i32> = rows.next().unwrap().unwrap().get(0);
+            assert_eq!(Ok(1), id);
+        }
 
-        let id: Result<i32> = rows.next().unwrap().unwrap().get(0);
-        assert_eq!(Ok(1), id);
+        // plain api
+        {
+            let mut rows = stmt.query(&[(":name", &"one")]).unwrap();
+            let id: Result<i32> = rows.next().unwrap().unwrap().get(0);
+            assert_eq!(Ok(1), id);
+        }
     }
 
     #[test]
+    #[allow(deprecated)]
     fn test_query_map_named() {
         let db = Connection::open_in_memory().unwrap();
         let sql = r#"
@@ -920,18 +1025,34 @@ mod test {
         let mut stmt = db
             .prepare("SELECT id FROM test where name = :name")
             .unwrap();
-        let mut rows = stmt
-            .query_map_named(&[(":name", &"one")], |row| {
-                let id: Result<i32> = row.get(0);
-                id.map(|i| 2 * i)
-            })
-            .unwrap();
+        // legacy `_named` api
+        {
+            let mut rows = stmt
+                .query_map_named(&[(":name", &"one")], |row| {
+                    let id: Result<i32> = row.get(0);
+                    id.map(|i| 2 * i)
+                })
+                .unwrap();
 
-        let doubled_id: i32 = rows.next().unwrap().unwrap();
-        assert_eq!(2, doubled_id);
+            let doubled_id: i32 = rows.next().unwrap().unwrap();
+            assert_eq!(2, doubled_id);
+        }
+        // plain api
+        {
+            let mut rows = stmt
+                .query_map(&[(":name", &"one")], |row| {
+                    let id: Result<i32> = row.get(0);
+                    id.map(|i| 2 * i)
+                })
+                .unwrap();
+
+            let doubled_id: i32 = rows.next().unwrap().unwrap();
+            assert_eq!(2, doubled_id);
+        }
     }
 
     #[test]
+    #[allow(deprecated)]
     fn test_query_and_then_named() {
         let db = Connection::open_in_memory().unwrap();
         let sql = r#"
@@ -969,6 +1090,44 @@ mod test {
     }
 
     #[test]
+    fn test_query_and_then_by_name() {
+        let db = Connection::open_in_memory().unwrap();
+        let sql = r#"
+        CREATE TABLE test (id INTEGER PRIMARY KEY NOT NULL, name TEXT NOT NULL, flag INTEGER);
+        INSERT INTO test(id, name) VALUES (1, "one");
+        INSERT INTO test(id, name) VALUES (2, "one");
+        "#;
+        db.execute_batch(sql).unwrap();
+
+        let mut stmt = db
+            .prepare("SELECT id FROM test where name = :name ORDER BY id ASC")
+            .unwrap();
+        let mut rows = stmt
+            .query_and_then(&[(":name", &"one")], |row| {
+                let id: i32 = row.get(0)?;
+                if id == 1 {
+                    Ok(id)
+                } else {
+                    Err(Error::SqliteSingleThreadedMode)
+                }
+            })
+            .unwrap();
+
+        // first row should be Ok
+        let doubled_id: i32 = rows.next().unwrap().unwrap();
+        assert_eq!(1, doubled_id);
+
+        // second row should be Err
+        #[allow(clippy::match_wild_err_arm)]
+        match rows.next().unwrap() {
+            Ok(_) => panic!("invalid Ok"),
+            Err(Error::SqliteSingleThreadedMode) => (),
+            Err(_) => panic!("invalid Err"),
+        }
+    }
+
+    #[test]
+    #[allow(deprecated)]
     fn test_unbound_parameters_are_null() {
         let db = Connection::open_in_memory().unwrap();
         let sql = "CREATE TABLE test (x TEXT, y TEXT)";
@@ -980,9 +1139,7 @@ mod test {
         stmt.execute_named(&[(":x", &"one")]).unwrap();
 
         let result: Option<String> = db
-            .query_row("SELECT y FROM test WHERE x = 'one'", NO_PARAMS, |row| {
-                row.get(0)
-            })
+            .query_row("SELECT y FROM test WHERE x = 'one'", [], |row| row.get(0))
             .unwrap();
         assert!(result.is_none());
     }
@@ -1027,8 +1184,8 @@ mod test {
         let mut stmt = db
             .prepare("INSERT INTO test (x, y) VALUES (:x, :y)")
             .unwrap();
-        stmt.execute_named(&[(":x", &"one")]).unwrap();
-        stmt.execute_named(&[(":y", &"two")]).unwrap();
+        stmt.execute(&[(":x", &"one")]).unwrap();
+        stmt.execute(&[(":y", &"two")]).unwrap();
 
         let result: String = db
             .query_row("SELECT x FROM test WHERE y = 'two'", NO_PARAMS, |row| {
@@ -1046,16 +1203,16 @@ mod test {
         let mut stmt = db
             .prepare("INSERT OR IGNORE INTO foo (x) VALUES (?)")
             .unwrap();
-        assert_eq!(stmt.insert(&[1i32]).unwrap(), 1);
-        assert_eq!(stmt.insert(&[2i32]).unwrap(), 2);
-        match stmt.insert(&[1i32]).unwrap_err() {
+        assert_eq!(stmt.insert(&[&1i32]).unwrap(), 1);
+        assert_eq!(stmt.insert(&[&2i32]).unwrap(), 2);
+        match stmt.insert(&[&1i32]).unwrap_err() {
             Error::StatementChangedRows(0) => (),
             err => panic!("Unexpected error {}", err),
         }
         let mut multi = db
             .prepare("INSERT INTO foo (x) SELECT 3 UNION ALL SELECT 4")
             .unwrap();
-        match multi.insert(NO_PARAMS).unwrap_err() {
+        match multi.insert([]).unwrap_err() {
             Error::StatementChangedRows(2) => (),
             err => panic!("Unexpected error {}", err),
         }
@@ -1076,14 +1233,14 @@ mod test {
         assert_eq!(
             db.prepare("INSERT INTO foo VALUES (10)")
                 .unwrap()
-                .insert(NO_PARAMS)
+                .insert([])
                 .unwrap(),
             1
         );
         assert_eq!(
             db.prepare("INSERT INTO bar VALUES (10)")
                 .unwrap()
-                .insert(NO_PARAMS)
+                .insert([])
                 .unwrap(),
             1
         );
@@ -1099,9 +1256,9 @@ mod test {
                    END;";
         db.execute_batch(sql).unwrap();
         let mut stmt = db.prepare("SELECT 1 FROM foo WHERE x = ?").unwrap();
-        assert!(stmt.exists(&[1i32]).unwrap());
-        assert!(stmt.exists(&[2i32]).unwrap());
-        assert!(!stmt.exists(&[0i32]).unwrap());
+        assert!(stmt.exists([1i32]).unwrap());
+        assert!(stmt.exists(&[&2i32]).unwrap());
+        assert!(!stmt.exists([&0i32]).unwrap());
     }
 
     #[test]
@@ -1114,7 +1271,7 @@ mod test {
                    END;";
         db.execute_batch(sql).unwrap();
         let mut stmt = db.prepare("SELECT y FROM foo WHERE x = ?").unwrap();
-        let y: Result<i64> = stmt.query_row(&[1i32], |r| r.get(0));
+        let y: Result<i64> = stmt.query_row([1i32], |r| r.get(0));
         assert_eq!(3i64, y.unwrap());
     }
 
@@ -1127,7 +1284,7 @@ mod test {
                    END;";
         db.execute_batch(sql).unwrap();
         let mut stmt = db.prepare("SELECT y FROM foo").unwrap();
-        let y: Result<i64> = stmt.query_row(NO_PARAMS, |r| r.get("y"));
+        let y: Result<i64> = stmt.query_row([], |r| r.get("y"));
         assert_eq!(3i64, y.unwrap());
     }
 
@@ -1165,28 +1322,40 @@ mod test {
         .unwrap();
         // existing collection:
         let data = vec![1, 2, 3];
-        db.query_row("SELECT ?1, ?2, ?3", &data, |row| row.get::<_, u8>(0))
-            .unwrap();
-        db.query_row("SELECT ?1, ?2, ?3", data.as_slice(), |row| {
+        db.query_row("SELECT ?1, ?2, ?3", params_from_iter(&data), |row| {
             row.get::<_, u8>(0)
         })
         .unwrap();
-        db.query_row("SELECT ?1, ?2, ?3", data, |row| row.get::<_, u8>(0))
-            .unwrap();
+        db.query_row(
+            "SELECT ?1, ?2, ?3",
+            params_from_iter(data.as_slice()),
+            |row| row.get::<_, u8>(0),
+        )
+        .unwrap();
+        db.query_row("SELECT ?1, ?2, ?3", params_from_iter(data), |row| {
+            row.get::<_, u8>(0)
+        })
+        .unwrap();
 
         use std::collections::BTreeSet;
         let data: BTreeSet<String> = ["one", "two", "three"]
             .iter()
             .map(|s| (*s).to_string())
             .collect();
-        db.query_row("SELECT ?1, ?2, ?3", &data, |row| row.get::<_, String>(0))
-            .unwrap();
+        db.query_row("SELECT ?1, ?2, ?3", params_from_iter(&data), |row| {
+            row.get::<_, String>(0)
+        })
+        .unwrap();
 
         let data = [0; 3];
-        db.query_row("SELECT ?1, ?2, ?3", &data, |row| row.get::<_, u8>(0))
-            .unwrap();
-        db.query_row("SELECT ?1, ?2, ?3", data.iter(), |row| row.get::<_, u8>(0))
-            .unwrap();
+        db.query_row("SELECT ?1, ?2, ?3", params_from_iter(&data), |row| {
+            row.get::<_, u8>(0)
+        })
+        .unwrap();
+        db.query_row("SELECT ?1, ?2, ?3", params_from_iter(data.iter()), |row| {
+            row.get::<_, u8>(0)
+        })
+        .unwrap();
     }
 
     #[test]
@@ -1243,7 +1412,7 @@ mod test {
         let db = Connection::open_in_memory().unwrap();
         let expected = "a\x00b";
         let actual: String = db
-            .query_row("SELECT ?", &[&expected], |row| row.get(0))
+            .query_row("SELECT ?", [expected], |row| row.get(0))
             .unwrap();
         assert_eq!(expected, actual);
     }

--- a/src/trace.rs
+++ b/src/trace.rs
@@ -142,13 +142,13 @@ mod test {
         let mut db = Connection::open_in_memory().unwrap();
         db.trace(Some(tracer));
         {
-            let _ = db.query_row("SELECT ?", &[1i32], |_| Ok(()));
+            let _ = db.query_row("SELECT ?", &[&1i32], |_| Ok(()));
             let _ = db.query_row("SELECT ?", &["hello"], |_| Ok(()));
         }
         db.trace(None);
         {
-            let _ = db.query_row("SELECT ?", &[2i32], |_| Ok(()));
-            let _ = db.query_row("SELECT ?", &["goodbye"], |_| Ok(()));
+            let _ = db.query_row("SELECT ?", [2i32], |_| Ok(()));
+            let _ = db.query_row("SELECT ?", ["goodbye"], |_| Ok(()));
         }
 
         let traced_stmts = TRACED_STMTS.lock().unwrap();

--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -467,7 +467,7 @@ impl Connection {
 #[cfg(test)]
 mod test {
     use super::DropBehavior;
-    use crate::{Connection, Error, NO_PARAMS};
+    use crate::{Connection, Error};
 
     fn checked_memory_handle() -> Connection {
         let db = Connection::open_in_memory().unwrap();
@@ -492,7 +492,7 @@ mod test {
             let tx = db.transaction().unwrap();
             assert_eq!(
                 2i32,
-                tx.query_row::<i32, _, _>("SELECT SUM(x) FROM foo", NO_PARAMS, |r| r.get(0))
+                tx.query_row::<i32, _, _>("SELECT SUM(x) FROM foo", [], |r| r.get(0))
                     .unwrap()
             );
         }
@@ -531,7 +531,7 @@ mod test {
 
         assert_eq!(
             2i32,
-            db.query_row::<i32, _, _>("SELECT SUM(x) FROM foo", NO_PARAMS, |r| r.get(0))
+            db.query_row::<i32, _, _>("SELECT SUM(x) FROM foo", [], |r| r.get(0))
                 .unwrap()
         );
     }
@@ -559,7 +559,7 @@ mod test {
             let tx = db.transaction().unwrap();
             assert_eq!(
                 6i32,
-                tx.query_row::<i32, _, _>("SELECT SUM(x) FROM foo", NO_PARAMS, |r| r.get(0))
+                tx.query_row::<i32, _, _>("SELECT SUM(x) FROM foo", [], |r| r.get(0))
                     .unwrap()
             );
         }
@@ -666,7 +666,7 @@ mod test {
 
     fn assert_current_sum(x: i32, conn: &Connection) {
         let i = conn
-            .query_row::<i32, _, _>("SELECT SUM(x) FROM foo", NO_PARAMS, |r| r.get(0))
+            .query_row::<i32, _, _>("SELECT SUM(x) FROM foo", [], |r| r.get(0))
             .unwrap();
         assert_eq!(x, i);
     }

--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -661,7 +661,7 @@ mod test {
     }
 
     fn insert(x: i32, conn: &Connection) {
-        conn.execute("INSERT INTO foo VALUES(?)", &[x]).unwrap();
+        conn.execute("INSERT INTO foo VALUES(?)", [x]).unwrap();
     }
 
     fn assert_current_sum(x: i32, conn: &Connection) {

--- a/src/types/chrono.rs
+++ b/src/types/chrono.rs
@@ -128,7 +128,7 @@ impl FromSql for DateTime<Local> {
 
 #[cfg(test)]
 mod test {
-    use crate::{Connection, Result, NO_PARAMS};
+    use crate::{Connection, Result};
     use chrono::{DateTime, Duration, Local, NaiveDate, NaiveDateTime, NaiveTime, TimeZone, Utc};
 
     fn checked_memory_handle() -> Connection {
@@ -145,13 +145,9 @@ mod test {
         db.execute("INSERT INTO foo (t) VALUES (?)", &[&date])
             .unwrap();
 
-        let s: String = db
-            .query_row("SELECT t FROM foo", NO_PARAMS, |r| r.get(0))
-            .unwrap();
+        let s: String = db.query_row("SELECT t FROM foo", [], |r| r.get(0)).unwrap();
         assert_eq!("2016-02-23", s);
-        let t: NaiveDate = db
-            .query_row("SELECT t FROM foo", NO_PARAMS, |r| r.get(0))
-            .unwrap();
+        let t: NaiveDate = db.query_row("SELECT t FROM foo", [], |r| r.get(0)).unwrap();
         assert_eq!(date, t);
     }
 
@@ -162,13 +158,9 @@ mod test {
         db.execute("INSERT INTO foo (t) VALUES (?)", &[&time])
             .unwrap();
 
-        let s: String = db
-            .query_row("SELECT t FROM foo", NO_PARAMS, |r| r.get(0))
-            .unwrap();
+        let s: String = db.query_row("SELECT t FROM foo", [], |r| r.get(0)).unwrap();
         assert_eq!("23:56:04", s);
-        let v: NaiveTime = db
-            .query_row("SELECT t FROM foo", NO_PARAMS, |r| r.get(0))
-            .unwrap();
+        let v: NaiveTime = db.query_row("SELECT t FROM foo", [], |r| r.get(0)).unwrap();
         assert_eq!(time, v);
     }
 
@@ -182,20 +174,13 @@ mod test {
         db.execute("INSERT INTO foo (t) VALUES (?)", &[&dt])
             .unwrap();
 
-        let s: String = db
-            .query_row("SELECT t FROM foo", NO_PARAMS, |r| r.get(0))
-            .unwrap();
+        let s: String = db.query_row("SELECT t FROM foo", [], |r| r.get(0)).unwrap();
         assert_eq!("2016-02-23T23:56:04", s);
-        let v: NaiveDateTime = db
-            .query_row("SELECT t FROM foo", NO_PARAMS, |r| r.get(0))
-            .unwrap();
+        let v: NaiveDateTime = db.query_row("SELECT t FROM foo", [], |r| r.get(0)).unwrap();
         assert_eq!(dt, v);
 
-        db.execute("UPDATE foo set b = datetime(t)", NO_PARAMS)
-            .unwrap(); // "YYYY-MM-DD HH:MM:SS"
-        let hms: NaiveDateTime = db
-            .query_row("SELECT b FROM foo", NO_PARAMS, |r| r.get(0))
-            .unwrap();
+        db.execute("UPDATE foo set b = datetime(t)", []).unwrap(); // "YYYY-MM-DD HH:MM:SS"
+        let hms: NaiveDateTime = db.query_row("SELECT b FROM foo", [], |r| r.get(0)).unwrap();
         assert_eq!(dt, hms);
     }
 
@@ -210,30 +195,24 @@ mod test {
         db.execute("INSERT INTO foo (t) VALUES (?)", &[&utc])
             .unwrap();
 
-        let s: String = db
-            .query_row("SELECT t FROM foo", NO_PARAMS, |r| r.get(0))
-            .unwrap();
+        let s: String = db.query_row("SELECT t FROM foo", [], |r| r.get(0)).unwrap();
         assert_eq!("2016-02-23T23:56:04.789+00:00", s);
 
-        let v1: DateTime<Utc> = db
-            .query_row("SELECT t FROM foo", NO_PARAMS, |r| r.get(0))
-            .unwrap();
+        let v1: DateTime<Utc> = db.query_row("SELECT t FROM foo", [], |r| r.get(0)).unwrap();
         assert_eq!(utc, v1);
 
         let v2: DateTime<Utc> = db
-            .query_row("SELECT '2016-02-23 23:56:04.789'", NO_PARAMS, |r| r.get(0))
+            .query_row("SELECT '2016-02-23 23:56:04.789'", [], |r| r.get(0))
             .unwrap();
         assert_eq!(utc, v2);
 
         let v3: DateTime<Utc> = db
-            .query_row("SELECT '2016-02-23 23:56:04'", NO_PARAMS, |r| r.get(0))
+            .query_row("SELECT '2016-02-23 23:56:04'", [], |r| r.get(0))
             .unwrap();
         assert_eq!(utc - Duration::milliseconds(789), v3);
 
         let v4: DateTime<Utc> = db
-            .query_row("SELECT '2016-02-23 23:56:04.789+00:00'", NO_PARAMS, |r| {
-                r.get(0)
-            })
+            .query_row("SELECT '2016-02-23 23:56:04.789+00:00'", [], |r| r.get(0))
             .unwrap();
         assert_eq!(utc, v4);
     }
@@ -250,31 +229,25 @@ mod test {
             .unwrap();
 
         // Stored string should be in UTC
-        let s: String = db
-            .query_row("SELECT t FROM foo", NO_PARAMS, |r| r.get(0))
-            .unwrap();
+        let s: String = db.query_row("SELECT t FROM foo", [], |r| r.get(0)).unwrap();
         assert!(s.ends_with("+00:00"));
 
-        let v: DateTime<Local> = db
-            .query_row("SELECT t FROM foo", NO_PARAMS, |r| r.get(0))
-            .unwrap();
+        let v: DateTime<Local> = db.query_row("SELECT t FROM foo", [], |r| r.get(0)).unwrap();
         assert_eq!(local, v);
     }
 
     #[test]
     fn test_sqlite_functions() {
         let db = checked_memory_handle();
-        let result: Result<NaiveTime> =
-            db.query_row("SELECT CURRENT_TIME", NO_PARAMS, |r| r.get(0));
+        let result: Result<NaiveTime> = db.query_row("SELECT CURRENT_TIME", [], |r| r.get(0));
         assert!(result.is_ok());
-        let result: Result<NaiveDate> =
-            db.query_row("SELECT CURRENT_DATE", NO_PARAMS, |r| r.get(0));
+        let result: Result<NaiveDate> = db.query_row("SELECT CURRENT_DATE", [], |r| r.get(0));
         assert!(result.is_ok());
         let result: Result<NaiveDateTime> =
-            db.query_row("SELECT CURRENT_TIMESTAMP", NO_PARAMS, |r| r.get(0));
+            db.query_row("SELECT CURRENT_TIMESTAMP", [], |r| r.get(0));
         assert!(result.is_ok());
         let result: Result<DateTime<Utc>> =
-            db.query_row("SELECT CURRENT_TIMESTAMP", NO_PARAMS, |r| r.get(0));
+            db.query_row("SELECT CURRENT_TIMESTAMP", [], |r| r.get(0));
         assert!(result.is_ok());
     }
 }

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -131,7 +131,7 @@ impl fmt::Display for Type {
 #[cfg(test)]
 mod test {
     use super::Value;
-    use crate::{params, Connection, Error, Statement, NO_PARAMS};
+    use crate::{params, Connection, Error, Statement};
     use std::f64::EPSILON;
     use std::os::raw::{c_double, c_int};
 
@@ -150,9 +150,7 @@ mod test {
         db.execute("INSERT INTO foo(b) VALUES (?)", &[&v1234])
             .unwrap();
 
-        let v: Vec<u8> = db
-            .query_row("SELECT b FROM foo", NO_PARAMS, |r| r.get(0))
-            .unwrap();
+        let v: Vec<u8> = db.query_row("SELECT b FROM foo", [], |r| r.get(0)).unwrap();
         assert_eq!(v, v1234);
     }
 
@@ -164,9 +162,7 @@ mod test {
         db.execute("INSERT INTO foo(b) VALUES (?)", &[&empty])
             .unwrap();
 
-        let v: Vec<u8> = db
-            .query_row("SELECT b FROM foo", NO_PARAMS, |r| r.get(0))
-            .unwrap();
+        let v: Vec<u8> = db.query_row("SELECT b FROM foo", [], |r| r.get(0)).unwrap();
         assert_eq!(v, empty);
     }
 
@@ -177,9 +173,7 @@ mod test {
         let s = "hello, world!";
         db.execute("INSERT INTO foo(t) VALUES (?)", &[&s]).unwrap();
 
-        let from: String = db
-            .query_row("SELECT t FROM foo", NO_PARAMS, |r| r.get(0))
-            .unwrap();
+        let from: String = db.query_row("SELECT t FROM foo", [], |r| r.get(0)).unwrap();
         assert_eq!(from, s);
     }
 
@@ -191,9 +185,7 @@ mod test {
         db.execute("INSERT INTO foo(t) VALUES (?)", [s.to_owned()])
             .unwrap();
 
-        let from: String = db
-            .query_row("SELECT t FROM foo", NO_PARAMS, |r| r.get(0))
-            .unwrap();
+        let from: String = db.query_row("SELECT t FROM foo", [], |r| r.get(0)).unwrap();
         assert_eq!(from, s);
     }
 
@@ -206,7 +198,7 @@ mod test {
 
         assert_eq!(
             10i64,
-            db.query_row::<i64, _, _>("SELECT i FROM foo", NO_PARAMS, |r| r.get(0))
+            db.query_row::<i64, _, _>("SELECT i FROM foo", [], |r| r.get(0))
                 .unwrap()
         );
     }
@@ -224,7 +216,7 @@ mod test {
         let mut stmt = db
             .prepare("SELECT t, b FROM foo ORDER BY ROWID ASC")
             .unwrap();
-        let mut rows = stmt.query(NO_PARAMS).unwrap();
+        let mut rows = stmt.query([]).unwrap();
 
         {
             let row1 = rows.next().unwrap().unwrap();
@@ -254,12 +246,12 @@ mod test {
 
         db.execute(
             "INSERT INTO foo(b, t, i, f) VALUES (X'0102', 'text', 1, 1.5)",
-            NO_PARAMS,
+            [],
         )
         .unwrap();
 
         let mut stmt = db.prepare("SELECT b, t, i, f, n FROM foo").unwrap();
-        let mut rows = stmt.query(NO_PARAMS).unwrap();
+        let mut rows = stmt.query([]).unwrap();
 
         let row = rows.next().unwrap().unwrap();
 
@@ -364,12 +356,12 @@ mod test {
 
         db.execute(
             "INSERT INTO foo(b, t, i, f) VALUES (X'0102', 'text', 1, 1.5)",
-            NO_PARAMS,
+            [],
         )
         .unwrap();
 
         let mut stmt = db.prepare("SELECT b, t, i, f, n FROM foo").unwrap();
-        let mut rows = stmt.query(NO_PARAMS).unwrap();
+        let mut rows = stmt.query([]).unwrap();
 
         let row = rows.next().unwrap().unwrap();
         assert_eq!(Value::Blob(vec![1, 2]), row.get::<_, Value>(0).unwrap());
@@ -393,9 +385,9 @@ mod test {
                 .unwrap();
             let res = $db_etc
                 .query_statement
-                .query_row(NO_PARAMS, |row| row.get::<_, $get_type>(0));
+                .query_row([], |row| row.get::<_, $get_type>(0));
             assert_eq!(res.unwrap(), $expected_value);
-            $db_etc.delete_statement.execute(NO_PARAMS).unwrap();
+            $db_etc.delete_statement.execute([]).unwrap();
         };
         ($db_etc:ident, $insert_value:expr, $get_type:ty,expect_from_sql_error) => {
             $db_etc
@@ -404,9 +396,9 @@ mod test {
                 .unwrap();
             let res = $db_etc
                 .query_statement
-                .query_row(NO_PARAMS, |row| row.get::<_, $get_type>(0));
+                .query_row([], |row| row.get::<_, $get_type>(0));
             res.unwrap_err();
-            $db_etc.delete_statement.execute(NO_PARAMS).unwrap();
+            $db_etc.delete_statement.execute([]).unwrap();
         };
         ($db_etc:ident, $insert_value:expr, $get_type:ty,expect_to_sql_error) => {
             $db_etc

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -94,7 +94,7 @@ mod value_ref;
 /// # use rusqlite::types::{Null};
 ///
 /// fn insert_null(conn: &Connection) -> Result<usize> {
-///     conn.execute("INSERT INTO people (name) VALUES (?)", &[Null])
+///     conn.execute("INSERT INTO people (name) VALUES (?)", [Null])
 /// }
 /// ```
 #[derive(Copy, Clone)]
@@ -188,7 +188,7 @@ mod test {
         let db = checked_memory_handle();
 
         let s = "hello, world!";
-        db.execute("INSERT INTO foo(t) VALUES (?)", &[s.to_owned()])
+        db.execute("INSERT INTO foo(t) VALUES (?)", [s.to_owned()])
             .unwrap();
 
         let from: String = db
@@ -201,7 +201,7 @@ mod test {
     fn test_value() {
         let db = checked_memory_handle();
 
-        db.execute("INSERT INTO foo(i) VALUES (?)", &[Value::Integer(10)])
+        db.execute("INSERT INTO foo(i) VALUES (?)", [Value::Integer(10)])
             .unwrap();
 
         assert_eq!(

--- a/src/types/serde_json.rs
+++ b/src/types/serde_json.rs
@@ -27,7 +27,7 @@ impl FromSql for Value {
 #[cfg(test)]
 mod test {
     use crate::types::ToSql;
-    use crate::{Connection, NO_PARAMS};
+    use crate::Connection;
 
     fn checked_memory_handle() -> Connection {
         let db = Connection::open_in_memory().unwrap();
@@ -48,13 +48,9 @@ mod test {
         )
         .unwrap();
 
-        let t: serde_json::Value = db
-            .query_row("SELECT t FROM foo", NO_PARAMS, |r| r.get(0))
-            .unwrap();
+        let t: serde_json::Value = db.query_row("SELECT t FROM foo", [], |r| r.get(0)).unwrap();
         assert_eq!(data, t);
-        let b: serde_json::Value = db
-            .query_row("SELECT b FROM foo", NO_PARAMS, |r| r.get(0))
-            .unwrap();
+        let b: serde_json::Value = db.query_row("SELECT b FROM foo", [], |r| r.get(0)).unwrap();
         assert_eq!(data, b);
     }
 }

--- a/src/types/time.rs
+++ b/src/types/time.rs
@@ -32,7 +32,7 @@ impl FromSql for OffsetDateTime {
 
 #[cfg(test)]
 mod test {
-    use crate::{Connection, Result, NO_PARAMS};
+    use crate::{Connection, Result};
     use std::time::Duration;
     use time::OffsetDateTime;
 
@@ -62,11 +62,9 @@ mod test {
         for ts in ts_vec {
             db.execute("INSERT INTO foo(t) VALUES (?)", &[&ts]).unwrap();
 
-            let from: OffsetDateTime = db
-                .query_row("SELECT t FROM foo", NO_PARAMS, |r| r.get(0))
-                .unwrap();
+            let from: OffsetDateTime = db.query_row("SELECT t FROM foo", [], |r| r.get(0)).unwrap();
 
-            db.execute("DELETE FROM foo", NO_PARAMS).unwrap();
+            db.execute("DELETE FROM foo", []).unwrap();
 
             assert_eq!(from, ts);
         }
@@ -76,7 +74,7 @@ mod test {
     fn test_sqlite_functions() {
         let db = checked_memory_handle();
         let result: Result<OffsetDateTime> =
-            db.query_row("SELECT CURRENT_TIMESTAMP", NO_PARAMS, |r| r.get(0));
+            db.query_row("SELECT CURRENT_TIMESTAMP", [], |r| r.get(0));
         assert!(result.is_ok());
     }
 }

--- a/src/types/to_sql.rs
+++ b/src/types/to_sql.rs
@@ -336,7 +336,7 @@ mod test {
                 (?, 'neg one'), (?, 'neg two'),
                 (?, 'pos one'), (?, 'pos two'),
                 (?, 'min'), (?, 'max')",
-            &[0i128, -1i128, -2i128, 1i128, 2i128, i128::MIN, i128::MAX],
+            [0i128, -1i128, -2i128, 1i128, 2i128, i128::MIN, i128::MAX],
         )
         .unwrap();
 

--- a/src/types/to_sql.rs
+++ b/src/types/to_sql.rs
@@ -324,7 +324,7 @@ mod test {
     #[cfg(feature = "i128_blob")]
     #[test]
     fn test_i128() {
-        use crate::{Connection, NO_PARAMS};
+        use crate::Connection;
         use std::i128;
         let db = Connection::open_in_memory().unwrap();
         db.execute_batch("CREATE TABLE foo (i128 BLOB, desc TEXT)")
@@ -345,7 +345,7 @@ mod test {
             .unwrap();
 
         let res = stmt
-            .query_map(NO_PARAMS, |row| {
+            .query_map([], |row| {
                 Ok((row.get::<_, i128>(0)?, row.get::<_, String>(1)?))
             })
             .unwrap()

--- a/src/unlock_notify.rs
+++ b/src/unlock_notify.rs
@@ -100,7 +100,7 @@ pub unsafe fn wait_for_unlock_notify(_db: *mut ffi::sqlite3) -> c_int {
 #[cfg(feature = "unlock_notify")]
 #[cfg(test)]
 mod test {
-    use crate::{Connection, OpenFlags, Result, Transaction, TransactionBehavior, NO_PARAMS};
+    use crate::{Connection, OpenFlags, Result, Transaction, TransactionBehavior};
     use std::sync::mpsc::sync_channel;
     use std::thread;
     use std::time;
@@ -122,7 +122,7 @@ mod test {
             tx2.commit().unwrap();
         });
         assert_eq!(tx.recv().unwrap(), 1);
-        let the_answer: Result<i64> = db1.query_row("SELECT x FROM foo", NO_PARAMS, |r| r.get(0));
+        let the_answer: Result<i64> = db1.query_row("SELECT x FROM foo", [], |r| r.get(0));
         assert_eq!(42i64, the_answer.unwrap());
         child.join().unwrap();
     }

--- a/src/vtab/csvtab.rs
+++ b/src/vtab/csvtab.rs
@@ -362,7 +362,7 @@ impl From<csv::Error> for Error {
 #[cfg(test)]
 mod test {
     use crate::vtab::csvtab;
-    use crate::{Connection, Result, NO_PARAMS};
+    use crate::{Connection, Result};
     use fallible_iterator::FallibleIterator;
 
     #[test]
@@ -380,7 +380,7 @@ mod test {
             }
 
             let ids: Result<Vec<i32>> = s
-                .query(NO_PARAMS)
+                .query([])
                 .unwrap()
                 .map(|row| row.get::<_, i32>(0))
                 .collect();
@@ -405,7 +405,7 @@ mod test {
                 )
                 .unwrap();
 
-            let mut rows = s.query(NO_PARAMS).unwrap();
+            let mut rows = s.query([]).unwrap();
             let row = rows.next().unwrap().unwrap();
             assert_eq!(row.get_unwrap::<_, i32>(0), 2);
         }

--- a/src/vtab/series.rs
+++ b/src/vtab/series.rs
@@ -273,7 +273,7 @@ unsafe impl VTabCursor for SeriesTabCursor<'_> {
 mod test {
     use crate::ffi;
     use crate::vtab::series;
-    use crate::{Connection, NO_PARAMS};
+    use crate::Connection;
 
     #[test]
     fn test_series_module() {
@@ -287,7 +287,7 @@ mod test {
 
         let mut s = db.prepare("SELECT * FROM generate_series(0,20,5)").unwrap();
 
-        let series = s.query_map(NO_PARAMS, |row| row.get::<_, i32>(0)).unwrap();
+        let series = s.query_map([], |row| row.get::<_, i32>(0)).unwrap();
 
         let mut expected = 0;
         for value in series {


### PR DESCRIPTION
Fixes #609

I've wanted to do this for a long time, but it required a bunch of type-fu that I wasn't fully prepared for how to do. (It required differentiating between slices, references to arrays, 

This fixes two warts in the current API:

1. The `_named` variants of many functions are now redundant — functions accepting query parameters now all support named params too. e.g. you can pass named parameters to `statement.query()`/`query_map`/etc and no longer need to use the `query_named`/`query_map_named`/etc variants. The `_named` variants are now all deprecated, but users should be able call the un-`_named` apis directly (the `_named` ones all just do that now). Alternatively, they can drop `#![allow(deprecated)]` somewhere if they don't care about using old APIs.

2. `rusqlite::NO_PARAMS` is no longer needed, although I left it in there for now. ~~It's probably worth deprecating too, but it's used everywhere so I didn't do this yet (I still removed it from the example code, and from some tests though).~~ I deprecated it — there's no need to keep it anymore, and people who don't have time to do the update can `#![allow(deprecated)]`. (The update is just replacing `NO_PARAMS` with `[]` though)

Both of these have *really* bugged me for quite some time (hence filing 609), but I didn't see a way around them. Anyway, the fix isn't so bad, and basically involves creating a new `Params` trait and implementing it for a lot of stuff.

I also took the opportunity to write more thorough docs on parameter passing since this expands the number of ways to do it, and will likely help people migrate. These docs are the doc comment for the new `Params` trait (which is a lot simpler than the design I came up with in #609).

# Breakage

This is a large change and is breaking, I suspect many (or even most) rusqlite users will need to make *some* changes, but they're intended to be fairly easy, and most code shouldn't be breaking.

I think the only two things (the most notable ones anyway) that used to work that require changing are:

1. `thing.query(&[1i32, 2, 3])` or similar where a slice literal is passed in and each item is not a reference. This should be changed to `thing.query([1i32, 2, 3])` (e.g. takes an array now) or one of a few other options (`&[&foo, &bar]` or `params![foo, bar]` both work too)

2. `thing.query(blah.iter())` or similar where the full iterator functionality of the old API is used. This is a pretty rare use case (only really coming up when dynamically generating SQL for the most part). It's still supported though, but you need to do `thing.query(rusqlite::params_from_iter(blah.iter()))` or something like that.

Aside from that there are several deprecations but they're all easy to fix — either use the new APIs or use `#![allow(deprecated)]`. (I don't really have strong opinions on when to take these out, but breaking it all in one go would be too much IMO)

There might be a few other cases but in general things should actually be more forgiving overall.

Anyway, when making a changelog, we should link here, although maybe I'll throw together something more explicit about updating.

(I also made `RowIndex` sealed while I was at it since I expected to mess with this too, but didn't have — still, it should be sealed, nobody should be implementing it externally.)