### PR TITLE
Use `env::var` instead of `cfg` in some cases in build.rs

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - master
-      - fix_cross_compilation
   pull_request:
     branches:
       - master

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - master
+      - fix_cross_compilation
   pull_request:
     branches:
       - master

--- a/libsqlite3-sys/Cargo.toml
+++ b/libsqlite3-sys/Cargo.toml
@@ -13,8 +13,8 @@ categories = ["external-ffi-bindings"]
 
 [features]
 default = ["min_sqlite_version_3_6_8"]
-bundled = ["cc", "bundled_bindings"]
-bundled-windows = ["cc", "bundled_bindings"]
+bundled = ["bundled_bindings"]
+bundled-windows = ["bundled_bindings"]
 buildtime_bindgen = ["bindgen", "pkg-config", "vcpkg"]
 sqlcipher = []
 min_sqlite_version_3_6_8 = ["pkg-config", "vcpkg"]
@@ -39,7 +39,5 @@ winsqlite3 = ["min_sqlite_version_3_7_16"]
 [build-dependencies]
 bindgen = { version = "0.58", optional = true, default-features = false, features = ["runtime"] }
 pkg-config = { version = "0.3.19", optional = true }
-cc = { version = "1.0", optional = true }
-
-[target.'cfg(target_env = "msvc")'.build-dependencies]
+cc = { version = "1.0" }
 vcpkg = { version = "0.2", optional = true }

--- a/libsqlite3-sys/Cargo.toml
+++ b/libsqlite3-sys/Cargo.toml
@@ -13,8 +13,8 @@ categories = ["external-ffi-bindings"]
 
 [features]
 default = ["min_sqlite_version_3_6_8"]
-bundled = ["bundled_bindings"]
-bundled-windows = ["bundled_bindings"]
+bundled = ["cc", "bundled_bindings"]
+bundled-windows = ["cc", "bundled_bindings"]
 buildtime_bindgen = ["bindgen", "pkg-config", "vcpkg"]
 sqlcipher = []
 min_sqlite_version_3_6_8 = ["pkg-config", "vcpkg"]
@@ -39,5 +39,5 @@ winsqlite3 = ["min_sqlite_version_3_7_16"]
 [build-dependencies]
 bindgen = { version = "0.58", optional = true, default-features = false, features = ["runtime"] }
 pkg-config = { version = "0.3.19", optional = true }
-cc = { version = "1.0" }
+cc = { version = "1.0", optional = true }
 vcpkg = { version = "0.2", optional = true }

--- a/libsqlite3-sys/build.rs
+++ b/libsqlite3-sys/build.rs
@@ -43,14 +43,12 @@ fn main() {
                  This can lead to issues if your version of SQLCipher is not up to date!");
         }
         build_linked::main(&out_dir, &out_path)
+    } else if cfg!(feature = "bundled")
+        || (win_target() && cfg!(feature = "bundled-windows"))
+    {
+        build_bundled::main(&out_dir, &out_path)
     } else {
-        if cfg!(feature = "bundled")
-            || (win_target() && cfg!(feature = "bundled-windows"))
-        {
-            build_bundled::main(&out_dir, &out_path)
-        } else {
-            build_linked::main(&out_dir, &out_path)
-        }
+        build_linked::main(&out_dir, &out_path)
     }
 }
 

--- a/libsqlite3-sys/build.rs
+++ b/libsqlite3-sys/build.rs
@@ -1,11 +1,12 @@
 use std::env;
 use std::path::Path;
 
-/// Tells whether we're building for Windows.
-/// This is more suitable than a plain `cfg!(windows)`, since the latter does not properly handle cross-compilation
+/// Tells whether we're building for Windows. This is more suitable than a plain
+/// `cfg!(windows)`, since the latter does not properly handle cross-compilation
 ///
-/// Note that there is no way to know at compile-time which system we'll be targetting, and this test must be made at run-time (of the build script)
-/// See https://doc.rust-lang.org/cargo/reference/environment-variables.html#environment-variables-cargo-sets-for-build-scripts
+/// Note that there is no way to know at compile-time which system we'll be
+/// targetting, and this test must be made at run-time (of the build script) See
+/// https://doc.rust-lang.org/cargo/reference/environment-variables.html#environment-variables-cargo-sets-for-build-scripts
 fn win_target() -> bool {
     std::env::var("CARGO_CFG_WINDOWS").is_ok()
 }
@@ -17,8 +18,8 @@ fn android_target() -> bool {
     std::env::var("CARGO_CFG_TARGET_OS").map_or(false, |v| v == "android")
 }
 
-/// Tells whether a given compiler will be used
-/// `compiler_name` is compared to the content of `CARGO_CFG_TARGET_ENV` (and is always lowercase)
+/// Tells whether a given compiler will be used `compiler_name` is compared to
+/// the content of `CARGO_CFG_TARGET_ENV` (and is always lowercase)
 ///
 /// See [`win_target`]
 fn is_compiler(compiler_name: &str) -> bool {

--- a/libsqlite3-sys/build.rs
+++ b/libsqlite3-sys/build.rs
@@ -14,7 +14,7 @@ fn win_target() -> bool {
 /// See [`win_target`]
 #[cfg(any(feature = "bundled", feature = "bundled-windows"))]
 fn android_target() -> bool {
-    std::env::var("CARGO_CFG_TARGET_OS") == Ok(String::from("android"))
+    std::env::var("CARGO_CFG_TARGET_OS").map_or(false, |v| v == "android")
 }
 
 /// Tells whether a given compiler will be used
@@ -22,7 +22,7 @@ fn android_target() -> bool {
 ///
 /// See [`win_target`]
 fn is_compiler(compiler_name: &str) -> bool {
-    std::env::var("CARGO_CFG_TARGET_ENV") == Ok(String::from(compiler_name))
+    std::env::var("CARGO_CFG_TARGET_ENV").map_or(false, |v| v == compiler_name)
 }
 
 fn main() {

--- a/libsqlite3-sys/build.rs
+++ b/libsqlite3-sys/build.rs
@@ -1,6 +1,29 @@
 use std::env;
 use std::path::Path;
 
+/// Tells whether we're building for Windows.
+/// This is more suitable than a plain `cfg!(windows)`, since the latter does not properly handle cross-compilation
+///
+/// Note that there is no way to know at compile-time which system we'll be targetting, and this test must be made at run-time (of the build script)
+/// See https://doc.rust-lang.org/cargo/reference/environment-variables.html#environment-variables-cargo-sets-for-build-scripts
+fn win_target() -> bool {
+    std::env::var("CARGO_CFG_WINDOWS").is_ok()
+}
+
+/// Tells whether we're building for Android.
+/// See [`win_target`]
+fn android_target() -> bool {
+    std::env::var("CARGO_CFG_TARGET_OS") == Ok(String::from("android"))
+}
+
+/// Tells whether a given compiler will be used
+/// `compiler_name` is compared to the content of `CARGO_CFG_TARGET_ENV` (and is always lowercase)
+///
+/// See [`win_target`]
+fn is_compiler(compiler_name: &str) -> bool {
+    std::env::var("CARGO_CFG_TARGET_ENV") == Ok(String::from(compiler_name))
+}
+
 fn main() {
     let out_dir = env::var("OUT_DIR").unwrap();
     let out_path = Path::new(&out_dir).join("bindgen.rs");
@@ -12,33 +35,31 @@ fn main() {
         return;
     }
     if cfg!(feature = "sqlcipher") {
-        if cfg!(any(
-            feature = "bundled",
-            all(windows, feature = "bundled-windows")
-        )) {
+        if cfg!(feature = "bundled")
+            || (win_target() && cfg!(feature = "bundled-windows"))
+        {
             println!(
                 "cargo:warning=Builds with bundled SQLCipher are not supported. Searching for SQLCipher to link against. \
                  This can lead to issues if your version of SQLCipher is not up to date!");
         }
         build_linked::main(&out_dir, &out_path)
     } else {
-        // This can't be `cfg!` without always requiring our `mod build_bundled` (and
-        // thus `cc`)
-        #[cfg(any(feature = "bundled", all(windows, feature = "bundled-windows")))]
+        if cfg!(feature = "bundled")
+            || (win_target() && cfg!(feature = "bundled-windows"))
         {
             build_bundled::main(&out_dir, &out_path)
-        }
-        #[cfg(not(any(feature = "bundled", all(windows, feature = "bundled-windows"))))]
-        {
+        } else {
             build_linked::main(&out_dir, &out_path)
         }
     }
 }
 
-#[cfg(any(feature = "bundled", all(windows, feature = "bundled-windows")))]
+//#[cfg(any(feature = "bundled", all(windows, feature = "bundled-windows")))]
 mod build_bundled {
     use std::env;
     use std::path::Path;
+
+    use super::{is_compiler, win_target};
 
     pub fn main(out_dir: &str, out_path: &Path) {
         if cfg!(feature = "sqlcipher") {
@@ -86,7 +107,7 @@ mod build_bundled {
         // on android sqlite can't figure out where to put the temp files.
         // the bundled sqlite on android also uses `SQLITE_TEMP_STORE=3`.
         // https://android.googlesource.com/platform/external/sqlite/+/2c8c9ae3b7e6f340a19a0001c2a889a211c9d8b2/dist/Android.mk
-        if cfg!(target_os = "android") {
+        if super::android_target() {
             cfg.flag("-DSQLITE_TEMP_STORE=3");
         }
 
@@ -101,7 +122,7 @@ mod build_bundled {
         //
         // There may be other platforms that don't support `isnan`, they should be
         // tested for here.
-        if cfg!(target_env = "msvc") {
+        if is_compiler("msvc") {
             use cc::windows_registry::{find_vs_version, VsVers};
             let vs_has_nan = match find_vs_version() {
                 Ok(ver) => ver != VsVers::Vs12,
@@ -113,11 +134,11 @@ mod build_bundled {
         } else {
             cfg.flag("-DHAVE_ISNAN");
         }
-        if cfg!(not(target_os = "windows")) {
+        if ! win_target() {
             cfg.flag("-DHAVE_LOCALTIME_R");
         }
         // Target wasm32-wasi can't compile the default VFS
-        if env::var("TARGET") == Ok("wasm32-wasi".to_string()) {
+        if is_compiler("wasm32-wasi") {
             cfg.flag("-DSQLITE_OS_OTHER")
                 // https://github.com/rust-lang/rust/issues/74393
                 .flag("-DLONGDOUBLE_TYPE=double");
@@ -202,17 +223,17 @@ mod build_linked {
     #[cfg(all(feature = "vcpkg", target_env = "msvc"))]
     extern crate vcpkg;
 
-    use super::{bindings, env_prefix, HeaderLocation};
+    use super::{bindings, env_prefix, HeaderLocation, is_compiler, win_target};
     use std::env;
     use std::path::Path;
 
     pub fn main(_out_dir: &str, out_path: &Path) {
         let header = find_sqlite();
-        if cfg!(any(
+        if (cfg!(any(
             feature = "bundled_bindings",
-            feature = "bundled",
-            all(windows, feature = "bundled-windows")
-        )) && !cfg!(feature = "buildtime_bindgen")
+            feature = "bundled"
+        )) || (win_target() && cfg!(feature = "bundled-windows")))
+        && !cfg!(feature = "buildtime_bindgen")
         {
             // Generally means the `bundled_bindings` feature is enabled
             // (there's also an edge case where we get here involving
@@ -242,7 +263,7 @@ mod build_linked {
         println!("cargo:rerun-if-env-changed={}_INCLUDE_DIR", env_prefix());
         println!("cargo:rerun-if-env-changed={}_LIB_DIR", env_prefix());
         println!("cargo:rerun-if-env-changed={}_STATIC", env_prefix());
-        if cfg!(all(feature = "vcpkg", target_env = "msvc")) {
+        if cfg!(feature = "vcpkg") && is_compiler("msvc") {
             println!("cargo:rerun-if-env-changed=VCPKGRS_DYNAMIC");
         }
 
@@ -252,7 +273,7 @@ mod build_linked {
         // on is available, for example.
         println!("cargo:link-target={}", link_lib);
 
-        if cfg!(all(windows, feature = "winsqlite3")) {
+        if win_target() && cfg!(feature = "winsqlite3") {
             println!("cargo:rustc-link-lib=dylib={}", link_lib);
             return HeaderLocation::Wrapper;
         }
@@ -298,27 +319,25 @@ mod build_linked {
         }
     }
 
-    #[cfg(all(feature = "vcpkg", target_env = "msvc"))]
     fn try_vcpkg() -> Option<HeaderLocation> {
-        // See if vcpkg can find it.
-        if let Ok(mut lib) = vcpkg::Config::new().probe(link_lib()) {
-            if let Some(mut header) = lib.include_paths.pop() {
-                header.push("sqlite3.h");
-                return Some(HeaderLocation::FromPath(header.to_string_lossy().into()));
+        if cfg!(feature = "vcpkg") && is_compiler("msvc") {
+            // See if vcpkg can find it.
+            if let Ok(mut lib) = vcpkg::Config::new().probe(link_lib()) {
+                if let Some(mut header) = lib.include_paths.pop() {
+                    header.push("sqlite3.h");
+                    return Some(HeaderLocation::FromPath(header.to_string_lossy().into()));
+                }
             }
+            None
+        } else {
+            None
         }
-        None
-    }
-
-    #[cfg(not(all(feature = "vcpkg", target_env = "msvc")))]
-    fn try_vcpkg() -> Option<HeaderLocation> {
-        None
     }
 
     fn link_lib() -> &'static str {
         if cfg!(feature = "sqlcipher") {
             "sqlcipher"
-        } else if cfg!(all(windows, feature = "winsqlite3")) {
+        } else if win_target() && cfg!(feature = "winsqlite3") {
             "winsqlite3"
         } else {
             "sqlite3"
@@ -357,6 +376,8 @@ mod bindings {
     use std::fs::OpenOptions;
     use std::io::Write;
     use std::path::Path;
+
+    use super::win_target;
 
     #[derive(Debug)]
     struct SqliteTypeChooser;
@@ -400,7 +421,7 @@ mod bindings {
         if cfg!(feature = "session") {
             bindings = bindings.clang_arg("-DSQLITE_ENABLE_SESSION");
         }
-        if cfg!(all(windows, feature = "winsqlite3")) {
+        if win_target() && cfg!(feature = "winsqlite3") {
             bindings = bindings
                 .clang_arg("-DBINDGEN_USE_WINSQLITE3")
                 .blocklist_item("NTDDI_.+")

--- a/libsqlite3-sys/build.rs
+++ b/libsqlite3-sys/build.rs
@@ -223,7 +223,7 @@ impl From<HeaderLocation> for String {
 }
 
 mod build_linked {
-    #[cfg(all(feature = "vcpkg", target_env = "msvc"))]
+    #[cfg(feature = "vcpkg")]
     extern crate vcpkg;
 
     use super::{bindings, env_prefix, is_compiler, win_target, HeaderLocation};

--- a/libsqlite3-sys/build.rs
+++ b/libsqlite3-sys/build.rs
@@ -35,17 +35,13 @@ fn main() {
         return;
     }
     if cfg!(feature = "sqlcipher") {
-        if cfg!(feature = "bundled")
-            || (win_target() && cfg!(feature = "bundled-windows"))
-        {
+        if cfg!(feature = "bundled") || (win_target() && cfg!(feature = "bundled-windows")) {
             println!(
                 "cargo:warning=Builds with bundled SQLCipher are not supported. Searching for SQLCipher to link against. \
                  This can lead to issues if your version of SQLCipher is not up to date!");
         }
         build_linked::main(&out_dir, &out_path)
-    } else if cfg!(feature = "bundled")
-        || (win_target() && cfg!(feature = "bundled-windows"))
-    {
+    } else if cfg!(feature = "bundled") || (win_target() && cfg!(feature = "bundled-windows")) {
         build_bundled::main(&out_dir, &out_path)
     } else {
         build_linked::main(&out_dir, &out_path)
@@ -132,7 +128,7 @@ mod build_bundled {
         } else {
             cfg.flag("-DHAVE_ISNAN");
         }
-        if ! win_target() {
+        if !win_target() {
             cfg.flag("-DHAVE_LOCALTIME_R");
         }
         // Target wasm32-wasi can't compile the default VFS
@@ -221,17 +217,15 @@ mod build_linked {
     #[cfg(all(feature = "vcpkg", target_env = "msvc"))]
     extern crate vcpkg;
 
-    use super::{bindings, env_prefix, HeaderLocation, is_compiler, win_target};
+    use super::{bindings, env_prefix, is_compiler, win_target, HeaderLocation};
     use std::env;
     use std::path::Path;
 
     pub fn main(_out_dir: &str, out_path: &Path) {
         let header = find_sqlite();
-        if (cfg!(any(
-            feature = "bundled_bindings",
-            feature = "bundled"
-        )) || (win_target() && cfg!(feature = "bundled-windows")))
-        && !cfg!(feature = "buildtime_bindgen")
+        if (cfg!(any(feature = "bundled_bindings", feature = "bundled"))
+            || (win_target() && cfg!(feature = "bundled-windows")))
+            && !cfg!(feature = "buildtime_bindgen")
         {
             // Generally means the `bundled_bindings` feature is enabled
             // (there's also an edge case where we get here involving


### PR DESCRIPTION
This MR is properly using `std::env::var("CARGO_CFG_whatever")` instead of `cfg!(whatever)`

This is required to handle cross-compilation, see https://doc.rust-lang.org/cargo/reference/environment-variables.html#environment-variables-cargo-sets-for-build-scripts \
Note that this requires to pull `vcpkg` as a dev-dependency whatever cargo features are used. But this does not cuase any trouble on native Windows, native Linux or cross Linux-to-Windows.

Without these changes, using msvc-wine to build rusqlite would try to compile libsqlite with `-DHAVE_LOCALTIME_R` (which fails).


(Note also that there is an undocumented feature (`bundled-windows`), that you may want to either document or drop completely)