### PR TITLE
Update time to appease `deps.rs`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -96,7 +96,7 @@ bundled-full = [
 ]
 
 [dependencies]
-time = { version = "0.2", optional = true }
+time = { version = "0.2.23", optional = true }
 bitflags = "1.2"
 hashlink = "0.6"
 chrono = { version = "0.4", optional = true }


### PR DESCRIPTION
We have the deps.rs badge in our README, and it's complaining about the recent `time` CVE (which is a bit dubious for a few reasons I won't get into). That said, it's trivial for us to update it ourselves to shut deps.rs up, so here's the PR.