### PR TITLE
Upgrade chrono to 0.4.19

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -99,7 +99,7 @@ bundled-full = [
 time = { version = "0.2", optional = true }
 bitflags = "1.2"
 hashlink = "0.6"
-chrono = { version = "0.4", optional = true }
+chrono = { version = "0.4.19", optional = true }
 serde_json = { version = "1.0", optional = true }
 csv = { version = "1.1", optional = true }
 url = { version = "2.1", optional = true }


### PR DESCRIPTION
This fixes an annoying and hard to debug error `the trait is not implemented`, as `rusqlite` uses an 3 years old `chrono`, that used to expose a module `chrono::datetime` which is now private.

```rust
#[derive(Debug)]
struct Focus {
    datetime: DateTime<Local>,
    title: String,
}

...

    let mut query = db.prepare("SELECT datetime, title FROM titles").unwrap();
    let focus_iter = query
        .query_map(params![], |row| {
            Ok(Focus {
                datetime: row.get(0)?,
                title: row.get(1)?,
            })
        })
        .unwrap();
```

```
error[E0277]: the trait bound `chrono::datetime::DateTime<chrono::offset::local::Local>: rusqlite::types::from_sql::FromSql` is not satisfied
  --> src/client.rs:24:31
   |
24 |                 datetime: row.get(0)?,
   |                               ^^^ the trait `rusqlite::types::from_sql::FromSql` is not implemented for `chrono::datetime::DateTime<chrono::offset::local::Local>`
```

Didn't test this beyond that it builds and runs fine in my project.