### PR TITLE
Correct pkg-config version

### DIFF
--- a/libsqlite3-sys/Cargo.toml
+++ b/libsqlite3-sys/Cargo.toml
@@ -38,7 +38,7 @@ winsqlite3 = ["min_sqlite_version_3_7_16"]
 
 [build-dependencies]
 bindgen = { version = "0.58", optional = true, default-features = false, features = ["runtime"] }
-pkg-config = { version = "0.3", optional = true }
+pkg-config = { version = "0.3.19", optional = true }
 cc = { version = "1.0", optional = true }
 
 [target.'cfg(target_env = "msvc")'.build-dependencies]


### PR DESCRIPTION
This crate says it works with pkg-config 3.0.0, but it can't:

```
  Compiling pkg-config v0.3.0
error[E0432]: unresolved import `std::fs::PathExt`
  --> /Users/user/.cargo/registry/src/github.com-1ecc6299db9ec823/pkg-config-0.3.0/src/lib.rs:60:5
   |
60 | use std::fs::PathExt;
   |     ^^^^^^^^^^^^^^^^ no `PathExt` in `fs`

error[E0554]: `#![feature]` may not be used on the stable release channel
  --> /Users/user/.cargo/registry/src/github.com-1ecc6299db9ec823/pkg-config-0.3.0/src/lib.rs:53:1
   |
53 | #![feature(env, path, unicode, process, fs)]
   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```

This matters when using `-Z minimal-versions` cargo option.