### PR TITLE
Enable LTO support for clang-like compiler when using feature "bundled" in libsqlite3-sys

### DIFF
--- a/libsqlite3-sys/build.rs
+++ b/libsqlite3-sys/build.rs
@@ -129,6 +129,10 @@ mod build_bundled {
             .flag("-D_POSIX_THREAD_SAFE_FUNCTIONS") // cross compile with MinGW
             .warnings(false);
 
+        if cfg.get_compiler().is_like_clang() {
+            cfg.flag_if_supported("-flto");
+        }
+
         if cfg!(feature = "bundled-sqlcipher") {
             cfg.flag("-DSQLITE_HAS_CODEC").flag("-DSQLITE_TEMP_STORE=2");
 


### PR DESCRIPTION
This PR enables LTO support in libsqlite3-sys when the compiler is clang-like.

I've tested that it all tests inside libsqlite3-sys passed by adding:

```
[dev-dependencies]
libsqlite3-sys = { path = ".", features = ["bundled"] }
```

to `libsqlite3-sys/Cargo.toml` and run `cargo test --release`.

I've also run the test inside `rusqlite` with `features = ["bundled"]` for `libsqlite3-sys`.

Signed-off-by: Jiahao XU <Jiahao_XU@outlook.com>