### PR TITLE
Fix build failure on Debian GNU/Linux 10

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -151,3 +151,26 @@ jobs:
 
       - name: Upload to codecov.io
         uses: codecov/codecov-action@v1
+
+  # Checks that the library builds properly when using the MSRV as compiler.
+  msrv:
+    name: Minimum Supported Rust Version
+    runs-on: ubuntu-20.04
+    steps:
+    - uses: actions/checkout@v2
+    - name: Install Rust
+      uses: actions-rs/toolchain@v1
+      with:
+        toolchain: 1.41
+        profile: minimal
+        override: true
+    - name: Rust and Cargo version
+      run: |
+        rustc --version --verbose
+        cargo --version --verbose
+    - name: Basic build
+      run: |
+        cargo build --features bundled
+    - name: Basic tests
+      run: |
+        cargo test --features bundled

--- a/clippy.toml
+++ b/clippy.toml
@@ -1,1 +1,2 @@
 doc-valid-idents = ["SQLite", "lang_transaction"]
+msrv = "1.41.0"

--- a/libsqlite3-sys/build.rs
+++ b/libsqlite3-sys/build.rs
@@ -377,7 +377,10 @@ mod bindings {
     fn generating_bundled_bindings() -> bool {
         // Hacky way to know if we're generating the bundled bindings
         println!("cargo:rerun-if-env-changed=LIBSQLITE3_SYS_BUNDLING");
-        matches!(std::env::var("LIBSQLITE3_SYS_BUNDLING"), Ok(v) if v != "0")
+        match std::env::var("LIBSQLITE3_SYS_BUNDLING") {
+            Ok(v) if v != "0" => true,
+            _ => false,
+        }
     }
 
     pub fn write_to_out_dir(header: HeaderLocation, out_path: &Path) {

--- a/src/inner_connection.rs
+++ b/src/inner_connection.rs
@@ -261,7 +261,8 @@ impl InnerConnection {
         let tail = if c_tail.is_null() {
             0
         } else {
-            let n = unsafe { c_tail.offset_from(c_sql) };
+            // note: feature ptr_offset_from (#41079) only available in Rust 1.47 or later
+            let n = (c_tail as isize) - (c_sql as isize);
             if n <= 0 || n >= len as isize {
                 0
             } else {

--- a/src/types/from_sql.rs
+++ b/src/types/from_sql.rs
@@ -136,7 +136,10 @@ impl FromSql for f64 {
 impl FromSql for bool {
     #[inline]
     fn column_result(value: ValueRef<'_>) -> FromSqlResult<Self> {
-        i64::column_result(value).map(|i| !matches!(i, 0))
+        i64::column_result(value).map(|i| match i {
+            0 => false,
+            _ => true,
+        })
     }
 }
 

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -428,34 +428,40 @@ mod test {
         // Basic non-converting test.
         test_conversion!(db_etc, 0u8, u8, expect 0u8);
 
+        // Constants like u32::MAX are only available in Rust 1.43+.
+        const U32_MAX: u32 = 4294967295;
+        const I64_MIN: i64 = -9223372036854775808;
+        const I64_MAX: i64 = 9223372036854775807;
+        const U64_MAX: u64 = 18446744073709551615;
+
         // In-range integral conversions.
         test_conversion!(db_etc, 100u8, i8, expect 100i8);
         test_conversion!(db_etc, 200u8, u8, expect 200u8);
         test_conversion!(db_etc, 100u16, i8, expect 100i8);
         test_conversion!(db_etc, 200u16, u8, expect 200u8);
-        test_conversion!(db_etc, u32::MAX, u64, expect u32::MAX as u64);
-        test_conversion!(db_etc, i64::MIN, i64, expect i64::MIN);
-        test_conversion!(db_etc, i64::MAX, i64, expect i64::MAX);
-        test_conversion!(db_etc, i64::MAX, u64, expect i64::MAX as u64);
+        test_conversion!(db_etc, U32_MAX, u64, expect U32_MAX as u64);
+        test_conversion!(db_etc, I64_MIN, i64, expect I64_MIN);
+        test_conversion!(db_etc, I64_MAX, i64, expect I64_MAX);
+        test_conversion!(db_etc, I64_MAX, u64, expect I64_MAX as u64);
         test_conversion!(db_etc, 100usize, usize, expect 100usize);
         test_conversion!(db_etc, 100u64, u64, expect 100u64);
-        test_conversion!(db_etc, i64::MAX as u64, u64, expect i64::MAX as u64);
+        test_conversion!(db_etc, I64_MAX as u64, u64, expect I64_MAX as u64);
 
         // Out-of-range integral conversions.
         test_conversion!(db_etc, 200u8, i8, expect_from_sql_error);
         test_conversion!(db_etc, 400u16, i8, expect_from_sql_error);
         test_conversion!(db_etc, 400u16, u8, expect_from_sql_error);
         test_conversion!(db_etc, -1i8, u8, expect_from_sql_error);
-        test_conversion!(db_etc, i64::MIN, u64, expect_from_sql_error);
-        test_conversion!(db_etc, u64::MAX, i64, expect_to_sql_error);
-        test_conversion!(db_etc, u64::MAX, u64, expect_to_sql_error);
-        test_conversion!(db_etc, i64::MAX as u64 + 1, u64, expect_to_sql_error);
+        test_conversion!(db_etc, I64_MIN, u64, expect_from_sql_error);
+        test_conversion!(db_etc, U64_MAX, i64, expect_to_sql_error);
+        test_conversion!(db_etc, U64_MAX, u64, expect_to_sql_error);
+        test_conversion!(db_etc, I64_MAX as u64 + 1, u64, expect_to_sql_error);
 
         // FromSql integer to float, always works.
-        test_conversion!(db_etc, i64::MIN, f32, expect i64::MIN as f32);
-        test_conversion!(db_etc, i64::MAX, f32, expect i64::MAX as f32);
-        test_conversion!(db_etc, i64::MIN, f64, expect i64::MIN as f64);
-        test_conversion!(db_etc, i64::MAX, f64, expect i64::MAX as f64);
+        test_conversion!(db_etc, I64_MIN, f32, expect I64_MIN as f32);
+        test_conversion!(db_etc, I64_MAX, f32, expect I64_MAX as f32);
+        test_conversion!(db_etc, I64_MIN, f64, expect I64_MIN as f64);
+        test_conversion!(db_etc, I64_MAX, f64, expect I64_MAX as f64);
 
         // FromSql float to int conversion, never works even if the actual value
         // is an integer.

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -239,7 +239,10 @@ mod test {
     #[allow(clippy::cognitive_complexity)]
     fn test_mismatched_types() -> Result<()> {
         fn is_invalid_column_type(err: Error) -> bool {
-            matches!(err, Error::InvalidColumnType(..))
+            match err {
+                Error::InvalidColumnType(..) => true,
+                _ => false,
+            }
         }
 
         let db = checked_memory_handle()?;


### PR DESCRIPTION
**Short summary:**
rusqlite 0.25.1 does not build with the default Rust compiler that comes with Debian GNU/Linux 10, but version 0.23.1 did build just fine on that system. This pull request makes some adjustments so that it builds again and Debian users can enjoy the newer version, too.

**Longer explanation:**
[Debian](https://www.debian.org/) is a Linux distribution, and among the top ten most-popular distributions according to [DistroWatch](https://distrowatch.com/table.php?distribution=debian), and a lot of other distributions are based on Debian. Like other Linux distributions it comes with various prepackaged software, and among that software also is the Rust compiler. However, the current stable release of Debian comes with Rust 1.41.1, which is [a bit over a year old](https://blog.rust-lang.org/2020/02/27/Rust-1.41.1.html). Therefore, it does not support some of the newer Rust features from the current stable branch of Rust. The three main "problematic" newer features are:

* the [`matches!` macro](https://doc.rust-lang.org/std/macro.matches.html), introduced in Rust 1.42.0, and
* pointer's offset_from() that uses a library feature that was still unstable until Rust 1.47 was released, and
* `MIN` and `MAX` constants for types like `u32` and `i64`, those have been added in Rust 1.43.0.

The pull request replaces all of them with compatible versions that also work with Rust 1.41. I tried to use the corresponding code snippets that were used in those places in earlier rusqlite versions as replacements where possible, so that the functionality should not be impacted. The tests still pass.

Furthermore, I took the liberty to add a Minimum Supported Rust Version (MSRV) to the configuration file for Clippy, `clippy.toml`, and set it to 1.41.0. That way Clippy does not warn about using the `matches!` macro anymore. I guess that was the reason why someone replaced the match expressions with the macro in the first place. On top of that a new workflow is added to GitHub actions, using that older Rust version, to ensure it builds and tests pass.


_I am aware that these changes may be a bit intrusive,_ so if you decide not to merge these changes, I'm fine with that, too. Because what this pull request also does as a side effect is setting the MSRV of rusqlite to 1.41.0. I was unable to find an explicit statement what rusqlite's current MSRV is, so I am not sure whether this is OK or not.