### PR TITLE
fix typo in .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ matrix:
 
 addons:
   apt:
-    packages: # recommanded versions for rust-bindgen
+    packages: # recommended versions for rust-bindgen
       - llvm-3.9-dev
       - libclang-3.9-dev
       - libsqlcipher-dev


### PR DESCRIPTION
Just fixes a typo in a comment in the Travis CI configuration.