### PR TITLE
Fix build on some older versions of Rust

### DIFF
--- a/libsqlite3-sys/build.rs
+++ b/libsqlite3-sys/build.rs
@@ -377,7 +377,10 @@ mod bindings {
     fn generating_bundled_bindings() -> bool {
         // Hacky way to know if we're generating the bundled bindings
         println!("cargo:rerun-if-env-changed=LIBSQLITE3_SYS_BUNDLING");
-        matches!(std::env::var("LIBSQLITE3_SYS_BUNDLING"), Ok(v) if v != "0")
+        match std::env::var("LIBSQLITE3_SYS_BUNDLING") {
+            Ok(v) => v != "0",
+            Err(_) => false,
+        }
     }
 
     pub fn write_to_out_dir(header: HeaderLocation, out_path: &Path) {

--- a/src/inner_connection.rs
+++ b/src/inner_connection.rs
@@ -261,7 +261,7 @@ impl InnerConnection {
         let tail = if c_tail.is_null() {
             0
         } else {
-            let n = unsafe { c_tail.offset_from(c_sql) };
+            let n = (c_tail as isize) - (c_sql as isize);
             if n <= 0 || n >= len as isize {
                 0
             } else {

--- a/src/types/from_sql.rs
+++ b/src/types/from_sql.rs
@@ -136,7 +136,7 @@ impl FromSql for f64 {
 impl FromSql for bool {
     #[inline]
     fn column_result(value: ValueRef<'_>) -> FromSqlResult<Self> {
-        i64::column_result(value).map(|i| !matches!(i, 0))
+        i64::column_result(value).map(|i| i != 0)
     }
 }
 

--- a/src/vtab/series.rs
+++ b/src/vtab/series.rs
@@ -185,6 +185,7 @@ impl SeriesTabCursor<'_> {
         }
     }
 }
+#[allow(clippy::comparison_chain)]
 unsafe impl VTabCursor for SeriesTabCursor<'_> {
     fn filter(&mut self, idx_num: c_int, _idx_str: Option<&str>, args: &Values<'_>) -> Result<()> {
         let mut idx_num = QueryPlanFlags::from_bits_truncate(idx_num);
@@ -203,7 +204,6 @@ unsafe impl VTabCursor for SeriesTabCursor<'_> {
         }
         if idx_num.contains(QueryPlanFlags::STEP) {
             self.step = args.get(i)?;
-            #[allow(clippy::comparison_chain)]
             if self.step == 0 {
                 self.step = 1;
             } else if self.step < 0 {


### PR DESCRIPTION
This is a less obtrusive version of #952, that also handles non-default features. It doesn't commit to any MSRV, but works back to 1.41 since some users care about that, and it's only a couple tiny fixes.

This doesn't include changes to make the tests pass under older rust, since that's not needed for normal usage.