### PR TITLE
Improve flexibility of named params

### DIFF
--- a/src/params.rs
+++ b/src/params.rs
@@ -188,8 +188,8 @@ impl Params for &[&dyn ToSql] {
     }
 }
 
-impl Sealed for &[(&str, &dyn ToSql)] {}
-impl Params for &[(&str, &dyn ToSql)] {
+impl<T: ToSql> Sealed for &[(&str, T)] {}
+impl<T: ToSql> Params for &[(&str, T)] {
     #[inline]
     fn __bind_in(self, stmt: &mut Statement<'_>) -> Result<()> {
         stmt.bind_parameters_named(self)

--- a/src/statement.rs
+++ b/src/statement.rs
@@ -539,11 +539,8 @@ impl Statement<'_> {
     }
 
     #[inline]
-    pub(crate) fn bind_parameters_named<T: ?Sized + ToSql>(
-        &mut self,
-        params: &[(&str, &T)],
-    ) -> Result<()> {
-        for &(name, value) in params {
+    pub(crate) fn bind_parameters_named<T: ToSql>(&mut self, params: &[(&str, T)]) -> Result<()> {
+        for &(name, ref value) in params {
             if let Some(i) = self.parameter_index(name)? {
                 let ts: &dyn ToSql = &value;
                 self.bind_parameter(ts, i)?;


### PR DESCRIPTION
Fixes #907... but I guess maybe they don't need it.

My main concern with this change is that it might make type inference work less well for users not using `named_params!`. It also might make the docs less clear...

What do you think @gwenn. The use case for this is pretty niche, is it worth supporting?