### PR TITLE
Fix build failure on Debian GNU/Linux 10 (without changes of CI and clippy.toml)

### DIFF
--- a/libsqlite3-sys/build.rs
+++ b/libsqlite3-sys/build.rs
@@ -377,7 +377,10 @@ mod bindings {
     fn generating_bundled_bindings() -> bool {
         // Hacky way to know if we're generating the bundled bindings
         println!("cargo:rerun-if-env-changed=LIBSQLITE3_SYS_BUNDLING");
-        matches!(std::env::var("LIBSQLITE3_SYS_BUNDLING"), Ok(v) if v != "0")
+        match std::env::var("LIBSQLITE3_SYS_BUNDLING") {
+            Ok(v) if v != "0" => true,
+            _ => false,
+        }
     }
 
     pub fn write_to_out_dir(header: HeaderLocation, out_path: &Path) {

--- a/src/inner_connection.rs
+++ b/src/inner_connection.rs
@@ -261,7 +261,8 @@ impl InnerConnection {
         let tail = if c_tail.is_null() {
             0
         } else {
-            let n = unsafe { c_tail.offset_from(c_sql) };
+            // note: feature ptr_offset_from (#41079) only available in Rust 1.47 or later
+            let n = (c_tail as isize) - (c_sql as isize);
             if n <= 0 || n >= len as isize {
                 0
             } else {

--- a/src/types/from_sql.rs
+++ b/src/types/from_sql.rs
@@ -136,7 +136,10 @@ impl FromSql for f64 {
 impl FromSql for bool {
     #[inline]
     fn column_result(value: ValueRef<'_>) -> FromSqlResult<Self> {
-        i64::column_result(value).map(|i| !matches!(i, 0))
+        i64::column_result(value).map(|i| match i {
+            0 => false,
+            _ => true,
+        })
     }
 }
 

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -428,34 +428,40 @@ mod test {
         // Basic non-converting test.
         test_conversion!(db_etc, 0u8, u8, expect 0u8);
 
+        // Constants like u32::MAX are only available in Rust 1.43+.
+        const U32_MAX: u32 = 4294967295;
+        const I64_MIN: i64 = -9223372036854775808;
+        const I64_MAX: i64 = 9223372036854775807;
+        const U64_MAX: u64 = 18446744073709551615;
+
         // In-range integral conversions.
         test_conversion!(db_etc, 100u8, i8, expect 100i8);
         test_conversion!(db_etc, 200u8, u8, expect 200u8);
         test_conversion!(db_etc, 100u16, i8, expect 100i8);
         test_conversion!(db_etc, 200u16, u8, expect 200u8);
-        test_conversion!(db_etc, u32::MAX, u64, expect u32::MAX as u64);
-        test_conversion!(db_etc, i64::MIN, i64, expect i64::MIN);
-        test_conversion!(db_etc, i64::MAX, i64, expect i64::MAX);
-        test_conversion!(db_etc, i64::MAX, u64, expect i64::MAX as u64);
+        test_conversion!(db_etc, U32_MAX, u64, expect U32_MAX as u64);
+        test_conversion!(db_etc, I64_MIN, i64, expect I64_MIN);
+        test_conversion!(db_etc, I64_MAX, i64, expect I64_MAX);
+        test_conversion!(db_etc, I64_MAX, u64, expect I64_MAX as u64);
         test_conversion!(db_etc, 100usize, usize, expect 100usize);
         test_conversion!(db_etc, 100u64, u64, expect 100u64);
-        test_conversion!(db_etc, i64::MAX as u64, u64, expect i64::MAX as u64);
+        test_conversion!(db_etc, I64_MAX as u64, u64, expect I64_MAX as u64);
 
         // Out-of-range integral conversions.
         test_conversion!(db_etc, 200u8, i8, expect_from_sql_error);
         test_conversion!(db_etc, 400u16, i8, expect_from_sql_error);
         test_conversion!(db_etc, 400u16, u8, expect_from_sql_error);
         test_conversion!(db_etc, -1i8, u8, expect_from_sql_error);
-        test_conversion!(db_etc, i64::MIN, u64, expect_from_sql_error);
-        test_conversion!(db_etc, u64::MAX, i64, expect_to_sql_error);
-        test_conversion!(db_etc, u64::MAX, u64, expect_to_sql_error);
-        test_conversion!(db_etc, i64::MAX as u64 + 1, u64, expect_to_sql_error);
+        test_conversion!(db_etc, I64_MIN, u64, expect_from_sql_error);
+        test_conversion!(db_etc, U64_MAX, i64, expect_to_sql_error);
+        test_conversion!(db_etc, U64_MAX, u64, expect_to_sql_error);
+        test_conversion!(db_etc, I64_MAX as u64 + 1, u64, expect_to_sql_error);
 
         // FromSql integer to float, always works.
-        test_conversion!(db_etc, i64::MIN, f32, expect i64::MIN as f32);
-        test_conversion!(db_etc, i64::MAX, f32, expect i64::MAX as f32);
-        test_conversion!(db_etc, i64::MIN, f64, expect i64::MIN as f64);
-        test_conversion!(db_etc, i64::MAX, f64, expect i64::MAX as f64);
+        test_conversion!(db_etc, I64_MIN, f32, expect I64_MIN as f32);
+        test_conversion!(db_etc, I64_MAX, f32, expect I64_MAX as f32);
+        test_conversion!(db_etc, I64_MIN, f64, expect I64_MIN as f64);
+        test_conversion!(db_etc, I64_MAX, f64, expect I64_MAX as f64);
 
         // FromSql float to int conversion, never works even if the actual value
         // is an integer.

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -239,7 +239,10 @@ mod test {
     #[allow(clippy::cognitive_complexity)]
     fn test_mismatched_types() -> Result<()> {
         fn is_invalid_column_type(err: Error) -> bool {
-            matches!(err, Error::InvalidColumnType(..))
+            match err {
+                Error::InvalidColumnType(..) => true,
+                _ => false,
+            }
         }
 
         let db = checked_memory_handle()?;


### PR DESCRIPTION
@thomcc:

> f you need this, I don't really see a problem with accepting the code changes (e.g. without the CI/clippy.toml/etc changes), and putting them in a 0.25.2 patch release, since they are small, unobtrusive, don't impact any public APIs, and the work has already been done.

As mentioned in #949, here's the new PR. It is essentially the same as #949, but without setting the MSRV in clippy.toml and without adding a new CI job. I'd be happy if these changes could be merged and released as a new patch release.