### PR TITLE
Add Statement::parameter_name

### DIFF
--- a/src/raw_statement.rs
+++ b/src/raw_statement.rs
@@ -145,6 +145,18 @@ impl RawStatement {
     }
 
     #[inline]
+    pub fn bind_parameter_name(&self, index: i32) -> Option<&CStr> {
+        unsafe {
+            let name = ffi::sqlite3_bind_parameter_name(self.ptr, index);
+            if name.is_null() {
+                None
+            } else {
+                Some(CStr::from_ptr(name))
+            }
+        }
+    }
+
+    #[inline]
     pub fn clear_bindings(&self) -> c_int {
         unsafe { ffi::sqlite3_clear_bindings(self.ptr) }
     }


### PR DESCRIPTION
This PR does what it says on the tin: it adds the inverse method of `parameter_index`. Although this method isn't used by this library (e.g., for parameter binding), it's useful for external consumers who want to massage a heap of parameters into the right shape for a statement.