### PR TITLE
define SQLITE_API to ensure api functions are not hidden

### DIFF
--- a/libsqlite3-sys/build.rs
+++ b/libsqlite3-sys/build.rs
@@ -535,7 +535,8 @@ mod bindings {
             .trust_clang_mangling(false)
             .header(header.clone())
             .parse_callbacks(Box::new(SqliteTypeChooser))
-            .rustfmt_bindings(true);
+            .rustfmt_bindings(true)
+            .clang_arg("-DSQLITE_API=__attribute__ ((visibility(\"default\")))"); // ensure SQLITE_API functions are not hidden
 
         if cfg!(any(feature = "sqlcipher", feature = "bundled-sqlcipher")) {
             bindings = bindings.clang_arg("-DSQLITE_HAS_CODEC");

--- a/libsqlite3-sys/build.rs
+++ b/libsqlite3-sys/build.rs
@@ -536,6 +536,7 @@ mod bindings {
             .header(header.clone())
             .parse_callbacks(Box::new(SqliteTypeChooser))
             .rustfmt_bindings(true)
+            .clang_arg("-fvisibility=hidden") // set visibility to hidden for symbols without explicit visibility attributes
             .clang_arg("-DSQLITE_API=__attribute__ ((visibility(\"default\")))"); // ensure SQLITE_API functions are not hidden
 
         if cfg!(any(feature = "sqlcipher", feature = "bundled-sqlcipher")) {


### PR DESCRIPTION
There is an issue with some targets (including `wasm32-unknown-unknown`) in which LLVM sets the default visibility of functions to hidden. See: https://github.com/rust-lang/rust-bindgen/issues/751

This did not used to be a problem with the sqlite headers, but as of clang 11 (the version that rust is currently using), it appears that all of the sqlite api functions in `sqlite3.h` are being set to hidden by default. 

The result is that if you attempt to build libsqlite3-sys with `--target wasm32-unknown-unknown` and the feature `buildtime_bindgen`, the generated bindings are missing all of the API functions.

I know of two possible fixes for this (see https://github.com/rust-lang/rust-bindgen/issues/751#issuecomment-496891269):
 - set `clang_arg("-fvisibility=default")` in the call to bindgen (which would set _all_ symbols to visible)
 - add a `visibility("default")` attribute to the symbols that should be exported

The sqlite header (`sqlite3.h`) provides a hook for modifying the attributes on API functions, as each one is prefixed by `SQLITE_API` (set to empty string by default). See for example https://github.com/rusqlite/rusqlite/blob/master/libsqlite3-sys/sqlite3/sqlite3.h#L51-L53 and https://github.com/rusqlite/rusqlite/blob/master/libsqlite3-sys/sqlite3/sqlite3.h#L402

This provides a clean mechanism by which we can simply insist that all `SQLITE_API` functions are visible to bindgen regardless of target platform. The proposed fix therefore is to define `SQLITE_API` to `__attribute__ ((visibility("default")))` -- it should be safe to do this on any target so I have not gated it with any feature.