### PR TITLE
[Cosmetic] Remove check macro

### DIFF
--- a/src/blob/pos_io.rs
+++ b/src/blob/pos_io.rs
@@ -4,6 +4,7 @@ use std::convert::TryFrom;
 use std::mem::MaybeUninit;
 use std::slice::from_raw_parts_mut;
 
+use crate::error::check;
 use crate::ffi;
 use crate::{Error, Result};
 
@@ -44,15 +45,14 @@ impl<'conn> Blob<'conn> {
         //    losslessly converted to i32, since `len` came from an i32.
         // Sanity check the above.
         debug_assert!(i32::try_from(write_start).is_ok() && i32::try_from(buf.len()).is_ok());
-        unsafe {
-            check!(ffi::sqlite3_blob_write(
+        check(unsafe {
+            ffi::sqlite3_blob_write(
                 self.blob,
                 buf.as_ptr() as *const _,
                 buf.len() as i32,
                 write_start as i32,
-            ));
-        }
-        Ok(())
+            )
+        })
     }
 
     /// An alias for `write_at` provided for compatibility with the conceptually
@@ -151,12 +151,12 @@ impl<'conn> Blob<'conn> {
         debug_assert!(i32::try_from(read_len).is_ok());
 
         unsafe {
-            check!(ffi::sqlite3_blob_read(
+            check(ffi::sqlite3_blob_read(
                 self.blob,
                 buf.as_mut_ptr() as *mut _,
                 read_len as i32,
                 read_start as i32,
-            ));
+            ))?;
 
             Ok(from_raw_parts_mut(buf.as_mut_ptr() as *mut u8, read_len))
         }

--- a/src/config.rs
+++ b/src/config.rs
@@ -2,6 +2,7 @@
 
 use std::os::raw::c_int;
 
+use crate::error::check;
 use crate::ffi;
 use crate::{Connection, Result};
 
@@ -80,12 +81,12 @@ impl Connection {
         let c = self.db.borrow();
         unsafe {
             let mut val = 0;
-            check!(ffi::sqlite3_db_config(
+            check(ffi::sqlite3_db_config(
                 c.db(),
                 config as c_int,
                 -1,
-                &mut val
-            ));
+                &mut val,
+            ))?;
             Ok(val != 0)
         }
     }
@@ -109,12 +110,12 @@ impl Connection {
         let c = self.db.borrow_mut();
         unsafe {
             let mut val = 0;
-            check!(ffi::sqlite3_db_config(
+            check(ffi::sqlite3_db_config(
                 c.db(),
                 config as c_int,
                 if new_val { 1 } else { 0 },
-                &mut val
-            ));
+                &mut val,
+            ))?;
             Ok(val != 0)
         }
     }

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,6 +1,6 @@
 use crate::types::FromSqlError;
 use crate::types::Type;
-use crate::{errmsg_to_string, ffi};
+use crate::{errmsg_to_string, ffi, Result};
 use std::error;
 use std::fmt;
 use std::os::raw::c_int;
@@ -357,11 +357,10 @@ pub unsafe fn error_from_handle(db: *mut ffi::sqlite3, code: c_int) -> Error {
     error_from_sqlite_code(code, message)
 }
 
-macro_rules! check {
-    ($funcall:expr) => {{
-        let rc = $funcall;
-        if rc != crate::ffi::SQLITE_OK {
-            return Err(crate::error::error_from_sqlite_code(rc, None).into());
-        }
-    }};
+pub fn check(code: c_int) -> Result<()> {
+    if code != crate::ffi::SQLITE_OK {
+        Err(crate::error::error_from_sqlite_code(code, None))
+    } else {
+        Ok(())
+    }
 }

--- a/src/inner_connection.rs
+++ b/src/inner_connection.rs
@@ -10,7 +10,7 @@ use std::sync::{Arc, Mutex};
 use super::ffi;
 use super::str_for_sqlite;
 use super::{Connection, InterruptHandle, OpenFlags, Result};
-use crate::error::{error_from_handle, error_from_sqlite_code, Error};
+use crate::error::{check, error_from_handle, error_from_sqlite_code, Error};
 use crate::raw_statement::RawStatement;
 use crate::statement::Statement;
 use crate::unlock_notify;
@@ -304,8 +304,7 @@ impl InnerConnection {
 
     #[cfg(feature = "modern_sqlite")] // 3.10.0
     pub fn cache_flush(&mut self) -> Result<()> {
-        check!(unsafe { ffi::sqlite3_db_cacheflush(self.db()) });
-        Ok(())
+        check(unsafe { ffi::sqlite3_db_cacheflush(self.db()) })
     }
 
     #[cfg(not(feature = "hooks"))]

--- a/src/inner_connection.rs
+++ b/src/inner_connection.rs
@@ -10,7 +10,7 @@ use std::sync::{Arc, Mutex};
 use super::ffi;
 use super::str_for_sqlite;
 use super::{Connection, InterruptHandle, OpenFlags, Result};
-use crate::error::{check, error_from_handle, error_from_sqlite_code, Error};
+use crate::error::{error_from_handle, error_from_sqlite_code, Error};
 use crate::raw_statement::RawStatement;
 use crate::statement::Statement;
 use crate::unlock_notify;
@@ -304,7 +304,7 @@ impl InnerConnection {
 
     #[cfg(feature = "modern_sqlite")] // 3.10.0
     pub fn cache_flush(&mut self) -> Result<()> {
-        check(unsafe { ffi::sqlite3_db_cacheflush(self.db()) })
+        crate::error::check(unsafe { ffi::sqlite3_db_cacheflush(self.db()) })
     }
 
     #[cfg(not(feature = "hooks"))]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -83,7 +83,6 @@ pub use crate::transaction::{DropBehavior, Savepoint, Transaction, TransactionBe
 pub use crate::types::ToSql;
 pub use crate::version::*;
 
-#[macro_use]
 mod error;
 
 #[cfg(feature = "backup")]


### PR DESCRIPTION
Can be replaced by a simple function and ? operator.