### PR TITLE
Disable leak-sanitizer for now

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -91,7 +91,7 @@ jobs:
         env:
           RUSTFLAGS: -Zsanitizer=address
           RUSTDOCFLAGS: -Zsanitizer=address
-          ASAN_OPTIONS: 'detect_stack_use_after_return=1'
+          ASAN_OPTIONS: 'detect_stack_use_after_return=1:detect_leaks=0'
           # Work around https://github.com/rust-lang/rust/issues/59125 by
           # disabling backtraces. In an ideal world we'd probably suppress the
           # leak sanitization, but we don't care about backtraces here, so long


### PR DESCRIPTION
I'm pretty confident these aren't real leaks and are just us not configuring asan correctly. That said, for now just disable.

Will file an issue about this after landing.

Fixes #889