### PR TITLE
Fix example code in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Rusqlite is an ergonomic wrapper for using SQLite from Rust. It attempts to expo
 an interface similar to [rust-postgres](https://github.com/sfackler/rust-postgres).
 
 ```rust
-use rusqlite::{params, Connection, Result};
+use rusqlite::{params, Connection, Result, NO_PARAMS};
 
 #[derive(Debug)]
 struct Person {
@@ -31,7 +31,7 @@ fn main() -> Result<()> {
                   name            TEXT NOT NULL,
                   data            BLOB
                   )",
-        [],
+        params!(),
     )?;
     let me = Person {
         id: 0,
@@ -44,7 +44,7 @@ fn main() -> Result<()> {
     )?;
 
     let mut stmt = conn.prepare("SELECT id, name, data FROM person")?;
-    let person_iter = stmt.query_map([], |row| {
+    let person_iter = stmt.query_map(NO_PARAMS, |row| {
         Ok(Person {
             id: row.get(0)?,
             name: row.get(1)?,


### PR DESCRIPTION
Currently, the code in the README doesn't even compile.

```
error[E0277]: `[_; 0]` is not an iterator
  --> src/main.rs:19:9
   |
19 |         [],
   |         ^^ borrow the array with `&` or call `.iter()` on it to iterate over it
   |
   = help: the trait `Iterator` is not implemented for `[_; 0]`
   = note: arrays are not iterators, but slices like the following are: `&[1, 2, 3]`
   = note: required because of the requirements on the impl of `IntoIterator` for `[_; 0]`

error[E0277]: `[_; 0]` is not an iterator
  --> src/main.rs:32:38
   |
32 |     let person_iter = stmt.query_map([], |row| {
   |                                      ^^ borrow the array with `&` or call `.iter()` on it to iterate over it
   |
   = help: the trait `Iterator` is not implemented for `[_; 0]`
   = note: arrays are not iterators, but slices like the following are: `&[1, 2, 3]`
   = note: required because of the requirements on the impl of `IntoIterator` for `[_; 0]`

error: aborting due to 2 previous errors
```

This merge request update the code for making it compile with the latest version

