### PR TITLE
Silent some clippy warnings

### DIFF
--- a/libsqlite3-sys/src/error.rs
+++ b/libsqlite3-sys/src/error.rs
@@ -23,7 +23,7 @@ pub enum ErrorCode {
     /// Operation terminated by sqlite3_interrupt()
     OperationInterrupted,
     /// Some kind of disk I/O error occurred
-    SystemIOFailure,
+    SystemIoFailure,
     /// The database disk image is malformed
     DatabaseCorrupt,
     /// Unknown opcode in sqlite3_file_control()
@@ -43,7 +43,7 @@ pub enum ErrorCode {
     /// Data type mismatch
     TypeMismatch,
     /// Library used incorrectly
-    APIMisuse,
+    ApiMisuse,
     /// Uses OS features not supported on host
     NoLargeFileSupport,
     /// Authorization denied
@@ -73,7 +73,7 @@ impl Error {
             super::SQLITE_NOMEM => ErrorCode::OutOfMemory,
             super::SQLITE_READONLY => ErrorCode::ReadOnly,
             super::SQLITE_INTERRUPT => ErrorCode::OperationInterrupted,
-            super::SQLITE_IOERR => ErrorCode::SystemIOFailure,
+            super::SQLITE_IOERR => ErrorCode::SystemIoFailure,
             super::SQLITE_CORRUPT => ErrorCode::DatabaseCorrupt,
             super::SQLITE_NOTFOUND => ErrorCode::NotFound,
             super::SQLITE_FULL => ErrorCode::DiskFull,
@@ -83,7 +83,7 @@ impl Error {
             super::SQLITE_TOOBIG => ErrorCode::TooBig,
             super::SQLITE_CONSTRAINT => ErrorCode::ConstraintViolation,
             super::SQLITE_MISMATCH => ErrorCode::TypeMismatch,
-            super::SQLITE_MISUSE => ErrorCode::APIMisuse,
+            super::SQLITE_MISUSE => ErrorCode::ApiMisuse,
             super::SQLITE_NOLFS => ErrorCode::NoLargeFileSupport,
             super::SQLITE_AUTH => ErrorCode::AuthorizationForStatementDenied,
             super::SQLITE_RANGE => ErrorCode::ParameterOutOfRange,

--- a/libsqlite3-sys/src/lib.rs
+++ b/libsqlite3-sys/src/lib.rs
@@ -18,6 +18,7 @@ pub fn SQLITE_TRANSIENT() -> sqlite3_destructor_type {
 /// Run-Time Limit Categories
 #[repr(i32)]
 #[non_exhaustive]
+#[allow(clippy::upper_case_acronyms)]
 pub enum Limit {
     /// The maximum size of any string or BLOB or table row, in bytes.
     SQLITE_LIMIT_LENGTH = SQLITE_LIMIT_LENGTH,

--- a/src/collation.rs
+++ b/src/collation.rs
@@ -109,6 +109,7 @@ impl InnerConnection {
         x_coll_needed: fn(&Connection, &str) -> Result<()>,
     ) -> Result<()> {
         use std::mem;
+        #[allow(clippy::needless_return)]
         unsafe extern "C" fn collation_needed_callback(
             arg1: *mut c_void,
             arg2: *mut ffi::sqlite3,

--- a/src/config.rs
+++ b/src/config.rs
@@ -10,6 +10,7 @@ use crate::{Connection, Result};
 #[repr(i32)]
 #[allow(non_snake_case, non_camel_case_types)]
 #[non_exhaustive]
+#[allow(clippy::upper_case_acronyms)]
 pub enum DbConfig {
     //SQLITE_DBCONFIG_MAINDBNAME = 1000, /* const char* */
     //SQLITE_DBCONFIG_LOOKASIDE = 1001,  /* void* int int */

--- a/src/hooks.rs
+++ b/src/hooks.rs
@@ -13,6 +13,7 @@ use crate::{Connection, InnerConnection};
 #[derive(Clone, Copy, Debug, PartialEq)]
 #[repr(i32)]
 #[non_exhaustive]
+#[allow(clippy::upper_case_acronyms)]
 pub enum Action {
     /// Unsupported / unexpected action
     UNKNOWN = -1,

--- a/src/session.rs
+++ b/src/session.rs
@@ -695,6 +695,7 @@ impl From<i32> for ConflictType {
 #[repr(i32)]
 #[derive(Debug, PartialEq)]
 #[non_exhaustive]
+#[allow(clippy::upper_case_acronyms)]
 pub enum ConflictAction {
     SQLITE_CHANGESET_OMIT = ffi::SQLITE_CHANGESET_OMIT,
     SQLITE_CHANGESET_REPLACE = ffi::SQLITE_CHANGESET_REPLACE,

--- a/src/session.rs
+++ b/src/session.rs
@@ -667,6 +667,7 @@ impl Connection {
 #[repr(i32)]
 #[derive(Debug, PartialEq)]
 #[non_exhaustive]
+#[allow(clippy::upper_case_acronyms)]
 pub enum ConflictType {
     UNKNOWN = -1,
     SQLITE_CHANGESET_DATA = ffi::SQLITE_CHANGESET_DATA,

--- a/src/vtab/mod.rs
+++ b/src/vtab/mod.rs
@@ -261,6 +261,7 @@ pub trait CreateVTab<'vtab>: VTab<'vtab> {
 /// See [Virtual Table Constraint Operator Codes](https://sqlite.org/c3ref/c_index_constraint_eq.html) for details.
 #[derive(Debug, PartialEq)]
 #[allow(non_snake_case, non_camel_case_types, missing_docs)]
+#[allow(clippy::upper_case_acronyms)]
 pub enum IndexConstraintOp {
     SQLITE_INDEX_CONSTRAINT_EQ,
     SQLITE_INDEX_CONSTRAINT_GT,


### PR DESCRIPTION
* allow(clippy::upper_case_acronyms) for rust enum entries that match
  SQLite constants.
* allow(clippy::needless_return) for collation_needed_callback until we
  find a way to propagate the error.