### PR TITLE
`bundled-full` should not be a default feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -94,8 +94,6 @@ bundled-full = [
     "window",
 ]
 
-default = ["bundled-full"]
-
 [dependencies]
 time = { version = "0.2.23", optional = true }
 bitflags = "1.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rusqlite"
-version = "0.25.2"
+version = "0.25.3"
 authors = ["The rusqlite developers"]
 edition = "2018"
 description = "Ergonomic wrapper for SQLite"


### PR DESCRIPTION
Undo adding `bundled-full` to default features as that's a huge accidental breaking change just made in `0.25.2`.

We can talk about re-adding it later, I think probably not, but I could possibly be convinced.