### PR TITLE
Add missing params! in README's example

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ fn main() -> Result<()> {
                   name            TEXT NOT NULL,
                   data            BLOB
                   )",
-        [],
+        params![],
     )?;
     let me = Person {
         id: 0,
@@ -44,7 +44,7 @@ fn main() -> Result<()> {
     )?;
 
     let mut stmt = conn.prepare("SELECT id, name, data FROM person")?;
-    let person_iter = stmt.query_map([], |row| {
+    let person_iter = stmt.query_map(params![], |row| {
         Ok(Person {
             id: row.get(0)?,
             name: row.get(1)?,


### PR DESCRIPTION
Right now the README's example doesn't compile.