### PR TITLE
Add support for authorizer hook

### DIFF
--- a/src/hooks.rs
+++ b/src/hooks.rs
@@ -38,6 +38,8 @@ impl From<i32> for Action {
 }
 
 /// `feature = "hooks"` The context recieved by an authorizer hook.
+///
+/// See <https://sqlite.org/c3ref/set_authorizer.html> for more info.
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct AuthContext<'c> {
     // The action to be authorized.
@@ -51,11 +53,13 @@ pub struct AuthContext<'c> {
     pub accessor: Option<&'c str>,
 }
 
-/// `feature = "hooks"` Actions and arguments
-/// found within a statement during preparation.
+/// `feature = "hooks"` Actions and arguments found within a statement during
+/// preparation.
+///
+/// See <https://sqlite.org/c3ref/c_alter_table.html> for more info.
 #[derive(Clone, Copy, Debug, PartialEq)]
 #[non_exhaustive]
-#[allow(missing_docs)] // This is self-documenting.
+#[allow(missing_docs)]
 pub enum AuthAction<'c> {
     /// This variant is not normally produced by SQLite. You may encounter it
     // if you're using a different version than what's supported by this library.
@@ -147,7 +151,7 @@ pub enum AuthAction<'c> {
         column_name: &'c str,
     },
     Attach {
-        filename: &'c std::path::Path,
+        filename: &'c str,
     },
     Detach {
         database_name: &'c str,
@@ -258,9 +262,7 @@ impl<'c> AuthAction<'c> {
                 table_name,
                 column_name,
             },
-            (ffi::SQLITE_ATTACH, Some(filename_str), _) => Self::Attach {
-                filename: std::path::Path::new(filename_str),
-            },
+            (ffi::SQLITE_ATTACH, Some(filename), _) => Self::Attach { filename },
             (ffi::SQLITE_DETACH, Some(database_name), _) => Self::Detach { database_name },
             (ffi::SQLITE_ALTER_TABLE, Some(database_name), Some(table_name)) => Self::AlterTable {
                 database_name,

--- a/src/inner_connection.rs
+++ b/src/inner_connection.rs
@@ -33,6 +33,8 @@ pub struct InnerConnection {
     pub free_update_hook: Option<unsafe fn(*mut ::std::os::raw::c_void)>,
     #[cfg(feature = "hooks")]
     pub progress_handler: Option<Box<dyn FnMut() -> bool + Send>>,
+    #[cfg(feature = "hooks")]
+    pub authorizer: Option<crate::hooks::BoxedAuthorizer>,
     owned: bool,
 }
 
@@ -51,6 +53,8 @@ impl InnerConnection {
             free_update_hook: None,
             #[cfg(feature = "hooks")]
             progress_handler: None,
+            #[cfg(feature = "hooks")]
+            authorizer: None,
             owned,
         }
     }


### PR DESCRIPTION
This PR adds support for an authorizer hook, which is the best way to get information about what the parser is doing. There shouldn't be any surprises here (except for maybe using a new definition of `Action` and not including docs that can be generated by a macro).