### PR TITLE
Update from upstream

### DIFF
--- a/libsqlite3-sys/build.rs
+++ b/libsqlite3-sys/build.rs
@@ -73,7 +73,8 @@ mod build_bundled {
             .flag("-DSQLITE_SOUNDEX")
             .flag("-DSQLITE_THREADSAFE=1")
             .flag("-DSQLITE_USE_URI")
-            .flag("-DHAVE_USLEEP=1");
+            .flag("-DHAVE_USLEEP=1")
+            .flag("-DSQLITE_TEMP_STORE=3");
         // Older versions of visual studio don't support c99 (including isnan), which
         // causes a build failure when the linker fails to find the `isnan`
         // function. `sqlite` provides its own implmentation, using the fact


### PR DESCRIPTION
This brings us up to date with sqlite upstream up to 0.24.2