### PR TITLE
Pass context to aggregate init and finalize

### DIFF
--- a/src/functions.rs
+++ b/src/functions.rs
@@ -911,7 +911,7 @@ mod test {
     struct Count;
 
     impl Aggregate<i64, Option<i64>> for Sum {
-        fn init(&self) -> i64 {
+        fn init(&self, _: &mut Context<'_>) -> i64 {
             0
         }
 
@@ -920,13 +920,13 @@ mod test {
             Ok(())
         }
 
-        fn finalize(&self, sum: Option<i64>) -> Result<Option<i64>> {
+        fn finalize(&self, _: &mut Context<'_>, sum: Option<i64>) -> Result<Option<i64>> {
             Ok(sum)
         }
     }
 
     impl Aggregate<i64, i64> for Count {
-        fn init(&self) -> i64 {
+        fn init(&self, _: &mut Context<'_>) -> i64 {
             0
         }
 
@@ -935,7 +935,7 @@ mod test {
             Ok(())
         }
 
-        fn finalize(&self, sum: Option<i64>) -> Result<i64> {
+        fn finalize(&self, _: &mut Context<'_>, sum: Option<i64>) -> Result<i64> {
             Ok(sum.unwrap_or(0))
         }
     }

--- a/src/functions.rs
+++ b/src/functions.rs
@@ -237,7 +237,7 @@ where
     /// Initializes the aggregation context. Will be called prior to the first
     /// call to [`step()`](Aggregate::step) to set up the context for an invocation of the
     /// function. (Note: `init()` will not be called if there are no rows.)
-    fn init(&self, _: &mut Context<'_>) -> A;
+    fn init(&self, _: &mut Context<'_>) -> Result<A>;
 
     /// "step" function called once for each row in an aggregate group. May be
     /// called 0 times if there are no rows.
@@ -599,7 +599,7 @@ unsafe extern "C" fn call_boxed_step<A, D, T>(
         };
 
         if (*pac as *mut A).is_null() {
-            *pac = Box::into_raw(Box::new((*boxed_aggr).init(&mut ctx)));
+            *pac = Box::into_raw(Box::new((*boxed_aggr).init(&mut ctx)?));
         }
 
         (*boxed_aggr).step(&mut ctx, &mut **pac)
@@ -911,8 +911,8 @@ mod test {
     struct Count;
 
     impl Aggregate<i64, Option<i64>> for Sum {
-        fn init(&self, _: &mut Context<'_>) -> i64 {
-            0
+        fn init(&self, _: &mut Context<'_>) -> Result<i64> {
+            Ok(0)
         }
 
         fn step(&self, ctx: &mut Context<'_>, sum: &mut i64) -> Result<()> {
@@ -926,8 +926,8 @@ mod test {
     }
 
     impl Aggregate<i64, i64> for Count {
-        fn init(&self, _: &mut Context<'_>) -> i64 {
-            0
+        fn init(&self, _: &mut Context<'_>) -> Result<i64> {
+            Ok(0)
         }
 
         fn step(&self, _ctx: &mut Context<'_>, sum: &mut i64) -> Result<()> {

--- a/src/functions.rs
+++ b/src/functions.rs
@@ -686,10 +686,7 @@ where
             !boxed_aggr.is_null(),
             "Internal error - null aggregate pointer"
         );
-        let mut ctx = Context {
-            ctx,
-            args: &mut [],
-        };
+        let mut ctx = Context { ctx, args: &mut [] };
         (*boxed_aggr).finalize(&mut ctx, a)
     });
     let t = match r {

--- a/src/functions.rs
+++ b/src/functions.rs
@@ -248,7 +248,9 @@ where
     /// once, will be given `Some(A)` (the same `A` as was created by
     /// [`init`](Aggregate::init) and given to [`step`](Aggregate::step)); if [`step()`](Aggregate::step) was not called (because
     /// the function is running against 0 rows), will be given `None`.
-    fn finalize(&self, _: Option<A>) -> Result<T>;
+    ///
+    /// The passed context will have no arguments.
+    fn finalize(&self, _: &mut Context<'_>, _: Option<A>) -> Result<T>;
 }
 
 /// `feature = "window"` WindowAggregate is the callback interface for
@@ -684,7 +686,11 @@ where
             !boxed_aggr.is_null(),
             "Internal error - null aggregate pointer"
         );
-        (*boxed_aggr).finalize(a)
+        let mut ctx = Context {
+            ctx,
+            args: &mut [],
+        };
+        (*boxed_aggr).finalize(&mut ctx, a)
     });
     let t = match r {
         Err(_) => {


### PR DESCRIPTION
Fixes #865.

Passing to init is useful as is, passing to finalize will only be useful once #643 is fixed.

This is a breaking change, though fixing the breakage is trivial. 