### PR TITLE
Fix nightly non_fmt_panic warning

### DIFF
--- a/src/inner_connection.rs
+++ b/src/inner_connection.rs
@@ -424,18 +424,14 @@ fn ensure_safe_sqlite_threading_mode() -> Result<()> {
             }
 
             unsafe {
-                let msg = "\
-Could not ensure safe initialization of SQLite.
-To fix this, either:
-* Upgrade SQLite to at least version 3.7.0
-* Ensure that SQLite has been initialized in Multi-thread or Serialized mode and call
-  rusqlite::bypass_sqlite_initialization() prior to your first connection attempt.";
-
-                if ffi::sqlite3_config(ffi::SQLITE_CONFIG_MULTITHREAD) != ffi::SQLITE_OK {
-                    panic!(msg);
-                }
-                if ffi::sqlite3_initialize() != ffi::SQLITE_OK {
-                    panic!(msg);
+                if ffi::sqlite3_config(ffi::SQLITE_CONFIG_MULTITHREAD) != ffi::SQLITE_OK || ffi::sqlite3_initialize() != ffi::SQLITE_OK {
+                    panic!(
+                        "Could not ensure safe initialization of SQLite.\n\
+                         To fix this, either:\n\
+                         * Upgrade SQLite to at least version 3.7.0\n\
+                         * Ensure that SQLite has been initialized in Multi-thread or Serialized mode and call\n\
+                           rusqlite::bypass_sqlite_initialization() prior to your first connection attempt."
+                    );
                 }
             }
         });


### PR DESCRIPTION
I use nightly primarially, and on nightly we get this warning for the inner_connection message code. Easy to fix, mostly. I did have to merge the checks into one branch though.

```
warning: panic message is not a string literal
   --> src/inner_connection.rs:435:28
    |
435 |                     panic!(msg);
    |                            ^^^
    |
    = note: `#[warn(non_fmt_panic)]` on by default
    = note: this is no longer accepted in Rust 2021
help: add a "{}" format string to Display the message
    |
435 |                     panic!("{}", msg);
    |                            ^^^^^
help: or use std::panic::panic_any instead
    |
435 |                     std::panic::panic_any(msg);
    |                     ^^^^^^^^^^^^^^^^^^^^^
    ```