### PR TITLE
feat: add wasm32-unknown-unknown support and memvfs feature

### DIFF
--- a/libsqlite3-sys/Cargo.toml
+++ b/libsqlite3-sys/Cargo.toml
@@ -35,6 +35,13 @@ with-asan = []
 wasm32-wasi-vfs = []
 # lowest version shipped with Windows 10.0.10586 was 3.8.8.3
 winsqlite3 = ["min_sqlite_version_3_7_16"]
+sqlite-memvfs = ["lazy_static", "parking_lot", "log", "anyhow"]
+
+[dependencies]
+lazy_static = { version = "1.4.0", optional = true }
+parking_lot = { version = "0.11.1", optional = true }
+log = { version = "0.4", optional = true }
+anyhow = { version = "1.0.40", optional = true }
 
 [build-dependencies]
 bindgen = { version = "0.58", optional = true, default-features = false, features = ["runtime"] }

--- a/libsqlite3-sys/build.rs
+++ b/libsqlite3-sys/build.rs
@@ -118,6 +118,15 @@ mod build_bundled {
                 cfg.file("sqlite3/wasm32-wasi-vfs.c");
             }
         }
+
+        if env::var("TARGET") == Ok("wasm32-unknown-unknown".to_string()) {
+            cfg.flag("-DSQLITE_OUTER_MALLOC");
+            cfg.flag("-DSQLITE_OS_OTHER")
+                .flag("-DLONGDOUBLE_TYPE=double");
+            cfg.file("sqlite3/wasm-ext.c");
+            cfg.include("wasm-include");
+        }
+
         if cfg!(feature = "unlock_notify") {
             cfg.flag("-DSQLITE_ENABLE_UNLOCK_NOTIFY");
         }
@@ -126,6 +135,9 @@ mod build_bundled {
         }
         if cfg!(feature = "session") {
             cfg.flag("-DSQLITE_ENABLE_SESSION");
+        }
+        if cfg!(feature = "sqlite-memvfs") {
+            cfg.flag("-DSQLITE_OS_OTHER");
         }
 
         if let Ok(limit) = env::var("SQLITE_MAX_VARIABLE_NUMBER") {

--- a/libsqlite3-sys/sqlite3/wasm-ext.c
+++ b/libsqlite3-sys/sqlite3/wasm-ext.c
@@ -1,0 +1,207 @@
+// import implementations from android bionic libc
+
+#include <stdio.h>
+#include <string.h>
+
+size_t strcspn(const char* s1, const char* s2) {
+    const char *p, *spanp;
+    char c, sc;
+    /*
+     * Stop as soon as we find any character from s2.  Note that there
+     * must be a NUL in s2; it suffices to stop when we find that, too.
+     */
+    for (p = s1;;) {
+        c = *p++;
+        spanp = s2;
+        do {
+            if ((sc = *spanp++) == c)
+                return (p - 1 - s1);
+        } while (sc != 0);
+    }
+    /* NOTREACHED */
+}
+
+int strcmp(const char *s1, const char *s2)
+{
+    while (*s1 == *s2++)
+		if (*s1++ == 0)
+			return (0);
+	return (*(unsigned char *)s1 - *(unsigned char *)--s2);
+}
+
+size_t
+strlen(const char *str)
+{
+    const char *s;
+    for (s = str; *s; ++s)
+        ;
+    return (s - str);
+}
+
+int
+strncmp(const char *s1, const char *s2, register size_t n)
+{
+    if (n == 0)
+        return (0);
+    do {
+        if (*s1 != *s2++)
+            return (*(unsigned char *)s1 - *(unsigned char *)--s2);
+        if (*s1++ == 0)
+            break;
+    } while (--n != 0);
+    return (0);
+}
+
+// import from glibc
+char *
+strrchr (const char *s, int c)
+{
+    const char *found, *p;
+    c = (unsigned char) c;
+    /* Since strchr is fast, we use it rather than the obvious loop.  */
+    if (c == '\0')
+        return strchr (s, '\0');
+    found = NULL;
+    while ((p = strchr (s, c)) != NULL)
+    {
+        found = p;
+        s = p + 1;
+    }
+    return (char *) found;
+}
+
+char *
+strchr (const char *s, int c)
+{
+    do {
+        if (*s == c)
+        {
+            return (char*)s;
+        }
+    } while (*s++);
+    return (0);
+}
+
+struct tm *
+localtime_r (const void *timep, struct tm *tmp)
+{
+    // TODO: fix this tz conversion
+    /* return __tz_convert (t, 1, tp); */
+    return tmp;
+}
+
+#define min(a, b)	(a) < (b) ? a : b
+/*
+ * Qsort routine from Bentley & McIlroy's "Engineering a Sort Function".
+ */
+#define swapcode(TYPE, parmi, parmj, n) {       \
+	long i = (n) / sizeof (TYPE);           \
+	TYPE *pi = (TYPE *) (parmi);            \
+	TYPE *pj = (TYPE *) (parmj);            \
+	do {                                    \
+            TYPE	t = *pi;                \
+            *pi++ = *pj;                        \
+            *pj++ = t;				\
+        } while (--i > 0);                      \
+    }
+#define SWAPINIT(a, es) swaptype = ((char *)a - (char *)0) % sizeof(long) || \
+	es % sizeof(long) ? 2 : es == sizeof(long)? 0 : 1;
+static __inline void
+swapfunc(char *a, char *b, int n, int swaptype)
+{
+    if (swaptype <= 1) 
+        swapcode(long, a, b, n)
+    else
+        swapcode(char, a, b, n)
+            }
+#define swap(a, b)                              \
+    if (swaptype == 0) {                        \
+        long t = *(long *)(a);			\
+        *(long *)(a) = *(long *)(b);		\
+        *(long *)(b) = t;			\
+    } else                                      \
+        swapfunc(a, b, es, swaptype)
+#define vecswap(a, b, n) 	if ((n) > 0) swapfunc(a, b, n, swaptype)
+static __inline char *
+med3(char *a, char *b, char *c, int (*cmp)(const void *, const void *))
+{
+    return cmp(a, b) < 0 ?
+        (cmp(b, c) < 0 ? b : (cmp(a, c) < 0 ? c : a ))
+        :(cmp(b, c) > 0 ? b : (cmp(a, c) < 0 ? a : c ));
+}
+void
+qsort(void *aa, size_t n, size_t es, int (*cmp)(const void *, const void *))
+{
+    char *pa, *pb, *pc, *pd, *pl, *pm, *pn;
+    int d, r, swaptype, swap_cnt;
+    char *a = aa;
+loop:	SWAPINIT(a, es);
+    swap_cnt = 0;
+    if (n < 7) {
+        for (pm = (char *)a + es; pm < (char *) a + n * es; pm += es)
+            for (pl = pm; pl > (char *) a && cmp(pl - es, pl) > 0;
+                 pl -= es)
+                swap(pl, pl - es);
+        return;
+    }
+    pm = (char *)a + (n / 2) * es;
+    if (n > 7) {
+        pl = (char *)a;
+        pn = (char *)a + (n - 1) * es;
+        if (n > 40) {
+            d = (n / 8) * es;
+            pl = med3(pl, pl + d, pl + 2 * d, cmp);
+            pm = med3(pm - d, pm, pm + d, cmp);
+            pn = med3(pn - 2 * d, pn - d, pn, cmp);
+        }
+        pm = med3(pl, pm, pn, cmp);
+    }
+    swap(a, pm);
+    pa = pb = (char *)a + es;
+    
+    pc = pd = (char *)a + (n - 1) * es;
+    for (;;) {
+        while (pb <= pc && (r = cmp(pb, a)) <= 0) {
+            if (r == 0) {
+                swap_cnt = 1;
+                swap(pa, pb);
+                pa += es;
+            }
+            pb += es;
+        }
+        while (pb <= pc && (r = cmp(pc, a)) >= 0) {
+            if (r == 0) {
+                swap_cnt = 1;
+                swap(pc, pd);
+                pd -= es;
+            }
+            pc -= es;
+        }
+        if (pb > pc)
+            break;
+        swap(pb, pc);
+        swap_cnt = 1;
+        pb += es;
+        pc -= es;
+    }
+    if (swap_cnt == 0) {  /* Switch to insertion sort */
+        for (pm = (char *) a + es; pm < (char *) a + n * es; pm += es)
+            for (pl = pm; pl > (char *) a && cmp(pl - es, pl) > 0; 
+                 pl -= es)
+                swap(pl, pl - es);
+        return;
+    }
+    pn = (char *)a + n * es;
+    r = min(pa - (char *)a, pb - pa);
+    vecswap(a, pb - r, r);
+    r = min(pd - pc, pn - pd - (int)es);
+    vecswap(pb, pn - r, r);
+    if ((r = pb - pa) > (int)es)
+        qsort(a, r / es, es, cmp);
+    if ((r = pd - pc) > (int)es) { 
+        /* Iterate rather than recurse to save stack space */
+        a = pn - r;
+        n = r / es;
+        goto loop;
+    }
+}

--- a/libsqlite3-sys/src/memvfs/file_io.rs
+++ b/libsqlite3-sys/src/memvfs/file_io.rs
@@ -1,0 +1,130 @@
+use std::os::raw;
+
+use crate::{sqlite3_file, sqlite3_int64, SQLITE_IOERR_SHORT_READ, SQLITE_NOTFOUND, SQLITE_OK};
+use log::trace;
+
+#[no_mangle]
+pub(super) unsafe extern "C" fn dss_close(_arg1: *mut sqlite3_file) -> raw::c_int {
+    SQLITE_OK
+}
+
+#[no_mangle]
+pub(super) unsafe extern "C" fn dss_read(
+    arg1: *mut sqlite3_file,
+    arg2: *mut raw::c_void,
+    i_amt: raw::c_int,
+    i_ofst: sqlite3_int64,
+) -> raw::c_int {
+    let p = arg1 as *mut super::File;
+    let file_name = &(*p).data.name;
+
+    let guard = super::Fs::get_node(file_name).expect("db must exist");
+    let file = guard.read();
+
+    if file
+        .copy_out(arg2, i_ofst as isize, i_amt as usize)
+        .is_none()
+    {
+        return SQLITE_IOERR_SHORT_READ;
+    }
+
+    SQLITE_OK
+}
+
+#[no_mangle]
+pub(super) unsafe extern "C" fn dss_write(
+    arg1: *mut sqlite3_file,
+    arg2: *const raw::c_void,
+    i_amt: raw::c_int,
+    i_ofst: sqlite3_int64,
+) -> raw::c_int {
+    let p = arg1 as *mut super::File;
+    let file_name = &(*p).data.name;
+
+    let guard = super::Fs::get_node(file_name).expect("db must exist");
+    let mut file = guard.write();
+    file.write_in(arg2, i_ofst as isize, i_amt as usize);
+
+    SQLITE_OK
+}
+
+#[no_mangle]
+pub(super) unsafe extern "C" fn dss_truncate(
+    _arg1: *mut sqlite3_file,
+    _size: sqlite3_int64,
+) -> raw::c_int {
+    SQLITE_OK
+}
+
+#[no_mangle]
+pub(super) unsafe extern "C" fn dss_sync(
+    _arg1: *mut sqlite3_file,
+    _flags: raw::c_int,
+) -> raw::c_int {
+    SQLITE_OK
+}
+
+#[no_mangle]
+pub(super) unsafe extern "C" fn dss_file_size(
+    arg1: *mut sqlite3_file,
+    p_size: *mut sqlite3_int64,
+) -> raw::c_int {
+    let p = arg1 as *mut super::File;
+    let file_name = &(*p).data.name;
+
+    let size = super::Fs::get_node(file_name)
+        .expect("db must exist")
+        .read()
+        .size;
+
+    *p_size = size as sqlite3_int64;
+
+    SQLITE_OK
+}
+
+#[no_mangle]
+pub(super) unsafe extern "C" fn dss_lock(
+    _arg1: *mut sqlite3_file,
+    _arg2: raw::c_int,
+) -> raw::c_int {
+    trace!("file io lock");
+    SQLITE_OK
+}
+
+#[no_mangle]
+pub(super) unsafe extern "C" fn dss_unlock(
+    _arg1: *mut sqlite3_file,
+    _arg2: raw::c_int,
+) -> raw::c_int {
+    trace!("file io unlock");
+    SQLITE_OK
+}
+
+#[no_mangle]
+pub(super) unsafe extern "C" fn dss_check_reserved_lock(
+    _arg1: *mut sqlite3_file,
+    p_res_out: *mut raw::c_int,
+) -> raw::c_int {
+    (*p_res_out) = 0;
+
+    SQLITE_OK
+}
+
+#[no_mangle]
+pub(super) unsafe extern "C" fn dss_file_control(
+    _arg1: *mut sqlite3_file,
+    _op: raw::c_int,
+    _p_arg: *mut raw::c_void,
+) -> raw::c_int {
+    SQLITE_NOTFOUND
+}
+
+#[no_mangle]
+pub(super) unsafe extern "C" fn dss_sector_size(_arg1: *mut sqlite3_file) -> raw::c_int {
+    SQLITE_OK
+}
+
+#[no_mangle]
+pub(super) unsafe extern "C" fn dss_device_characteristics(_arg1: *mut sqlite3_file) -> raw::c_int {
+    SQLITE_OK
+}

--- a/libsqlite3-sys/src/memvfs/helpers.rs
+++ b/libsqlite3-sys/src/memvfs/helpers.rs
@@ -1,0 +1,13 @@
+use log::warn;
+use std::ffi::CStr;
+use std::os::raw;
+
+pub(super) fn cchar_to_str<'a>(s: *const raw::c_char) -> Option<&'a str> {
+    match unsafe { CStr::from_ptr(s).to_str() } {
+        Ok(s) => Some(s),
+        Err(e) => {
+            warn!("translate c string to rust failed: err= {}", e);
+            None
+        }
+    }
+}

--- a/libsqlite3-sys/src/memvfs/mod.rs
+++ b/libsqlite3-sys/src/memvfs/mod.rs
@@ -1,0 +1,162 @@
+use std::collections::HashMap;
+use std::os::raw;
+use std::sync::Arc;
+
+use crate::{sqlite3_file, sqlite3_io_methods, sqlite3_vfs};
+use lazy_static::lazy_static;
+use parking_lot::RwLock;
+
+mod file_io;
+mod helpers;
+mod vfs;
+#[repr(C)]
+struct File {
+    base: sqlite3_file,
+    data: FileData,
+}
+#[repr(C)]
+struct FileData {
+    name: String,
+}
+struct Node {
+    size: usize,
+    data: Vec<u8>,
+}
+
+impl Node {
+    fn copy_out(&self, dst: *mut raw::c_void, offset: isize, count: usize) -> Option<()> {
+        if self.size < offset as usize + count {
+            log::trace!("handle invalid input offset");
+            return None;
+        }
+
+        let ptr = self.data.as_ptr();
+
+        let dst = dst as *mut u8;
+
+        unsafe {
+            let ptr = ptr.offset(offset);
+            ptr.copy_to(dst, count);
+        }
+
+        Some(())
+    }
+
+    fn write_in(&mut self, src: *const raw::c_void, offset: isize, count: usize) {
+        let new_end = offset as usize + count;
+        let count_extend: isize = new_end as isize - self.data.len() as isize;
+        if count_extend > 0 {
+            self.data.extend(vec![0; count_extend as usize]);
+        }
+
+        if new_end > self.size {
+            self.size = new_end;
+        }
+
+        let ptr = self.data.as_mut_ptr();
+
+        unsafe {
+            let ptr = ptr.offset(offset);
+            ptr.copy_from(src as *const u8, count);
+        }
+    }
+}
+
+const FS_NODE_INITIAL_SIZE: usize = 8192;
+
+lazy_static! {
+    static ref FS: RwLock<HashMap<String, Arc<RwLock<Node>>>> = RwLock::new(HashMap::new());
+}
+
+struct Fs;
+
+impl Fs {
+    fn file_exists(name: &str) -> bool {
+        FS.read().contains_key(name)
+    }
+
+    fn add_file(name: String) {
+        if Fs::file_exists(&name) {
+            return;
+        }
+
+        log::trace!("insert new fs node: {}", name);
+
+        let node = Node {
+            size: 0,
+            data: vec![0; FS_NODE_INITIAL_SIZE],
+        };
+        FS.write().insert(name, Arc::new(RwLock::new(node)));
+    }
+
+    #[allow(dead_code)]
+    fn del_file(name: &str) {
+        log::trace!("remove fs node: {}", name);
+
+        FS.write().remove(name);
+    }
+
+    fn get_node(name: &str) -> Option<Arc<RwLock<Node>>> {
+        FS.read().get(name).cloned()
+    }
+}
+
+pub(crate) fn get_mem_vfs() -> sqlite3_vfs {
+    let version = 1;
+    let file_size = std::mem::size_of::<File>() as raw::c_int;
+    let max_path_len = 1024;
+    let p_next = std::ptr::null_mut();
+
+    let z_name = "memvfs-rs";
+    let z_name = z_name.as_ptr() as *const raw::c_char;
+    let p_app_data = std::ptr::null_mut();
+
+    sqlite3_vfs {
+        iVersion: version,
+        szOsFile: file_size,
+        mxPathname: max_path_len,
+        pNext: p_next,
+        zName: z_name,
+        pAppData: p_app_data,
+        xOpen: Some(vfs::dss_open),
+        xDelete: Some(vfs::dss_delete),
+        xAccess: Some(vfs::dss_access),
+        xFullPathname: Some(vfs::dss_full_path_name),
+        xDlOpen: Some(vfs::dss_dl_open),
+        xDlError: Some(vfs::dss_dl_error),
+        xDlSym: Some(vfs::dss_dl_sym),
+        xDlClose: Some(vfs::dss_dl_close),
+        xRandomness: Some(vfs::dss_randomness),
+        xSleep: Some(vfs::dss_sleep),
+        xCurrentTime: Some(vfs::dss_current_time),
+        xGetLastError: Some(vfs::dss_get_last_error),
+        xCurrentTimeInt64: None,
+        xSetSystemCall: None,
+        xGetSystemCall: None,
+        xNextSystemCall: None,
+    }
+}
+
+fn get_io_methods() -> sqlite3_io_methods {
+    sqlite3_io_methods {
+        iVersion: 1,
+        xClose: Some(file_io::dss_close),
+        xRead: Some(file_io::dss_read),
+        xWrite: Some(file_io::dss_write),
+        xTruncate: Some(file_io::dss_truncate),
+        xSync: Some(file_io::dss_sync),
+        xFileSize: Some(file_io::dss_file_size),
+        xLock: Some(file_io::dss_lock),
+        xUnlock: Some(file_io::dss_unlock),
+        xCheckReservedLock: Some(file_io::dss_check_reserved_lock),
+        xFileControl: Some(file_io::dss_file_control),
+        xSectorSize: Some(file_io::dss_sector_size),
+        xDeviceCharacteristics: Some(file_io::dss_device_characteristics),
+        xShmMap: None,
+        xShmLock: None,
+        xShmBarrier: None,
+        xShmUnmap: None,
+        xFetch: None,
+        xUnfetch: None,
+    }
+}

--- a/libsqlite3-sys/src/memvfs/vfs.rs
+++ b/libsqlite3-sys/src/memvfs/vfs.rs
@@ -1,0 +1,146 @@
+use std::ffi::CStr;
+use std::os::raw;
+
+use crate::{sqlite3_file, sqlite3_int64, sqlite3_vfs, SQLITE_OK};
+
+use super::helpers::cchar_to_str;
+use super::File;
+
+#[no_mangle]
+pub(super) unsafe extern "C" fn dss_open(
+    _arg1: *mut sqlite3_vfs,
+    z_name: *const raw::c_char,
+    arg2: *mut sqlite3_file,
+    _flags: raw::c_int,
+    _p_out_flags: *mut raw::c_int,
+) -> raw::c_int {
+    let name = cchar_to_str(z_name)
+        .expect("meet non-utf8 db name")
+        .to_string();
+
+    log::trace!("open db: {}", name);
+
+    let p = arg2 as *mut File;
+    (*p).data.name = name.clone();
+
+    let io_methods = Box::new(super::get_io_methods());
+    let io_methods_r = io_methods.as_ref();
+    (*arg2).pMethods = io_methods_r;
+    std::mem::forget(io_methods);
+
+    super::Fs::add_file(name);
+
+    0
+}
+
+#[no_mangle]
+pub(super) unsafe extern "C" fn dss_delete(
+    _arg1: *mut sqlite3_vfs,
+    _z_name: *const raw::c_char,
+    _sync_dir: raw::c_int,
+) -> raw::c_int {
+    SQLITE_OK
+}
+
+#[no_mangle]
+pub(super) unsafe extern "C" fn dss_access(
+    _arg1: *mut sqlite3_vfs,
+    _z_name: *const raw::c_char,
+    _flags: raw::c_int,
+    p_res_out: *mut raw::c_int,
+) -> raw::c_int {
+    *p_res_out = 0;
+
+    SQLITE_OK
+}
+
+#[no_mangle]
+pub(super) unsafe extern "C" fn dss_full_path_name(
+    _arg1: *mut sqlite3_vfs,
+    z_name: *const raw::c_char,
+    _n_out: raw::c_int,
+    z_out: *mut raw::c_char,
+) -> raw::c_int {
+    let s_len = CStr::from_ptr(z_name).to_bytes().len();
+
+    std::ptr::copy(z_name, z_out, s_len);
+
+    SQLITE_OK
+}
+
+#[no_mangle]
+pub(super) unsafe extern "C" fn dss_dl_open(
+    _arg1: *mut sqlite3_vfs,
+    _z_filename: *const raw::c_char,
+) -> *mut raw::c_void {
+    std::ptr::null_mut()
+}
+
+#[no_mangle]
+pub(super) unsafe extern "C" fn dss_dl_error(
+    _arg1: *mut sqlite3_vfs,
+    _n_byte: raw::c_int,
+    _z_err_msg: *mut raw::c_char,
+) {
+}
+
+type SymFn = unsafe extern "C" fn(
+    arg1: *mut sqlite3_vfs,
+    arg2: *mut raw::c_void,
+    z_symbol: *const raw::c_char,
+);
+
+#[no_mangle]
+pub(super) unsafe extern "C" fn dss_dl_sym(
+    _arg1: *mut sqlite3_vfs,
+    _arg2: *mut raw::c_void,
+    _z_symbol: *const raw::c_char,
+) -> Option<SymFn> {
+    None
+}
+
+#[no_mangle]
+pub(super) unsafe extern "C" fn dss_dl_close(_arg1: *mut sqlite3_vfs, _arg2: *mut raw::c_void) {}
+
+#[no_mangle]
+pub(super) unsafe extern "C" fn dss_randomness(
+    _arg1: *mut sqlite3_vfs,
+    _n_byte: raw::c_int,
+    _z_out: *mut raw::c_char,
+) -> raw::c_int {
+    SQLITE_OK
+}
+
+// no need to sleep
+#[no_mangle]
+pub(super) unsafe extern "C" fn dss_sleep(
+    _arg1: *mut sqlite3_vfs,
+    _microseconds: raw::c_int,
+) -> raw::c_int {
+    SQLITE_OK
+}
+
+#[no_mangle]
+pub(super) unsafe extern "C" fn dss_current_time(
+    _arg1: *mut sqlite3_vfs,
+    _arg2: *mut f64,
+) -> raw::c_int {
+    SQLITE_OK
+}
+
+#[no_mangle]
+pub(super) unsafe extern "C" fn dss_get_last_error(
+    _arg1: *mut sqlite3_vfs,
+    _arg2: raw::c_int,
+    _arg3: *mut raw::c_char,
+) -> raw::c_int {
+    SQLITE_OK
+}
+
+#[no_mangle]
+pub(super) unsafe extern "C" fn dss_current_time_int64(
+    _arg1: *mut sqlite3_vfs,
+    _arg2: *mut sqlite3_int64,
+) -> raw::c_int {
+    SQLITE_OK
+}

--- a/libsqlite3-sys/wasm-include/__functions_malloc.h
+++ b/libsqlite3-sys/wasm-include/__functions_malloc.h
@@ -1,0 +1,26 @@
+#ifndef __wasilibc___functions_malloc_h
+#define __wasilibc___functions_malloc_h
+
+#define __need_size_t
+#define __need_wchar_t
+#define __need_NULL
+#include <stddef.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+void *malloc(size_t __size) __attribute__((__malloc__, __warn_unused_result__));
+void free(void *__ptr);
+void *calloc(size_t __nmemb, size_t __size) __attribute__((__malloc__, __warn_unused_result__));
+void *realloc(void *__ptr, size_t __size) __attribute__((__warn_unused_result__));
+
+#if defined(_GNU_SOURCE) || defined(_BSD_SOURCE)
+void *reallocarray(void *__ptr, size_t __nmemb, size_t __size) __attribute__((__warn_unused_result__));
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/libsqlite3-sys/wasm-include/__header_stdlib.h
+++ b/libsqlite3-sys/wasm-include/__header_stdlib.h
@@ -1,0 +1,21 @@
+#ifndef __wasilibc___header_stdlib_h
+#define __wasilibc___header_stdlib_h
+
+#define __need_size_t
+#include <stddef.h>
+
+#include <__functions_malloc.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+void abort(void) __attribute__((__noreturn__));
+void qsort(void *, size_t, size_t, int (*)(const void *, const void *));
+void _Exit(int) __attribute__((__noreturn__));
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/libsqlite3-sys/wasm-include/__header_time.h
+++ b/libsqlite3-sys/wasm-include/__header_time.h
@@ -1,0 +1,37 @@
+#ifndef __wasilibc___header_time_h
+#define __wasilibc___header_time_h
+
+#define __need_size_t
+#define __need_NULL
+#include <stddef.h>
+
+#include <__typedef_time_t.h>
+#include <__struct_timespec.h>
+#include <__struct_tm.h>
+#include <__typedef_clockid_t.h>
+
+/* #include <wasi/api.h> */
+
+#define TIMER_ABSTIME __WASI_SUBCLOCKFLAGS_SUBSCRIPTION_CLOCK_ABSTIME
+
+extern const struct __clockid _CLOCK_MONOTONIC;
+#define CLOCK_MONOTONIC (&_CLOCK_MONOTONIC)
+extern const struct __clockid _CLOCK_PROCESS_CPUTIME_ID;
+#define CLOCK_PROCESS_CPUTIME_ID (&_CLOCK_PROCESS_CPUTIME_ID)
+extern const struct __clockid _CLOCK_REALTIME;
+#define CLOCK_REALTIME (&_CLOCK_REALTIME)
+extern const struct __clockid _CLOCK_THREAD_CPUTIME_ID;
+#define CLOCK_THREAD_CPUTIME_ID (&_CLOCK_THREAD_CPUTIME_ID)
+
+/*
+ * TIME_UTC is the only standardized time base value.
+ */
+#define TIME_UTC 1
+
+/*
+ * Note that XSI specifies CLOCKS_PER_SEC to be 1000000, rather than
+ * 1000000000; the clock API is providing more precision than XSI specifies.
+ */
+#define CLOCKS_PER_SEC ((clock_t)1000000000)
+
+#endif

--- a/libsqlite3-sys/wasm-include/__struct_iovec.h
+++ b/libsqlite3-sys/wasm-include/__struct_iovec.h
@@ -1,0 +1,12 @@
+#ifndef __wasilibc___struct_iovec_h
+#define __wasilibc___struct_iovec_h
+
+#define __need_size_t
+#include <stddef.h>
+
+struct iovec {
+    void *iov_base;
+    size_t iov_len;
+};
+
+#endif

--- a/libsqlite3-sys/wasm-include/__struct_timespec.h
+++ b/libsqlite3-sys/wasm-include/__struct_timespec.h
@@ -1,0 +1,12 @@
+#ifndef __wasilibc___struct_timespec_h
+#define __wasilibc___struct_timespec_h
+
+#include <__typedef_time_t.h>
+
+/* As specified in POSIX. */
+struct timespec {
+    time_t tv_sec;
+    long tv_nsec;
+};
+
+#endif

--- a/libsqlite3-sys/wasm-include/__struct_timeval.h
+++ b/libsqlite3-sys/wasm-include/__struct_timeval.h
@@ -1,0 +1,13 @@
+#ifndef __wasilibc___struct_timeval_h
+#define __wasilibc___struct_timeval_h
+
+#include <__typedef_time_t.h>
+#include <__typedef_suseconds_t.h>
+
+/* As specified in POSIX. */
+struct timeval {
+    time_t tv_sec;
+    suseconds_t tv_usec;
+};
+
+#endif

--- a/libsqlite3-sys/wasm-include/__struct_tm.h
+++ b/libsqlite3-sys/wasm-include/__struct_tm.h
@@ -1,0 +1,19 @@
+#ifndef __wasilibc___struct_tm_h
+#define __wasilibc___struct_tm_h
+
+struct tm {
+    int tm_sec;
+    int tm_min;
+    int tm_hour;
+    int tm_mday;
+    int tm_mon;
+    int tm_year;
+    int tm_wday;
+    int tm_yday;
+    int tm_isdst;
+    int __tm_gmtoff;
+    const char *__tm_zone;
+    int __tm_nsec;
+};
+
+#endif

--- a/libsqlite3-sys/wasm-include/__typedef_clock_t.h
+++ b/libsqlite3-sys/wasm-include/__typedef_clock_t.h
@@ -1,0 +1,7 @@
+#ifndef __wasilibc___typedef_clock_t_h
+#define __wasilibc___typedef_clock_t_h
+
+/* Define this as a 64-bit signed integer to avoid wraparounds. */
+typedef long long clock_t;
+
+#endif

--- a/libsqlite3-sys/wasm-include/__typedef_clockid_t.h
+++ b/libsqlite3-sys/wasm-include/__typedef_clockid_t.h
@@ -1,0 +1,6 @@
+#ifndef __wasilibc___typedef_clockid_t_h
+#define __wasilibc___typedef_clockid_t_h
+
+typedef const struct __clockid *clockid_t;
+
+#endif

--- a/libsqlite3-sys/wasm-include/__typedef_suseconds_t.h
+++ b/libsqlite3-sys/wasm-include/__typedef_suseconds_t.h
@@ -1,0 +1,8 @@
+#ifndef __wasilibc___typedef_suseconds_t_h
+#define __wasilibc___typedef_suseconds_t_h
+
+/* Define this to be 64-bit as its main use is in struct timeval where the
+   extra space would otherwise be padding. */
+typedef long long suseconds_t;
+
+#endif

--- a/libsqlite3-sys/wasm-include/__typedef_time_t.h
+++ b/libsqlite3-sys/wasm-include/__typedef_time_t.h
@@ -1,0 +1,7 @@
+#ifndef __wasilibc___typedef_time_t_h
+#define __wasilibc___typedef_time_t_h
+
+/* Define this as a 64-bit signed integer to avoid the 2038 bug. */
+typedef long long time_t;
+
+#endif

--- a/libsqlite3-sys/wasm-include/alloca.h
+++ b/libsqlite3-sys/wasm-include/alloca.h
@@ -1,0 +1,19 @@
+#ifndef	_ALLOCA_H
+#define	_ALLOCA_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define	__NEED_size_t
+#include <bits/alltypes.h>
+
+void *alloca(size_t);
+
+#define alloca __builtin_alloca
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/libsqlite3-sys/wasm-include/assert.h
+++ b/libsqlite3-sys/wasm-include/assert.h
@@ -1,0 +1,23 @@
+#include <features.h>
+
+#undef assert
+
+#ifdef NDEBUG
+#define	assert(x) (void)0
+#else
+#define assert(x) ((void)((x) || (__assert_fail(#x, __FILE__, __LINE__, __func__),0)))
+#endif
+
+#if __STDC_VERSION__ >= 201112L && !defined(__cplusplus)
+#define static_assert _Static_assert
+#endif
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+_Noreturn void __assert_fail (const char *, const char *, int, const char *);
+
+#ifdef __cplusplus
+}
+#endif

--- a/libsqlite3-sys/wasm-include/bits/alltypes.h
+++ b/libsqlite3-sys/wasm-include/bits/alltypes.h
@@ -1,0 +1,454 @@
+#define _Addr long
+#define _Int64 long long
+#define _Reg long long
+
+#define __BYTE_ORDER __BYTE_ORDER__
+
+#define __LONG_MAX __LONG_MAX__
+
+/*
+ * Rather than define everything ourselves here in the musl layer, for
+ * WASI, reference the definitions in the lower layers.
+ */
+
+#if defined(__NEED_wchar_t) && !defined(__DEFINED_wchar_t)
+#define __need_wchar_t
+#include <stddef.h>
+#define __DEFINED_wchar_t
+#endif
+
+#if defined(__NEED_wint_t) && !defined(__DEFINED_wint_t)
+#define __need_wint_t
+#include <stddef.h>
+#define __DEFINED_wint_t
+#endif
+
+#if defined(__NEED_float_t) && !defined(__DEFINED_float_t)
+typedef float float_t;
+#define __DEFINED_float_t
+#endif
+
+#if defined(__NEED_double_t) && !defined(__DEFINED_double_t)
+typedef double double_t;
+#define __DEFINED_double_t
+#endif
+
+
+#if defined(__NEED_max_align_t) && !defined(__DEFINED_max_align_t)
+#define __need_max_align_t
+#include <stddef.h>
+#define __DEFINED_max_align_t
+#endif
+
+#if defined(__NEED_time_t) && !defined(__DEFINED_time_t)
+#include <__typedef_time_t.h>
+#define __DEFINED_time_t
+#endif
+
+#if defined(__NEED_suseconds_t) && !defined(__DEFINED_suseconds_t)
+#include <__typedef_suseconds_t.h>
+#define __DEFINED_suseconds_t
+#endif
+
+#if defined(__NEED_clockid_t) && !defined(__DEFINED_clockid_t)
+#include <__typedef_clockid_t.h>
+#define __DEFINED_clockid_t
+#endif
+
+#if defined(__NEED_sigset_t) && !defined(__DEFINED_sigset_t)
+#include <__typedef_sigset_t.h>
+#define __DEFINED_sigset_t
+#endif
+
+#if defined(__NEED_clock_t) && !defined(__DEFINED_clock_t)
+#include <__typedef_clock_t.h>
+#define __DEFINED_clock_t
+#endif
+#define __LITTLE_ENDIAN 1234
+#define __BIG_ENDIAN 4321
+#define __USE_TIME_BITS64 1
+
+#if defined(__NEED_size_t) && !defined(__DEFINED_size_t)
+typedef unsigned _Addr size_t;
+#define __DEFINED_size_t
+#endif
+
+#if defined(__NEED_uintptr_t) && !defined(__DEFINED_uintptr_t)
+typedef unsigned _Addr uintptr_t;
+#define __DEFINED_uintptr_t
+#endif
+
+#if defined(__NEED_ptrdiff_t) && !defined(__DEFINED_ptrdiff_t)
+typedef _Addr ptrdiff_t;
+#define __DEFINED_ptrdiff_t
+#endif
+
+#if defined(__NEED_ssize_t) && !defined(__DEFINED_ssize_t)
+typedef _Addr ssize_t;
+#define __DEFINED_ssize_t
+#endif
+
+#if defined(__NEED_intptr_t) && !defined(__DEFINED_intptr_t)
+typedef _Addr intptr_t;
+#define __DEFINED_intptr_t
+#endif
+
+#if defined(__NEED_regoff_t) && !defined(__DEFINED_regoff_t)
+typedef _Addr regoff_t;
+#define __DEFINED_regoff_t
+#endif
+
+#if defined(__NEED_register_t) && !defined(__DEFINED_register_t)
+typedef _Reg register_t;
+#define __DEFINED_register_t
+#endif
+
+#ifdef __wasilibc_unmodified_upstream /* Use alternate WASI libc headers */
+#if defined(__NEED_time_t) && !defined(__DEFINED_time_t)
+typedef _Int64 time_t;
+#define __DEFINED_time_t
+#endif
+
+#if defined(__NEED_suseconds_t) && !defined(__DEFINED_suseconds_t)
+typedef _Int64 suseconds_t;
+#define __DEFINED_suseconds_t
+#endif
+
+#else
+#if defined(__NEED_time_t) && !defined(__DEFINED_time_t)
+#include <__typedef_time_t.h>
+#define __DEFINED_time_t
+#endif
+
+#if defined(__NEED_suseconds_t) && !defined(__DEFINED_suseconds_t)
+#include <__typedef_suseconds_t.h>
+#define __DEFINED_suseconds_t
+#endif
+#endif
+
+#if defined(__NEED_int8_t) && !defined(__DEFINED_int8_t)
+typedef signed char     int8_t;
+#define __DEFINED_int8_t
+#endif
+
+#if defined(__NEED_int16_t) && !defined(__DEFINED_int16_t)
+typedef signed short    int16_t;
+#define __DEFINED_int16_t
+#endif
+
+#if defined(__NEED_int32_t) && !defined(__DEFINED_int32_t)
+typedef signed int      int32_t;
+#define __DEFINED_int32_t
+#endif
+
+#if defined(__NEED_int64_t) && !defined(__DEFINED_int64_t)
+typedef signed _Int64   int64_t;
+#define __DEFINED_int64_t
+#endif
+
+#if defined(__NEED_intmax_t) && !defined(__DEFINED_intmax_t)
+typedef signed _Int64   intmax_t;
+#define __DEFINED_intmax_t
+#endif
+
+#if defined(__NEED_uint8_t) && !defined(__DEFINED_uint8_t)
+typedef unsigned char   uint8_t;
+#define __DEFINED_uint8_t
+#endif
+
+#if defined(__NEED_uint16_t) && !defined(__DEFINED_uint16_t)
+typedef unsigned short  uint16_t;
+#define __DEFINED_uint16_t
+#endif
+
+#if defined(__NEED_uint32_t) && !defined(__DEFINED_uint32_t)
+typedef unsigned int    uint32_t;
+#define __DEFINED_uint32_t
+#endif
+
+#if defined(__NEED_uint64_t) && !defined(__DEFINED_uint64_t)
+typedef unsigned _Int64 uint64_t;
+#define __DEFINED_uint64_t
+#endif
+
+#if defined(__NEED_u_int64_t) && !defined(__DEFINED_u_int64_t)
+typedef unsigned _Int64 u_int64_t;
+#define __DEFINED_u_int64_t
+#endif
+
+#if defined(__NEED_uintmax_t) && !defined(__DEFINED_uintmax_t)
+typedef unsigned _Int64 uintmax_t;
+#define __DEFINED_uintmax_t
+#endif
+
+
+#if defined(__NEED_mode_t) && !defined(__DEFINED_mode_t)
+typedef unsigned mode_t;
+#define __DEFINED_mode_t
+#endif
+
+#if defined(__NEED_nlink_t) && !defined(__DEFINED_nlink_t)
+typedef unsigned _Reg nlink_t;
+#define __DEFINED_nlink_t
+#endif
+
+#if defined(__NEED_off_t) && !defined(__DEFINED_off_t)
+typedef _Int64 off_t;
+#define __DEFINED_off_t
+#endif
+
+#if defined(__NEED_ino_t) && !defined(__DEFINED_ino_t)
+typedef unsigned _Int64 ino_t;
+#define __DEFINED_ino_t
+#endif
+
+#if defined(__NEED_dev_t) && !defined(__DEFINED_dev_t)
+typedef unsigned _Int64 dev_t;
+#define __DEFINED_dev_t
+#endif
+
+#if defined(__NEED_blksize_t) && !defined(__DEFINED_blksize_t)
+typedef long blksize_t;
+#define __DEFINED_blksize_t
+#endif
+
+#if defined(__NEED_blkcnt_t) && !defined(__DEFINED_blkcnt_t)
+typedef _Int64 blkcnt_t;
+#define __DEFINED_blkcnt_t
+#endif
+
+#if defined(__NEED_fsblkcnt_t) && !defined(__DEFINED_fsblkcnt_t)
+typedef unsigned _Int64 fsblkcnt_t;
+#define __DEFINED_fsblkcnt_t
+#endif
+
+#if defined(__NEED_fsfilcnt_t) && !defined(__DEFINED_fsfilcnt_t)
+typedef unsigned _Int64 fsfilcnt_t;
+#define __DEFINED_fsfilcnt_t
+#endif
+
+
+#if defined(__NEED_wint_t) && !defined(__DEFINED_wint_t)
+typedef unsigned wint_t;
+#define __DEFINED_wint_t
+#endif
+
+#if defined(__NEED_wctype_t) && !defined(__DEFINED_wctype_t)
+typedef unsigned long wctype_t;
+#define __DEFINED_wctype_t
+#endif
+
+
+#if defined(__NEED_timer_t) && !defined(__DEFINED_timer_t)
+typedef void * timer_t;
+#define __DEFINED_timer_t
+#endif
+
+#if defined(__NEED_clockid_t) && !defined(__DEFINED_clockid_t)
+typedef int clockid_t;
+#define __DEFINED_clockid_t
+#endif
+
+#if defined(__NEED_clock_t) && !defined(__DEFINED_clock_t)
+typedef long clock_t;
+#define __DEFINED_clock_t
+#endif
+
+#ifdef __wasilibc_unmodified_upstream /* Use alternate WASI libc headers */
+#if defined(__NEED_struct_timeval) && !defined(__DEFINED_struct_timeval)
+struct timeval { time_t tv_sec; suseconds_t tv_usec; };
+#define __DEFINED_struct_timeval
+#endif
+
+#if defined(__NEED_struct_timespec) && !defined(__DEFINED_struct_timespec)
+struct timespec { time_t tv_sec; int :8*(sizeof(time_t)-sizeof(long))*(__BYTE_ORDER==4321); long tv_nsec; int :8*(sizeof(time_t)-sizeof(long))*(__BYTE_ORDER!=4321); };
+#define __DEFINED_struct_timespec
+#endif
+
+#else
+#include <__struct_timeval.h>
+#include <__struct_timespec.h>
+#endif
+
+#if defined(__NEED_pid_t) && !defined(__DEFINED_pid_t)
+typedef int pid_t;
+#define __DEFINED_pid_t
+#endif
+
+#if defined(__NEED_id_t) && !defined(__DEFINED_id_t)
+typedef unsigned id_t;
+#define __DEFINED_id_t
+#endif
+
+#if defined(__NEED_uid_t) && !defined(__DEFINED_uid_t)
+typedef unsigned uid_t;
+#define __DEFINED_uid_t
+#endif
+
+#if defined(__NEED_gid_t) && !defined(__DEFINED_gid_t)
+typedef unsigned gid_t;
+#define __DEFINED_gid_t
+#endif
+
+#if defined(__NEED_key_t) && !defined(__DEFINED_key_t)
+typedef int key_t;
+#define __DEFINED_key_t
+#endif
+
+#if defined(__NEED_useconds_t) && !defined(__DEFINED_useconds_t)
+typedef unsigned useconds_t;
+#define __DEFINED_useconds_t
+#endif
+
+
+#ifdef __cplusplus
+#if defined(__NEED_pthread_t) && !defined(__DEFINED_pthread_t)
+typedef unsigned long pthread_t;
+#define __DEFINED_pthread_t
+#endif
+
+#else
+#if defined(__NEED_pthread_t) && !defined(__DEFINED_pthread_t)
+typedef struct __pthread * pthread_t;
+#define __DEFINED_pthread_t
+#endif
+
+#endif
+#if defined(__NEED_pthread_once_t) && !defined(__DEFINED_pthread_once_t)
+typedef int pthread_once_t;
+#define __DEFINED_pthread_once_t
+#endif
+
+#if defined(__NEED_pthread_key_t) && !defined(__DEFINED_pthread_key_t)
+typedef unsigned pthread_key_t;
+#define __DEFINED_pthread_key_t
+#endif
+
+#if defined(__NEED_pthread_spinlock_t) && !defined(__DEFINED_pthread_spinlock_t)
+typedef int pthread_spinlock_t;
+#define __DEFINED_pthread_spinlock_t
+#endif
+
+#if defined(__NEED_pthread_mutexattr_t) && !defined(__DEFINED_pthread_mutexattr_t)
+typedef struct { unsigned __attr; } pthread_mutexattr_t;
+#define __DEFINED_pthread_mutexattr_t
+#endif
+
+#if defined(__NEED_pthread_condattr_t) && !defined(__DEFINED_pthread_condattr_t)
+typedef struct { unsigned __attr; } pthread_condattr_t;
+#define __DEFINED_pthread_condattr_t
+#endif
+
+#if defined(__NEED_pthread_barrierattr_t) && !defined(__DEFINED_pthread_barrierattr_t)
+typedef struct { unsigned __attr; } pthread_barrierattr_t;
+#define __DEFINED_pthread_barrierattr_t
+#endif
+
+#if defined(__NEED_pthread_rwlockattr_t) && !defined(__DEFINED_pthread_rwlockattr_t)
+typedef struct { unsigned __attr[2]; } pthread_rwlockattr_t;
+#define __DEFINED_pthread_rwlockattr_t
+#endif
+
+
+#ifdef __wasilibc_unmodified_upstream /* WASI doesn't need to define FILE as a complete type */
+#if defined(__NEED_struct__IO_FILE) && !defined(__DEFINED_struct__IO_FILE)
+struct _IO_FILE { char __x; };
+#define __DEFINED_struct__IO_FILE
+#endif
+
+#endif
+#if defined(__NEED_FILE) && !defined(__DEFINED_FILE)
+typedef struct _IO_FILE FILE;
+#define __DEFINED_FILE
+#endif
+
+
+#if defined(__NEED_va_list) && !defined(__DEFINED_va_list)
+typedef __builtin_va_list va_list;
+#define __DEFINED_va_list
+#endif
+
+#if defined(__NEED___isoc_va_list) && !defined(__DEFINED___isoc_va_list)
+typedef __builtin_va_list __isoc_va_list;
+#define __DEFINED___isoc_va_list
+#endif
+
+
+#if defined(__NEED_mbstate_t) && !defined(__DEFINED_mbstate_t)
+typedef struct __mbstate_t { unsigned __opaque1, __opaque2; } mbstate_t;
+#define __DEFINED_mbstate_t
+#endif
+
+
+#if defined(__NEED_locale_t) && !defined(__DEFINED_locale_t)
+typedef struct __locale_struct * locale_t;
+#define __DEFINED_locale_t
+#endif
+
+
+#if defined(__NEED_sigset_t) && !defined(__DEFINED_sigset_t)
+typedef struct __sigset_t { unsigned long __bits[128/sizeof(long)]; } sigset_t;
+#define __DEFINED_sigset_t
+#endif
+
+
+#ifdef __wasilibc_unmodified_upstream /* Use alternate WASI libc headers */
+#if defined(__NEED_struct_iovec) && !defined(__DEFINED_struct_iovec)
+struct iovec { void *iov_base; size_t iov_len; };
+#define __DEFINED_struct_iovec
+#endif
+
+#else
+#include <__struct_iovec.h>
+#endif
+
+#if defined(__NEED_socklen_t) && !defined(__DEFINED_socklen_t)
+typedef unsigned socklen_t;
+#define __DEFINED_socklen_t
+#endif
+
+#if defined(__NEED_sa_family_t) && !defined(__DEFINED_sa_family_t)
+typedef unsigned short sa_family_t;
+#define __DEFINED_sa_family_t
+#endif
+
+
+#if defined(__NEED_pthread_attr_t) && !defined(__DEFINED_pthread_attr_t)
+typedef struct { union { int __i[sizeof(long)==8?14:9]; volatile int __vi[sizeof(long)==8?14:9]; unsigned long __s[sizeof(long)==8?7:9]; } __u; } pthread_attr_t;
+#define __DEFINED_pthread_attr_t
+#endif
+
+#if defined(__NEED_pthread_mutex_t) && !defined(__DEFINED_pthread_mutex_t)
+typedef struct { union { int __i[sizeof(long)==8?10:6]; volatile int __vi[sizeof(long)==8?10:6]; volatile void *volatile __p[sizeof(long)==8?5:6]; } __u; } pthread_mutex_t;
+#define __DEFINED_pthread_mutex_t
+#endif
+
+#if defined(__NEED_mtx_t) && !defined(__DEFINED_mtx_t)
+typedef struct { union { int __i[sizeof(long)==8?10:6]; volatile int __vi[sizeof(long)==8?10:6]; volatile void *volatile __p[sizeof(long)==8?5:6]; } __u; } mtx_t;
+#define __DEFINED_mtx_t
+#endif
+
+#if defined(__NEED_pthread_cond_t) && !defined(__DEFINED_pthread_cond_t)
+typedef struct { union { int __i[12]; volatile int __vi[12]; void *__p[12*sizeof(int)/sizeof(void*)]; } __u; } pthread_cond_t;
+#define __DEFINED_pthread_cond_t
+#endif
+
+#if defined(__NEED_cnd_t) && !defined(__DEFINED_cnd_t)
+typedef struct { union { int __i[12]; volatile int __vi[12]; void *__p[12*sizeof(int)/sizeof(void*)]; } __u; } cnd_t;
+#define __DEFINED_cnd_t
+#endif
+
+#if defined(__NEED_pthread_rwlock_t) && !defined(__DEFINED_pthread_rwlock_t)
+typedef struct { union { int __i[sizeof(long)==8?14:8]; volatile int __vi[sizeof(long)==8?14:8]; void *__p[sizeof(long)==8?7:8]; } __u; } pthread_rwlock_t;
+#define __DEFINED_pthread_rwlock_t
+#endif
+
+#if defined(__NEED_pthread_barrier_t) && !defined(__DEFINED_pthread_barrier_t)
+typedef struct { union { int __i[sizeof(long)==8?8:5]; volatile int __vi[sizeof(long)==8?8:5]; void *__p[sizeof(long)==8?4:5]; } __u; } pthread_barrier_t;
+#define __DEFINED_pthread_barrier_t
+#endif
+
+
+#undef _Addr
+#undef _Int64
+#undef _Reg

--- a/libsqlite3-sys/wasm-include/ctype.h
+++ b/libsqlite3-sys/wasm-include/ctype.h
@@ -1,0 +1,75 @@
+#ifndef	_CTYPE_H
+#define	_CTYPE_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <features.h>
+
+int   isalnum(int);
+int   isalpha(int);
+int   isblank(int);
+int   iscntrl(int);
+int   isdigit(int);
+int   isgraph(int);
+int   islower(int);
+int   isprint(int);
+int   ispunct(int);
+int   isspace(int);
+int   isupper(int);
+int   isxdigit(int);
+int   tolower(int);
+int   toupper(int);
+
+#ifndef __cplusplus
+static __inline int __isspace(int _c)
+{
+	return _c == ' ' || (unsigned)_c-'\t' < 5;
+}
+
+#define isalpha(a) (0 ? isalpha(a) : (((unsigned)(a)|32)-'a') < 26)
+#define isdigit(a) (0 ? isdigit(a) : ((unsigned)(a)-'0') < 10)
+#define islower(a) (0 ? islower(a) : ((unsigned)(a)-'a') < 26)
+#define isupper(a) (0 ? isupper(a) : ((unsigned)(a)-'A') < 26)
+#define isprint(a) (0 ? isprint(a) : ((unsigned)(a)-0x20) < 0x5f)
+#define isgraph(a) (0 ? isgraph(a) : ((unsigned)(a)-0x21) < 0x5e)
+#define isspace(a) __isspace(a)
+#endif
+
+
+#if defined(_POSIX_SOURCE) || defined(_POSIX_C_SOURCE) \
+ || defined(_XOPEN_SOURCE) || defined(_GNU_SOURCE) \
+ || defined(_BSD_SOURCE)
+
+#define __NEED_locale_t
+#include <bits/alltypes.h>
+
+int   isalnum_l(int, locale_t);
+int   isalpha_l(int, locale_t);
+int   isblank_l(int, locale_t);
+int   iscntrl_l(int, locale_t);
+int   isdigit_l(int, locale_t);
+int   isgraph_l(int, locale_t);
+int   islower_l(int, locale_t);
+int   isprint_l(int, locale_t);
+int   ispunct_l(int, locale_t);
+int   isspace_l(int, locale_t);
+int   isupper_l(int, locale_t);
+int   isxdigit_l(int, locale_t);
+int   tolower_l(int, locale_t);
+int   toupper_l(int, locale_t);
+
+int   isascii(int);
+int   toascii(int);
+#define _tolower(a) ((a)|0x20)
+#define _toupper(a) ((a)&0x5f)
+#define isascii(a) (0 ? isascii(a) : (unsigned)(a) < 128)
+
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/libsqlite3-sys/wasm-include/features.h
+++ b/libsqlite3-sys/wasm-include/features.h
@@ -1,0 +1,40 @@
+#ifndef _FEATURES_H
+#define _FEATURES_H
+
+#if defined(_ALL_SOURCE) && !defined(_GNU_SOURCE)
+#define _GNU_SOURCE 1
+#endif
+
+#if defined(_DEFAULT_SOURCE) && !defined(_BSD_SOURCE)
+#define _BSD_SOURCE 1
+#endif
+
+#if !defined(_POSIX_SOURCE) && !defined(_POSIX_C_SOURCE) \
+ && !defined(_XOPEN_SOURCE) && !defined(_GNU_SOURCE) \
+ && !defined(_BSD_SOURCE) && !defined(__STRICT_ANSI__)
+#define _BSD_SOURCE 1
+#define _XOPEN_SOURCE 700
+#endif
+
+#if __STDC_VERSION__ >= 199901L
+#define __restrict restrict
+#elif !defined(__GNUC__)
+#define __restrict
+#endif
+
+#if __STDC_VERSION__ >= 199901L || defined(__cplusplus)
+#define __inline inline
+#elif !defined(__GNUC__)
+#define __inline
+#endif
+
+#if __STDC_VERSION__ >= 201112L
+#elif defined(__GNUC__)
+#define _Noreturn __attribute__((__noreturn__))
+#else
+#define _Noreturn
+#endif
+
+#define __REDIR(x,y) __typeof__(x) x __asm__(#y)
+
+#endif

--- a/libsqlite3-sys/wasm-include/math.h
+++ b/libsqlite3-sys/wasm-include/math.h
@@ -1,0 +1,459 @@
+#ifndef _MATH_H
+#define _MATH_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <features.h>
+
+#define __NEED_float_t
+#define __NEED_double_t
+#include <bits/alltypes.h>
+
+#if 100*__GNUC__+__GNUC_MINOR__ >= 303
+#define NAN       __builtin_nanf("")
+#define INFINITY  __builtin_inff()
+#else
+#define NAN       (0.0f/0.0f)
+#define INFINITY  1e5000f
+#endif
+
+#define HUGE_VALF INFINITY
+#define HUGE_VAL  ((double)INFINITY)
+#define HUGE_VALL ((long double)INFINITY)
+
+#define MATH_ERRNO  1
+#define MATH_ERREXCEPT 2
+#define math_errhandling 2
+
+#define FP_ILOGBNAN (-1-0x7fffffff)
+#define FP_ILOGB0 FP_ILOGBNAN
+
+#define FP_NAN       0
+#define FP_INFINITE  1
+#define FP_ZERO      2
+#define FP_SUBNORMAL 3
+#define FP_NORMAL    4
+
+#ifdef __FP_FAST_FMA
+#define FP_FAST_FMA 1
+#endif
+
+#ifdef __FP_FAST_FMAF
+#define FP_FAST_FMAF 1
+#endif
+
+#ifdef __FP_FAST_FMAL
+#define FP_FAST_FMAL 1
+#endif
+
+#ifdef __wasilibc_unmodified_upstream /* Use the compiler's definition of the fpclassify-like operations */
+int __fpclassify(double);
+int __fpclassifyf(float);
+int __fpclassifyl(long double);
+
+static __inline unsigned __FLOAT_BITS(float __f)
+{
+	union {float __f; unsigned __i;} __u;
+	__u.__f = __f;
+	return __u.__i;
+}
+static __inline unsigned long long __DOUBLE_BITS(double __f)
+{
+	union {double __f; unsigned long long __i;} __u;
+	__u.__f = __f;
+	return __u.__i;
+}
+
+#define fpclassify(x) ( \
+	sizeof(x) == sizeof(float) ? __fpclassifyf(x) : \
+	sizeof(x) == sizeof(double) ? __fpclassify(x) : \
+	__fpclassifyl(x) )
+
+#define isinf(x) ( \
+	sizeof(x) == sizeof(float) ? (__FLOAT_BITS(x) & 0x7fffffff) == 0x7f800000 : \
+	sizeof(x) == sizeof(double) ? (__DOUBLE_BITS(x) & -1ULL>>1) == 0x7ffULL<<52 : \
+	__fpclassifyl(x) == FP_INFINITE)
+
+#define isnan(x) ( \
+	sizeof(x) == sizeof(float) ? (__FLOAT_BITS(x) & 0x7fffffff) > 0x7f800000 : \
+	sizeof(x) == sizeof(double) ? (__DOUBLE_BITS(x) & -1ULL>>1) > 0x7ffULL<<52 : \
+	__fpclassifyl(x) == FP_NAN)
+
+#define isnormal(x) ( \
+	sizeof(x) == sizeof(float) ? ((__FLOAT_BITS(x)+0x00800000) & 0x7fffffff) >= 0x01000000 : \
+	sizeof(x) == sizeof(double) ? ((__DOUBLE_BITS(x)+(1ULL<<52)) & -1ULL>>1) >= 1ULL<<53 : \
+	__fpclassifyl(x) == FP_NORMAL)
+
+#define isfinite(x) ( \
+	sizeof(x) == sizeof(float) ? (__FLOAT_BITS(x) & 0x7fffffff) < 0x7f800000 : \
+	sizeof(x) == sizeof(double) ? (__DOUBLE_BITS(x) & -1ULL>>1) < 0x7ffULL<<52 : \
+	__fpclassifyl(x) > FP_INFINITE)
+
+int __signbit(double);
+int __signbitf(float);
+int __signbitl(long double);
+
+#define signbit(x) ( \
+	sizeof(x) == sizeof(float) ? (int)(__FLOAT_BITS(x)>>31) : \
+	sizeof(x) == sizeof(double) ? (int)(__DOUBLE_BITS(x)>>63) : \
+	__signbitl(x) )
+
+#define isunordered(x,y) (isnan((x)) ? ((void)(y),1) : isnan((y)))
+
+#define __ISREL_DEF(rel, op, type) \
+static __inline int __is##rel(type __x, type __y) \
+{ return !isunordered(__x,__y) && __x op __y; }
+
+__ISREL_DEF(lessf, <, float_t)
+__ISREL_DEF(less, <, double_t)
+__ISREL_DEF(lessl, <, long double)
+__ISREL_DEF(lessequalf, <=, float_t)
+__ISREL_DEF(lessequal, <=, double_t)
+__ISREL_DEF(lessequall, <=, long double)
+__ISREL_DEF(lessgreaterf, !=, float_t)
+__ISREL_DEF(lessgreater, !=, double_t)
+__ISREL_DEF(lessgreaterl, !=, long double)
+__ISREL_DEF(greaterf, >, float_t)
+__ISREL_DEF(greater, >, double_t)
+__ISREL_DEF(greaterl, >, long double)
+__ISREL_DEF(greaterequalf, >=, float_t)
+__ISREL_DEF(greaterequal, >=, double_t)
+__ISREL_DEF(greaterequall, >=, long double)
+
+#define __tg_pred_2(x, y, p) ( \
+	sizeof((x)+(y)) == sizeof(float) ? p##f(x, y) : \
+	sizeof((x)+(y)) == sizeof(double) ? p(x, y) : \
+	p##l(x, y) )
+
+#define isless(x, y)            __tg_pred_2(x, y, __isless)
+#define islessequal(x, y)       __tg_pred_2(x, y, __islessequal)
+#define islessgreater(x, y)     __tg_pred_2(x, y, __islessgreater)
+#define isgreater(x, y)         __tg_pred_2(x, y, __isgreater)
+#define isgreaterequal(x, y)    __tg_pred_2(x, y, __isgreaterequal)
+#else
+#define fpclassify(x)        (__builtin_fpclassify(FP_NAN, FP_INFINITE, \
+                                                   FP_NORMAL, FP_SUBNORMAL, \
+                                                   FP_ZERO, x))
+#define isinf(x)             (__builtin_isinf(x))
+#define isnan(x)             (__builtin_isnan(x))
+#define isnormal(x)          (__builtin_isnormal(x))
+#define isfinite(x)          (__builtin_isfinite(x))
+#define signbit(x)           (__builtin_signbit(x))
+#define isunordered(x, y)    (__builtin_isunordered(x, y))
+#define isless(x, y)         (__builtin_isless(x, y))
+#define islessequal(x, y)    (__builtin_islessequal(x, y))
+#define islessgreater(x, y)  (__builtin_islessgreater(x, y))
+#define isgreater(x, y)      (__builtin_isgreater(x, y))
+#define isgreaterequal(x, y) (__builtin_isgreaterequal(x, y))
+#endif
+
+double      acos(double);
+float       acosf(float);
+long double acosl(long double);
+
+double      acosh(double);
+float       acoshf(float);
+long double acoshl(long double);
+
+double      asin(double);
+float       asinf(float);
+long double asinl(long double);
+
+double      asinh(double);
+float       asinhf(float);
+long double asinhl(long double);
+
+double      atan(double);
+float       atanf(float);
+long double atanl(long double);
+
+double      atan2(double, double);
+float       atan2f(float, float);
+long double atan2l(long double, long double);
+
+double      atanh(double);
+float       atanhf(float);
+long double atanhl(long double);
+
+double      cbrt(double);
+float       cbrtf(float);
+long double cbrtl(long double);
+
+double      ceil(double);
+float       ceilf(float);
+long double ceill(long double);
+
+double      copysign(double, double);
+float       copysignf(float, float);
+long double copysignl(long double, long double);
+
+double      cos(double);
+float       cosf(float);
+long double cosl(long double);
+
+double      cosh(double);
+float       coshf(float);
+long double coshl(long double);
+
+double      erf(double);
+float       erff(float);
+long double erfl(long double);
+
+double      erfc(double);
+float       erfcf(float);
+long double erfcl(long double);
+
+double      exp(double);
+float       expf(float);
+long double expl(long double);
+
+double      exp2(double);
+float       exp2f(float);
+long double exp2l(long double);
+
+double      expm1(double);
+float       expm1f(float);
+long double expm1l(long double);
+
+double      fabs(double);
+float       fabsf(float);
+long double fabsl(long double);
+
+double      fdim(double, double);
+float       fdimf(float, float);
+long double fdiml(long double, long double);
+
+double      floor(double);
+float       floorf(float);
+long double floorl(long double);
+
+double      fma(double, double, double);
+float       fmaf(float, float, float);
+long double fmal(long double, long double, long double);
+
+double      fmax(double, double);
+float       fmaxf(float, float);
+long double fmaxl(long double, long double);
+
+double      fmin(double, double);
+float       fminf(float, float);
+long double fminl(long double, long double);
+
+double      fmod(double, double);
+float       fmodf(float, float);
+long double fmodl(long double, long double);
+
+double      frexp(double, int *);
+float       frexpf(float, int *);
+long double frexpl(long double, int *);
+
+double      hypot(double, double);
+float       hypotf(float, float);
+long double hypotl(long double, long double);
+
+int         ilogb(double);
+int         ilogbf(float);
+int         ilogbl(long double);
+
+double      ldexp(double, int);
+float       ldexpf(float, int);
+long double ldexpl(long double, int);
+
+double      lgamma(double);
+float       lgammaf(float);
+long double lgammal(long double);
+
+long long   llrint(double);
+long long   llrintf(float);
+long long   llrintl(long double);
+
+long long   llround(double);
+long long   llroundf(float);
+long long   llroundl(long double);
+
+double      log(double);
+float       logf(float);
+long double logl(long double);
+
+double      log10(double);
+float       log10f(float);
+long double log10l(long double);
+
+double      log1p(double);
+float       log1pf(float);
+long double log1pl(long double);
+
+double      log2(double);
+float       log2f(float);
+long double log2l(long double);
+
+double      logb(double);
+float       logbf(float);
+long double logbl(long double);
+
+long        lrint(double);
+long        lrintf(float);
+long        lrintl(long double);
+
+long        lround(double);
+long        lroundf(float);
+long        lroundl(long double);
+
+double      modf(double, double *);
+float       modff(float, float *);
+long double modfl(long double, long double *);
+
+double      nan(const char *);
+float       nanf(const char *);
+long double nanl(const char *);
+
+double      nearbyint(double);
+float       nearbyintf(float);
+long double nearbyintl(long double);
+
+double      nextafter(double, double);
+float       nextafterf(float, float);
+long double nextafterl(long double, long double);
+
+double      nexttoward(double, long double);
+float       nexttowardf(float, long double);
+long double nexttowardl(long double, long double);
+
+double      pow(double, double);
+float       powf(float, float);
+long double powl(long double, long double);
+
+double      remainder(double, double);
+float       remainderf(float, float);
+long double remainderl(long double, long double);
+
+double      remquo(double, double, int *);
+float       remquof(float, float, int *);
+long double remquol(long double, long double, int *);
+
+double      rint(double);
+float       rintf(float);
+long double rintl(long double);
+
+double      round(double);
+float       roundf(float);
+long double roundl(long double);
+
+double      scalbln(double, long);
+float       scalblnf(float, long);
+long double scalblnl(long double, long);
+
+double      scalbn(double, int);
+float       scalbnf(float, int);
+long double scalbnl(long double, int);
+
+double      sin(double);
+float       sinf(float);
+long double sinl(long double);
+
+double      sinh(double);
+float       sinhf(float);
+long double sinhl(long double);
+
+double      sqrt(double);
+float       sqrtf(float);
+long double sqrtl(long double);
+
+double      tan(double);
+float       tanf(float);
+long double tanl(long double);
+
+double      tanh(double);
+float       tanhf(float);
+long double tanhl(long double);
+
+double      tgamma(double);
+float       tgammaf(float);
+long double tgammal(long double);
+
+double      trunc(double);
+float       truncf(float);
+long double truncl(long double);
+
+
+#if defined(_XOPEN_SOURCE) || defined(_BSD_SOURCE)
+#undef  MAXFLOAT
+#define MAXFLOAT        3.40282346638528859812e+38F
+#endif
+
+#if defined(_XOPEN_SOURCE) || defined(_GNU_SOURCE) || defined(_BSD_SOURCE)
+#define M_E             2.7182818284590452354   /* e */
+#define M_LOG2E         1.4426950408889634074   /* log_2 e */
+#define M_LOG10E        0.43429448190325182765  /* log_10 e */
+#define M_LN2           0.69314718055994530942  /* log_e 2 */
+#define M_LN10          2.30258509299404568402  /* log_e 10 */
+#define M_PI            3.14159265358979323846  /* pi */
+#define M_PI_2          1.57079632679489661923  /* pi/2 */
+#define M_PI_4          0.78539816339744830962  /* pi/4 */
+#define M_1_PI          0.31830988618379067154  /* 1/pi */
+#define M_2_PI          0.63661977236758134308  /* 2/pi */
+#define M_2_SQRTPI      1.12837916709551257390  /* 2/sqrt(pi) */
+#define M_SQRT2         1.41421356237309504880  /* sqrt(2) */
+#define M_SQRT1_2       0.70710678118654752440  /* 1/sqrt(2) */
+
+extern int signgam;
+
+double      j0(double);
+double      j1(double);
+double      jn(int, double);
+
+double      y0(double);
+double      y1(double);
+double      yn(int, double);
+#endif
+
+#if defined(_GNU_SOURCE) || defined(_BSD_SOURCE)
+#define HUGE            3.40282346638528859812e+38F
+
+double      drem(double, double);
+float       dremf(float, float);
+
+int         finite(double);
+int         finitef(float);
+
+double      scalb(double, double);
+float       scalbf(float, float);
+
+double      significand(double);
+float       significandf(float);
+
+double      lgamma_r(double, int*);
+float       lgammaf_r(float, int*);
+
+float       j0f(float);
+float       j1f(float);
+float       jnf(int, float);
+
+float       y0f(float);
+float       y1f(float);
+float       ynf(int, float);
+#endif
+
+#ifdef _GNU_SOURCE
+long double lgammal_r(long double, int*);
+
+void        sincos(double, double*, double*);
+void        sincosf(float, float*, float*);
+void        sincosl(long double, long double*, long double*);
+
+double      exp10(double);
+float       exp10f(float);
+long double exp10l(long double);
+
+double      pow10(double);
+float       pow10f(float);
+long double pow10l(long double);
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/libsqlite3-sys/wasm-include/stdio.h
+++ b/libsqlite3-sys/wasm-include/stdio.h
@@ -1,0 +1,252 @@
+#ifndef _STDIO_H
+#define _STDIO_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <features.h>
+
+#define __NEED_FILE
+#define __NEED___isoc_va_list
+#define __NEED_size_t
+
+#ifdef __wasilibc_unmodified_upstream /* WASI doesn't need to define FILE as a complete type */
+#if __STDC_VERSION__ < 201112L
+#define __NEED_struct__IO_FILE
+#endif
+#endif
+
+#if defined(_POSIX_SOURCE) || defined(_POSIX_C_SOURCE) \
+ || defined(_XOPEN_SOURCE) || defined(_GNU_SOURCE) \
+ || defined(_BSD_SOURCE)
+#define __NEED_ssize_t
+#define __NEED_off_t
+#define __NEED_va_list
+#endif
+
+#include <bits/alltypes.h>
+
+#ifdef __wasilibc_unmodified_upstream /* Use the compiler's definition of NULL */
+#ifdef __cplusplus
+#define NULL 0L
+#else
+#define NULL ((void*)0)
+#endif
+#else
+#define __need_NULL
+#include <stddef.h>
+#endif
+
+#undef EOF
+#define EOF (-1)
+
+/* #ifdef __wasilibc_unmodified_upstream /\* Use alternate WASI libc headers *\/ */
+/* #undef SEEK_SET */
+/* #undef SEEK_CUR */
+/* #undef SEEK_END */
+/* #define SEEK_SET 0 */
+/* #define SEEK_CUR 1 */
+/* #define SEEK_END 2 */
+/* #else */
+/* #include <__seek.h> */
+/* #endif */
+
+#define _IOFBF 0
+#define _IOLBF 1
+#define _IONBF 2
+
+#define BUFSIZ 1024
+#define FILENAME_MAX 4096
+#define FOPEN_MAX 1000
+#ifdef __wasilibc_unmodified_upstream /* WASI has no temp directories */
+#define TMP_MAX 10000
+#define L_tmpnam 20
+#endif
+
+typedef union _G_fpos64_t {
+	char __opaque[16];
+	long long __lldata;
+	double __align;
+} fpos_t;
+
+extern FILE *const stdin;
+extern FILE *const stdout;
+extern FILE *const stderr;
+
+#define stdin  (stdin)
+#define stdout (stdout)
+#define stderr (stderr)
+
+FILE *fopen(const char *__restrict, const char *__restrict);
+FILE *freopen(const char *__restrict, const char *__restrict, FILE *__restrict);
+int fclose(FILE *);
+
+int remove(const char *);
+int rename(const char *, const char *);
+
+int feof(FILE *);
+int ferror(FILE *);
+int fflush(FILE *);
+void clearerr(FILE *);
+
+int fseek(FILE *, long, int);
+long ftell(FILE *);
+void rewind(FILE *);
+
+int fgetpos(FILE *__restrict, fpos_t *__restrict);
+int fsetpos(FILE *, const fpos_t *);
+
+size_t fread(void *__restrict, size_t, size_t, FILE *__restrict);
+size_t fwrite(const void *__restrict, size_t, size_t, FILE *__restrict);
+
+int fgetc(FILE *);
+int getc(FILE *);
+int getchar(void);
+int ungetc(int, FILE *);
+
+int fputc(int, FILE *);
+int putc(int, FILE *);
+int putchar(int);
+
+char *fgets(char *__restrict, int, FILE *__restrict);
+#if __STDC_VERSION__ < 201112L
+#ifdef __wasilibc_unmodified_upstream /* gets is obsolete */
+char *gets(char *);
+#else
+char *gets(char *) __attribute__((__deprecated__("gets is not defined on WASI")));
+#endif
+#endif
+
+int fputs(const char *__restrict, FILE *__restrict);
+int puts(const char *);
+
+int printf(const char *__restrict, ...);
+int fprintf(FILE *__restrict, const char *__restrict, ...);
+int sprintf(char *__restrict, const char *__restrict, ...);
+int snprintf(char *__restrict, size_t, const char *__restrict, ...);
+
+int vprintf(const char *__restrict, __isoc_va_list);
+int vfprintf(FILE *__restrict, const char *__restrict, __isoc_va_list);
+int vsprintf(char *__restrict, const char *__restrict, __isoc_va_list);
+int vsnprintf(char *__restrict, size_t, const char *__restrict, __isoc_va_list);
+
+int scanf(const char *__restrict, ...);
+int fscanf(FILE *__restrict, const char *__restrict, ...);
+int sscanf(const char *__restrict, const char *__restrict, ...);
+int vscanf(const char *__restrict, __isoc_va_list);
+int vfscanf(FILE *__restrict, const char *__restrict, __isoc_va_list);
+int vsscanf(const char *__restrict, const char *__restrict, __isoc_va_list);
+
+void perror(const char *);
+
+int setvbuf(FILE *__restrict, char *__restrict, int, size_t);
+void setbuf(FILE *__restrict, char *__restrict);
+
+#ifdef __wasilibc_unmodified_upstream /* WASI has no temp directories */
+char *tmpnam(char *);
+FILE *tmpfile(void);
+#else
+char *tmpnam(char *) __attribute__((__deprecated__("tmpnam is not defined on WASI")));
+FILE *tmpfile(void) __attribute__((__deprecated__("tmpfile is not defined on WASI")));
+#endif
+
+#if defined(_POSIX_SOURCE) || defined(_POSIX_C_SOURCE) \
+ || defined(_XOPEN_SOURCE) || defined(_GNU_SOURCE) \
+ || defined(_BSD_SOURCE)
+FILE *fmemopen(void *__restrict, size_t, const char *__restrict);
+FILE *open_memstream(char **, size_t *);
+FILE *fdopen(int, const char *);
+#ifdef __wasilibc_unmodified_upstream /* WASI has no popen */
+FILE *popen(const char *, const char *);
+int pclose(FILE *);
+#endif
+int fileno(FILE *);
+int fseeko(FILE *, off_t, int);
+off_t ftello(FILE *);
+int dprintf(int, const char *__restrict, ...);
+int vdprintf(int, const char *__restrict, __isoc_va_list);
+#if defined(__wasilibc_unmodified_upstream) || defined(_REENTRANT)
+void flockfile(FILE *);
+int ftrylockfile(FILE *);
+void funlockfile(FILE *);
+#endif
+int getc_unlocked(FILE *);
+int getchar_unlocked(void);
+int putc_unlocked(int, FILE *);
+int putchar_unlocked(int);
+ssize_t getdelim(char **__restrict, size_t *__restrict, int, FILE *__restrict);
+ssize_t getline(char **__restrict, size_t *__restrict, FILE *__restrict);
+int renameat(int, const char *, int, const char *);
+char *ctermid(char *);
+#define L_ctermid 20
+#endif
+
+
+#ifdef __wasilibc_unmodified_upstream /* WASI has no temp directories */
+#if defined(_XOPEN_SOURCE) || defined(_GNU_SOURCE) \
+ || defined(_BSD_SOURCE)
+#define P_tmpdir "/tmp"
+char *tempnam(const char *, const char *);
+#endif
+#endif
+
+#if defined(_GNU_SOURCE) || defined(_BSD_SOURCE)
+#define L_cuserid 20
+char *cuserid(char *);
+void setlinebuf(FILE *);
+void setbuffer(FILE *, char *, size_t);
+int fgetc_unlocked(FILE *);
+int fputc_unlocked(int, FILE *);
+int fflush_unlocked(FILE *);
+size_t fread_unlocked(void *, size_t, size_t, FILE *);
+size_t fwrite_unlocked(const void *, size_t, size_t, FILE *);
+void clearerr_unlocked(FILE *);
+int feof_unlocked(FILE *);
+int ferror_unlocked(FILE *);
+int fileno_unlocked(FILE *);
+int getw(FILE *);
+int putw(int, FILE *);
+char *fgetln(FILE *, size_t *);
+int asprintf(char **, const char *, ...);
+int vasprintf(char **, const char *, __isoc_va_list);
+#endif
+
+#ifdef _GNU_SOURCE
+char *fgets_unlocked(char *, int, FILE *);
+int fputs_unlocked(const char *, FILE *);
+
+typedef ssize_t (cookie_read_function_t)(void *, char *, size_t);
+typedef ssize_t (cookie_write_function_t)(void *, const char *, size_t);
+typedef int (cookie_seek_function_t)(void *, off_t *, int);
+typedef int (cookie_close_function_t)(void *);
+
+typedef struct _IO_cookie_io_functions_t {
+	cookie_read_function_t *read;
+	cookie_write_function_t *write;
+	cookie_seek_function_t *seek;
+	cookie_close_function_t *close;
+} cookie_io_functions_t;
+
+FILE *fopencookie(void *, const char *, cookie_io_functions_t);
+#endif
+
+#if defined(_LARGEFILE64_SOURCE) || defined(_GNU_SOURCE)
+#ifdef __wasilibc_unmodified_upstream /* WASI has no temp directories */
+#define tmpfile64 tmpfile
+#endif
+#define fopen64 fopen
+#define freopen64 freopen
+#define fseeko64 fseeko
+#define ftello64 ftello
+#define fgetpos64 fgetpos
+#define fsetpos64 fsetpos
+#define fpos64_t fpos_t
+#define off64_t off_t
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/libsqlite3-sys/wasm-include/stdlib.h
+++ b/libsqlite3-sys/wasm-include/stdlib.h
@@ -1,0 +1,215 @@
+#ifndef _STDLIB_H
+#define _STDLIB_H
+
+#ifdef __wasilibc_unmodified_upstream /* Use alternate WASI libc headers */
+#else
+#include <__functions_malloc.h>
+#include <__header_stdlib.h>
+#endif
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <features.h>
+
+#ifdef __wasilibc_unmodified_upstream /* Use the compiler's definition of NULL */
+#ifdef __cplusplus
+#define NULL 0L
+#else
+#define NULL ((void*)0)
+#endif
+#else
+#define __need_NULL
+#include <stddef.h>
+#endif
+
+#define __NEED_size_t
+#define __NEED_wchar_t
+
+#include <bits/alltypes.h>
+
+int atoi (const char *);
+long atol (const char *);
+long long atoll (const char *);
+double atof (const char *);
+
+float strtof (const char *__restrict, char **__restrict);
+double strtod (const char *__restrict, char **__restrict);
+long double strtold (const char *__restrict, char **__restrict);
+
+long strtol (const char *__restrict, char **__restrict, int);
+unsigned long strtoul (const char *__restrict, char **__restrict, int);
+long long strtoll (const char *__restrict, char **__restrict, int);
+unsigned long long strtoull (const char *__restrict, char **__restrict, int);
+
+int rand (void);
+void srand (unsigned);
+
+#ifdef __wasilibc_unmodified_upstream /* Use alternate WASI libc headers */
+void *malloc (size_t);
+void *calloc (size_t, size_t);
+void *realloc (void *, size_t);
+void free (void *);
+#endif
+void *aligned_alloc(size_t, size_t);
+
+_Noreturn void abort (void);
+int atexit (void (*) (void));
+_Noreturn void exit (int);
+_Noreturn void _Exit (int);
+int at_quick_exit (void (*) (void));
+_Noreturn void quick_exit (int);
+
+char *getenv (const char *);
+
+int system (const char *);
+
+void *bsearch (const void *, const void *, size_t, size_t, int (*)(const void *, const void *));
+void qsort (void *, size_t, size_t, int (*)(const void *, const void *));
+
+int abs (int);
+long labs (long);
+long long llabs (long long);
+
+typedef struct { int quot, rem; } div_t;
+typedef struct { long quot, rem; } ldiv_t;
+typedef struct { long long quot, rem; } lldiv_t;
+
+div_t div (int, int);
+ldiv_t ldiv (long, long);
+lldiv_t lldiv (long long, long long);
+
+int mblen (const char *, size_t);
+int mbtowc (wchar_t *__restrict, const char *__restrict, size_t);
+int wctomb (char *, wchar_t);
+size_t mbstowcs (wchar_t *__restrict, const char *__restrict, size_t);
+size_t wcstombs (char *__restrict, const wchar_t *__restrict, size_t);
+
+#define EXIT_FAILURE 1
+#define EXIT_SUCCESS 0
+
+size_t __ctype_get_mb_cur_max(void);
+#define MB_CUR_MAX (__ctype_get_mb_cur_max())
+
+#define RAND_MAX (0x7fffffff)
+
+
+#if defined(_POSIX_SOURCE) || defined(_POSIX_C_SOURCE) \
+ || defined(_XOPEN_SOURCE) || defined(_GNU_SOURCE) \
+ || defined(_BSD_SOURCE)
+
+#ifdef __wasilibc_unmodified_upstream /* WASI has no wait */
+#define WNOHANG    1
+#define WUNTRACED  2
+
+#define WEXITSTATUS(s) (((s) & 0xff00) >> 8)
+#define WTERMSIG(s) ((s) & 0x7f)
+#define WSTOPSIG(s) WEXITSTATUS(s)
+#define WIFEXITED(s) (!WTERMSIG(s))
+#define WIFSTOPPED(s) ((short)((((s)&0xffff)*0x10001)>>8) > 0x7f00)
+#define WIFSIGNALED(s) (((s)&0xffff)-1U < 0xffu)
+#endif
+
+int posix_memalign (void **, size_t, size_t);
+int setenv (const char *, const char *, int);
+int unsetenv (const char *);
+#ifdef __wasilibc_unmodified_upstream /* WASI has no temp directories */
+int mkstemp (char *);
+int mkostemp (char *, int);
+char *mkdtemp (char *);
+#endif
+int getsubopt (char **, char *const *, char **);
+int rand_r (unsigned *);
+
+#endif
+
+
+#if defined(_XOPEN_SOURCE) || defined(_GNU_SOURCE) \
+ || defined(_BSD_SOURCE)
+#ifdef __wasilibc_unmodified_upstream /* WASI has no absolute paths */
+char *realpath (const char *__restrict, char *__restrict);
+#endif
+long int random (void);
+void srandom (unsigned int);
+char *initstate (unsigned int, char *, size_t);
+char *setstate (char *);
+int putenv (char *);
+#ifdef __wasilibc_unmodified_upstream /* WASI has no pseudo-terminals */
+int posix_openpt (int);
+int grantpt (int);
+int unlockpt (int);
+char *ptsname (int);
+#endif
+char *l64a (long);
+long a64l (const char *);
+void setkey (const char *);
+double drand48 (void);
+double erand48 (unsigned short [3]);
+long int lrand48 (void);
+long int nrand48 (unsigned short [3]);
+long mrand48 (void);
+long jrand48 (unsigned short [3]);
+void srand48 (long);
+unsigned short *seed48 (unsigned short [3]);
+void lcong48 (unsigned short [7]);
+#endif
+
+#if defined(_GNU_SOURCE) || defined(_BSD_SOURCE)
+#include <alloca.h>
+#ifdef __wasilibc_unmodified_upstream /* WASI has no temp directories */
+char *mktemp (char *);
+int mkstemps (char *, int);
+int mkostemps (char *, int, int);
+#endif
+#ifdef __wasilibc_unmodified_upstream /* WASI libc doesn't build the legacy functions */
+void *valloc (size_t);
+void *memalign(size_t, size_t);
+int getloadavg(double *, int);
+#endif
+int clearenv(void);
+#ifdef __wasilibc_unmodified_upstream /* WASI has no wait */
+#define WCOREDUMP(s) ((s) & 0x80)
+#define WIFCONTINUED(s) ((s) == 0xffff)
+#endif
+#endif
+
+#ifdef _GNU_SOURCE
+#ifdef __wasilibc_unmodified_upstream /* WASI has no pseudo-terminals */
+int ptsname_r(int, char *, size_t);
+#endif
+char *ecvt(double, int, int *, int *);
+char *fcvt(double, int, int *, int *);
+char *gcvt(double, int, char *);
+char *secure_getenv(const char *);
+struct __locale_struct;
+float strtof_l(const char *__restrict, char **__restrict, struct __locale_struct *);
+double strtod_l(const char *__restrict, char **__restrict, struct __locale_struct *);
+long double strtold_l(const char *__restrict, char **__restrict, struct __locale_struct *);
+#endif
+
+#ifdef __wasilibc_unmodified_upstream /* WASI has no temp directories */
+#if defined(_LARGEFILE64_SOURCE) || defined(_GNU_SOURCE)
+#define mkstemp64 mkstemp
+#define mkostemp64 mkostemp
+#if defined(_GNU_SOURCE) || defined(_BSD_SOURCE)
+#define mkstemps64 mkstemps
+#define mkostemps64 mkostemps
+#endif
+#endif
+#endif
+
+#ifdef __wasilibc_unmodified_upstream /* Declare arc4random functions */
+#else
+#if defined(_GNU_SOURCE) || defined(_BSD_SOURCE)
+#include <stdint.h>
+uint32_t arc4random(void);
+void arc4random_buf(void *, size_t);
+uint32_t arc4random_uniform(uint32_t);
+#endif
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/libsqlite3-sys/wasm-include/string.h
+++ b/libsqlite3-sys/wasm-include/string.h
@@ -1,0 +1,126 @@
+#ifndef	_STRING_H
+#define	_STRING_H
+
+/* #ifdef __wasilibc_unmodified_upstream /\* Use alternate WASI libc headers *\/ */
+/* #else */
+/* #include <__header_string.h> */
+/* #endif */
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <features.h>
+
+#ifdef __wasilibc_unmodified_upstream /* Use the compiler's definition of NULL */
+#ifdef __cplusplus
+#define NULL 0L
+#else
+#define NULL ((void*)0)
+#endif
+#else
+#define __need_NULL
+#include <stddef.h>
+#endif
+
+#define __NEED_size_t
+#if defined(_POSIX_SOURCE) || defined(_POSIX_C_SOURCE) \
+ || defined(_XOPEN_SOURCE) || defined(_GNU_SOURCE) \
+ || defined(_BSD_SOURCE)
+#define __NEED_locale_t
+#endif
+
+#include <bits/alltypes.h>
+
+#ifdef __wasilibc_unmodified_upstream /* Use alternate WASI libc headers */
+void *memcpy (void *__restrict, const void *__restrict, size_t);
+void *memmove (void *, const void *, size_t);
+void *memset (void *, int, size_t);
+#endif
+int memcmp (const void *, const void *, size_t);
+#ifdef __wasilibc_unmodified_upstream /* Use alternate WASI libc headers */
+void *memchr (const void *, int, size_t);
+#endif
+
+char *strcpy (char *__restrict, const char *__restrict);
+char *strncpy (char *__restrict, const char *__restrict, size_t);
+
+char *strcat (char *__restrict, const char *__restrict);
+char *strncat (char *__restrict, const char *__restrict, size_t);
+
+#ifdef __wasilibc_unmodified_upstream /* Use alternate WASI libc headers */
+int strcmp (const char *, const char *);
+#endif
+int strncmp (const char *, const char *, size_t);
+
+int strcoll (const char *, const char *);
+size_t strxfrm (char *__restrict, const char *__restrict, size_t);
+
+char *strchr (const char *, int);
+char *strrchr (const char *, int);
+
+size_t strcspn (const char *, const char *);
+size_t strspn (const char *, const char *);
+char *strpbrk (const char *, const char *);
+char *strstr (const char *, const char *);
+char *strtok (char *__restrict, const char *__restrict);
+
+#ifdef __wasilibc_unmodified_upstream /* Use alternate WASI libc headers */
+size_t strlen (const char *);
+#endif
+
+char *strerror (int);
+
+#if defined(_BSD_SOURCE) || defined(_GNU_SOURCE)
+#include <strings.h>
+#endif
+
+#if defined(_POSIX_SOURCE) || defined(_POSIX_C_SOURCE) \
+ || defined(_XOPEN_SOURCE) || defined(_GNU_SOURCE) \
+ || defined(_BSD_SOURCE)
+char *strtok_r (char *__restrict, const char *__restrict, char **__restrict);
+int strerror_r (int, char *, size_t);
+char *stpcpy(char *__restrict, const char *__restrict);
+char *stpncpy(char *__restrict, const char *__restrict, size_t);
+size_t strnlen (const char *, size_t);
+#ifdef __wasilibc_unmodified_upstream /* Use alternate WASI libc headers */
+char *strdup (const char *);
+#endif
+char *strndup (const char *, size_t);
+char *strsignal(int);
+char *strerror_l (int, locale_t);
+int strcoll_l (const char *, const char *, locale_t);
+size_t strxfrm_l (char *__restrict, const char *__restrict, size_t, locale_t);
+#endif
+
+#if defined(_XOPEN_SOURCE) || defined(_GNU_SOURCE) \
+ || defined(_BSD_SOURCE)
+void *memccpy (void *__restrict, const void *__restrict, int, size_t);
+#endif
+
+#if defined(_GNU_SOURCE) || defined(_BSD_SOURCE)
+char *strsep(char **, const char *);
+size_t strlcat (char *, const char *, size_t);
+size_t strlcpy (char *, const char *, size_t);
+void explicit_bzero (void *, size_t);
+#endif
+
+#ifdef _GNU_SOURCE
+#define	strdupa(x)	strcpy(alloca(strlen(x)+1),x)
+int strverscmp (const char *, const char *);
+char *strchrnul(const char *, int);
+char *strcasestr(const char *, const char *);
+void *memmem(const void *, size_t, const void *, size_t);
+void *memrchr(const void *, int, size_t);
+void *mempcpy(void *, const void *, size_t);
+#ifdef __wasilibc_unmodified_upstream /* avoid unprototyped decls; use <libgen.h> */
+#ifndef __cplusplus
+char *basename();
+#endif
+#endif
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/libsqlite3-sys/wasm-include/strings.h
+++ b/libsqlite3-sys/wasm-include/strings.h
@@ -1,0 +1,39 @@
+#ifndef	_STRINGS_H
+#define	_STRINGS_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+
+#define __NEED_size_t
+#define __NEED_locale_t
+#include <bits/alltypes.h>
+
+#if defined(_GNU_SOURCE) || defined(_BSD_SOURCE) || defined(_POSIX_SOURCE) \
+ || (defined(_POSIX_C_SOURCE) && _POSIX_C_SOURCE+0 < 200809L) \
+ || (defined(_XOPEN_SOURCE) && _XOPEN_SOURCE+0 < 700)
+int bcmp (const void *, const void *, size_t);
+void bcopy (const void *, void *, size_t);
+void bzero (void *, size_t);
+char *index (const char *, int);
+char *rindex (const char *, int);
+#endif
+
+#if defined(_XOPEN_SOURCE) || defined(_GNU_SOURCE)  || defined(_BSD_SOURCE)
+int ffs (int);
+int ffsl (long);
+int ffsll (long long);
+#endif
+
+int strcasecmp (const char *, const char *);
+int strncasecmp (const char *, const char *, size_t);
+
+int strcasecmp_l (const char *, const char *, locale_t);
+int strncasecmp_l (const char *, const char *, size_t, locale_t);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/libsqlite3-sys/wasm-include/time.h
+++ b/libsqlite3-sys/wasm-include/time.h
@@ -1,0 +1,193 @@
+#ifndef	_TIME_H
+#define _TIME_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <features.h>
+
+#ifdef __wasilibc_unmodified_upstream /* Use the compiler's definition of NULL */
+#ifdef __cplusplus
+#define NULL 0L
+#else
+#define NULL ((void*)0)
+#endif
+#else
+#define __need_NULL
+#include <stddef.h>
+#endif
+
+
+#define __NEED_size_t
+#define __NEED_time_t
+#define __NEED_clock_t
+#define __NEED_struct_timespec
+
+#if defined(_POSIX_SOURCE) || defined(_POSIX_C_SOURCE) \
+ || defined(_XOPEN_SOURCE) || defined(_GNU_SOURCE) \
+ || defined(_BSD_SOURCE)
+#define __NEED_clockid_t
+#define __NEED_timer_t
+#define __NEED_pid_t
+#define __NEED_locale_t
+#endif
+
+#include <bits/alltypes.h>
+
+#if defined(_BSD_SOURCE) || defined(_GNU_SOURCE)
+#define __tm_gmtoff tm_gmtoff
+#define __tm_zone tm_zone
+#endif
+
+#ifdef __wasilibc_unmodified_upstream /* Use alternate WASI libc headers */
+struct tm {
+	int tm_sec;
+	int tm_min;
+	int tm_hour;
+	int tm_mday;
+	int tm_mon;
+	int tm_year;
+	int tm_wday;
+	int tm_yday;
+	int tm_isdst;
+	long __tm_gmtoff;
+	const char *__tm_zone;
+};
+#else
+#include <__header_time.h>
+#endif
+
+clock_t clock (void);
+time_t time (time_t *);
+double difftime (time_t, time_t);
+time_t mktime (struct tm *);
+size_t strftime (char *__restrict, size_t, const char *__restrict, const struct tm *__restrict);
+struct tm *gmtime (const time_t *);
+struct tm *localtime (const time_t *);
+char *asctime (const struct tm *);
+char *ctime (const time_t *);
+int timespec_get(struct timespec *, int);
+
+#ifdef __wasilibc_unmodified_upstream /* Use alternate WASI libc headers */
+#define CLOCKS_PER_SEC 1000000L
+
+#define TIME_UTC 1
+#endif
+
+#if defined(_POSIX_SOURCE) || defined(_POSIX_C_SOURCE) \
+ || defined(_XOPEN_SOURCE) || defined(_GNU_SOURCE) \
+ || defined(_BSD_SOURCE)
+
+size_t strftime_l (char *  __restrict, size_t, const char *  __restrict, const struct tm *  __restrict, locale_t);
+
+struct tm *gmtime_r (const time_t *__restrict, struct tm *__restrict);
+struct tm *localtime_r (const time_t *__restrict, struct tm *__restrict);
+char *asctime_r (const struct tm *__restrict, char *__restrict);
+char *ctime_r (const time_t *, char *);
+
+#ifdef __wasilibc_unmodified_upstream /* WASI has no timezone tables */
+void tzset (void);
+#endif
+
+struct itimerspec {
+	struct timespec it_interval;
+	struct timespec it_value;
+};
+
+#ifdef __wasilibc_unmodified_upstream /* Use alternate WASI libc headers */
+#define CLOCK_REALTIME           0
+#define CLOCK_MONOTONIC          1
+#define CLOCK_PROCESS_CPUTIME_ID 2
+#define CLOCK_THREAD_CPUTIME_ID  3
+#define CLOCK_MONOTONIC_RAW      4
+#define CLOCK_REALTIME_COARSE    5
+#define CLOCK_MONOTONIC_COARSE   6
+#define CLOCK_BOOTTIME           7
+#define CLOCK_REALTIME_ALARM     8
+#define CLOCK_BOOTTIME_ALARM     9
+#define CLOCK_SGI_CYCLE         10
+#define CLOCK_TAI               11
+
+#define TIMER_ABSTIME 1
+#endif
+
+int nanosleep (const struct timespec *, struct timespec *);
+int clock_getres (clockid_t, struct timespec *);
+int clock_gettime (clockid_t, struct timespec *);
+#ifdef __wasilibc_unmodified_upstream /* WASI has no clock_settime */
+int clock_settime (clockid_t, const struct timespec *);
+#endif
+int clock_nanosleep (clockid_t, int, const struct timespec *, struct timespec *);
+#ifdef __wasilibc_unmodified_upstream /* WASI has no clock_getcpuclockid */
+int clock_getcpuclockid (pid_t, clockid_t *);
+#endif
+
+#ifdef __wasilibc_unmodified_upstream /* WASI has no timers */
+struct sigevent;
+int timer_create (clockid_t, struct sigevent *__restrict, timer_t *__restrict);
+int timer_delete (timer_t);
+int timer_settime (timer_t, int, const struct itimerspec *__restrict, struct itimerspec *__restrict);
+int timer_gettime (timer_t, struct itimerspec *);
+int timer_getoverrun (timer_t);
+#endif
+
+#ifdef __wasilibc_unmodified_upstream /* WASI has no timezone tables */
+extern char *tzname[2];
+#endif
+
+#endif
+
+
+#if defined(_XOPEN_SOURCE) || defined(_BSD_SOURCE) || defined(_GNU_SOURCE)
+char *strptime (const char *__restrict, const char *__restrict, struct tm *__restrict);
+#ifdef __wasilibc_unmodified_upstream /* WASI has no timezone tables */
+extern int daylight;
+extern long timezone;
+#endif
+extern int getdate_err;
+struct tm *getdate (const char *);
+#endif
+
+
+#if defined(_GNU_SOURCE) || defined(_BSD_SOURCE)
+#ifdef __wasilibc_unmodified_upstream /* WASI has no stime */
+int stime(const time_t *);
+#endif
+time_t timegm(struct tm *);
+#endif
+
+#if _REDIR_TIME64
+__REDIR(time, __time64);
+__REDIR(difftime, __difftime64);
+__REDIR(mktime, __mktime64);
+__REDIR(gmtime, __gmtime64);
+__REDIR(localtime, __localtime64);
+__REDIR(ctime, __ctime64);
+__REDIR(timespec_get, __timespec_get_time64);
+#if defined(_POSIX_SOURCE) || defined(_POSIX_C_SOURCE) \
+ || defined(_XOPEN_SOURCE) || defined(_GNU_SOURCE) \
+ || defined(_BSD_SOURCE)
+__REDIR(gmtime_r, __gmtime64_r);
+__REDIR(localtime_r, __localtime64_r);
+__REDIR(ctime_r, __ctime64_r);
+__REDIR(nanosleep, __nanosleep_time64);
+__REDIR(clock_getres, __clock_getres_time64);
+__REDIR(clock_gettime, __clock_gettime64);
+__REDIR(clock_settime, __clock_settime64);
+__REDIR(clock_nanosleep, __clock_nanosleep_time64);
+__REDIR(timer_settime, __timer_settime64);
+__REDIR(timer_gettime, __timer_gettime64);
+#endif
+#if defined(_GNU_SOURCE) || defined(_BSD_SOURCE)
+__REDIR(stime, __stime64);
+__REDIR(timegm, __timegm_time64);
+#endif
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+
+
+#endif


### PR DESCRIPTION
# Content:

1. Add a memory virtual file system isolated by filename, different from sqlite3's ':memory:' mode
2. Add the ability to make SQLite link to external memory allocator
3. Reimplement the functions used in libc (such as strcspn, qsort)

With these three features: linking sqlite3 to Rust's memory allocator, using an in-memory virtual file system, linking to a separate implementation of string functions and qsort functions, along with fine-tuned WASI headers, our implementation works under `wasm32-unknown-unknown`

# Remind:
Time zone function temporarily missing