### PR TITLE
Update README to refer correct bundled SQLite version

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,8 +124,8 @@ You can adjust this behavior in a number of ways:
 * If you use the `bundled` feature, `libsqlite3-sys` will use the
   [cc](https://crates.io/crates/cc) crate to compile SQLite from source and
   link against that. This source is embedded in the `libsqlite3-sys` crate and
-  is currently SQLite 3.34.0 (as of `rusqlite` 0.24.1 / `libsqlite3-sys`
-  0.21.0).  This is probably the simplest solution to any build problems. You can enable this by adding the following in your `Cargo.toml` file:
+  is currently SQLite 3.35.0 (as of `rusqlite` 0.24.2 / `libsqlite3-sys`
+  0.21.1).  This is probably the simplest solution to any build problems. You can enable this by adding the following in your `Cargo.toml` file:
   ```toml
   [dependencies.rusqlite]
   version = "0.24.2"


### PR DESCRIPTION
This PR fixes a version bump in the README that was missed in #917 