### PR TITLE
add get_connection method to function context

### DIFF
--- a/src/functions.rs
+++ b/src/functions.rs
@@ -53,13 +53,13 @@
 //! }
 //! ```
 use std::any::Any;
+use std::marker::PhantomData;
+use std::ops::Deref;
 use std::os::raw::{c_int, c_void};
 use std::panic::{catch_unwind, RefUnwindSafe, UnwindSafe};
 use std::ptr;
 use std::slice;
 use std::sync::Arc;
-use std::marker::PhantomData;
-use std::ops::Deref;
 
 use crate::ffi;
 use crate::ffi::sqlite3_context;
@@ -223,7 +223,6 @@ impl Context<'_> {
         }
     }
 
-
     /// Get the db connection handle via sqlite3_context_db_handle
     /// https://www.sqlite.org/c3ref/context_db_handle.html
     ///
@@ -234,14 +233,14 @@ impl Context<'_> {
         let handle = ffi::sqlite3_context_db_handle(self.ctx);
         Ok(ConnectionRef {
             conn: Connection::from_handle(handle)?,
-            phantom: PhantomData
+            phantom: PhantomData,
         })
     }
 }
 
 /// A reference to a connection handle with a lifetime bound to something.
 pub struct ConnectionRef<'ctx> {
-	// comes from Connection::from_handle(sqlite3_context_db_handle(...))
+    // comes from Connection::from_handle(sqlite3_context_db_handle(...))
     // and is non-owning
     conn: Connection,
     phantom: PhantomData<&'ctx Context<'ctx>>,
@@ -255,9 +254,6 @@ impl Deref for ConnectionRef<'_> {
         &self.conn
     }
 }
-
-
-
 
 type AuxInner = Arc<dyn Any + Send + Sync + 'static>;
 

--- a/src/functions.rs
+++ b/src/functions.rs
@@ -223,12 +223,12 @@ impl Context<'_> {
         }
     }
 
-    /// Get the db connection handle via sqlite3_context_db_handle
-    /// https://www.sqlite.org/c3ref/context_db_handle.html
+    /// Get the db connection handle via [sqlite3_context_db_handle](https://www.sqlite.org/c3ref/context_db_handle.html)
+    ///
+    /// # Safety
     ///
     /// This function is marked unsafe because there is a potential for other
-    /// references to the connection to be sent across threads
-    /// https://github.com/rusqlite/rusqlite/issues/643#issuecomment-640181213
+    /// references to the connection to be sent across threads, [see this comment](https://github.com/rusqlite/rusqlite/issues/643#issuecomment-640181213).
     pub unsafe fn get_connection(&self) -> Result<ConnectionRef<'_>> {
         let handle = ffi::sqlite3_context_db_handle(self.ctx);
         Ok(ConnectionRef {


### PR DESCRIPTION
This method is marked unsafe because it internally creates a new Connection object which may have a different state than the originally created one (especially when that one is sent to another thread).

More detail by @thomcc here: https://github.com/rusqlite/rusqlite/issues/643#issuecomment-640181213

I'm not sure if it's possible to fix that and make this fully safe. One way I could think of is to have a global list of existing connections, and in the get_connection method look for the existing connection with the same internal sqlite object, then set a flag in that connection to disallow use in some way. Or possibly in the from_handle function throw if a handle for the given sqlite ffi already exists.

This fixes #643