### PR TITLE
Add a helper function for getting the byte data from a ValueRef, regardless of if its Text or Blob

### DIFF
--- a/src/types/serde_json.rs
+++ b/src/types/serde_json.rs
@@ -17,12 +17,8 @@ impl ToSql for Value {
 impl FromSql for Value {
     #[inline]
     fn column_result(value: ValueRef<'_>) -> FromSqlResult<Self> {
-        match value {
-            ValueRef::Text(s) => serde_json::from_slice(s),
-            ValueRef::Blob(b) => serde_json::from_slice(b),
-            _ => return Err(FromSqlError::InvalidType),
-        }
-        .map_err(|err| FromSqlError::Other(Box::new(err)))
+        let bytes = value.as_bytes()?;
+        serde_json::from_slice(bytes).map_err(|err| FromSqlError::Other(Box::new(err)))
     }
 }
 

--- a/src/types/value_ref.rs
+++ b/src/types/value_ref.rs
@@ -77,6 +77,16 @@ impl<'a> ValueRef<'a> {
             _ => Err(FromSqlError::InvalidType),
         }
     }
+
+    /// Returns the byte slice that makes up this ValueRef if it's either
+    /// [`ValueRef::Blob`] or [`ValueRef::Text`].
+    #[inline]
+    pub fn as_bytes(&self) -> FromSqlResult<&'a [u8]> {
+        match self {
+            ValueRef::Text(s) | ValueRef::Blob(s) => Ok(s),
+            _ => Err(FromSqlError::InvalidType),
+        }
+    }
 }
 
 impl From<ValueRef<'_>> for Value {


### PR DESCRIPTION
I was helping someone today and realized that this didn't exist, despite us doing it internally. It's a pretty niche use case, but it's generally what you want if you're working with serialized conventionally-text data.

I've also changed our existing code to use it, so it doesn't need additional tests (the existing code is tested for both blob/text values).