### PR TITLE
Use a weaker dependency on smallvec.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -109,7 +109,7 @@ fallible-iterator = "0.2"
 fallible-streaming-iterator = "0.1"
 memchr = "2.3"
 uuid = { version = "0.8", optional = true }
-smallvec = "1.4"
+smallvec = "1.0"
 
 [dev-dependencies]
 doc-comment = "0.3"


### PR DESCRIPTION
There's no reason to use 1.4, 1.0.0 works just as well.

1.4 causes a big perf regression in Firefox, see
https://github.com/servo/rust-smallvec/issues/243, so while we figure
that out we'd like to keep using 1.3.0.