### PR TITLE
 Improve API VTab::best_index: Separate mutable and immutable data 

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -136,6 +136,7 @@ name = "deny_single_threaded_sqlite_config"
 
 [[test]]
 name = "vtab"
+required-features = ["vtab"]
 
 [[bench]]
 name = "cache"

--- a/src/vtab/array.rs
+++ b/src/vtab/array.rs
@@ -98,7 +98,7 @@ unsafe impl<'vtab> VTab<'vtab> for ArrayTab {
     ) -> Result<BestIndex> {
         // Index of the pointer= constraint
         let mut ptr_idx = None;
-        for (i, constraint) in info.constraints().enumerate() {
+        for (i, constraint) in info.constraints().clone().enumerate() {
             if !constraint.is_usable() {
                 continue;
             }

--- a/src/vtab/array.rs
+++ b/src/vtab/array.rs
@@ -34,10 +34,8 @@ use std::rc::Rc;
 use crate::ffi;
 use crate::types::{ToSql, ToSqlOutput, Value};
 use crate::vtab::{
-    eponymous_only_module, Context, IndexConstraintOp,
-    IndexInfo, IndexConstraintUsages, BestIndex,
-    VTab, VTabConnection, VTabCursor,
-    Values,
+    eponymous_only_module, BestIndex, Context, IndexConstraintOp, IndexConstraintUsages, IndexInfo,
+    VTab, VTabConnection, VTabCursor, Values,
 };
 use crate::{Connection, Result};
 
@@ -94,7 +92,7 @@ unsafe impl<'vtab> VTab<'vtab> for ArrayTab {
     fn best_index(
         &self,
         info: &IndexInfo,
-        constraint_usages: &mut IndexConstraintUsages
+        constraint_usages: &mut IndexConstraintUsages,
     ) -> Result<BestIndex> {
         // Index of the pointer= constraint
         let mut ptr_idx = None;
@@ -115,14 +113,14 @@ unsafe impl<'vtab> VTab<'vtab> for ArrayTab {
                 constraint_usage.set_argv_index(1);
                 constraint_usage.set_omit(true);
             }
-            Ok(BestIndex{
+            Ok(BestIndex {
                 idx_num: 1,
                 order_by_consumed: false,
                 estimated_cost: 1f64,
                 estimated_rows: 100,
             })
         } else {
-            Ok(BestIndex{
+            Ok(BestIndex {
                 idx_num: 0,
                 order_by_consumed: false,
                 estimated_cost: 2_147_483_647f64,

--- a/src/vtab/csvtab.rs
+++ b/src/vtab/csvtab.rs
@@ -30,10 +30,8 @@ use std::str;
 use crate::ffi;
 use crate::types::Null;
 use crate::vtab::{
-    read_only_module, Context, dequote, parse_boolean, escape_double_quote, CreateVTab,
-    IndexInfo, IndexConstraintUsages, BestIndex,
-    VTab, VTabConnection, VTabCursor,
-    Values,
+    dequote, escape_double_quote, parse_boolean, read_only_module, BestIndex, Context, CreateVTab,
+    IndexConstraintUsages, IndexInfo, VTab, VTabConnection, VTabCursor, Values,
 };
 use crate::{Connection, Error, Result};
 
@@ -259,9 +257,9 @@ unsafe impl<'vtab> VTab<'vtab> for CsvTab {
     fn best_index(
         &self,
         _info: &IndexInfo,
-        _constraint_usages: &mut IndexConstraintUsages
+        _constraint_usages: &mut IndexConstraintUsages,
     ) -> Result<BestIndex> {
-        Ok(BestIndex{
+        Ok(BestIndex {
             idx_num: 0,
             order_by_consumed: false,
             estimated_cost: 1_000_000.,

--- a/src/vtab/csvtab.rs
+++ b/src/vtab/csvtab.rs
@@ -30,8 +30,10 @@ use std::str;
 use crate::ffi;
 use crate::types::Null;
 use crate::vtab::{
-    dequote, escape_double_quote, parse_boolean, read_only_module, Context, CreateVTab, IndexInfo,
-    VTab, VTabConnection, VTabCursor, Values,
+    read_only_module, Context, dequote, parse_boolean, escape_double_quote, CreateVTab,
+    IndexInfo, IndexConstraintUsages, BestIndex,
+    VTab, VTabConnection, VTabCursor,
+    Values,
 };
 use crate::{Connection, Error, Result};
 
@@ -253,10 +255,18 @@ unsafe impl<'vtab> VTab<'vtab> for CsvTab {
         Ok((schema.unwrap(), vtab))
     }
 
-    // Only a forward full table scan is supported.
-    fn best_index(&self, info: &mut IndexInfo) -> Result<()> {
-        info.set_estimated_cost(1_000_000.);
-        Ok(())
+    /// Only a forward full table scan is supported.
+    fn best_index(
+        &self,
+        _info: &IndexInfo,
+        _constraint_usages: &mut IndexConstraintUsages
+    ) -> Result<BestIndex> {
+        Ok(BestIndex{
+            idx_num: 0,
+            order_by_consumed: false,
+            estimated_cost: 1_000_000.,
+            estimated_rows: 1_000_000,
+        })
     }
 
     fn open(&self) -> Result<CsvTabCursor<'_>> {

--- a/src/vtab/mod.rs
+++ b/src/vtab/mod.rs
@@ -432,13 +432,6 @@ impl<'a> IndexConstraintUsages<'a> {
             slice::from_raw_parts_mut(info.aConstraintUsage, info.nConstraint as usize)
         };
 
-        // Initialize constraint_usages to some sane default value
-        for (index, each) in constraint_usages.iter_mut().enumerate() {
-            let mut each = IndexConstraintUsage(each);
-            each.set_argv_index(index as i32);
-            each.set_omit(false);
-        }
-
         Self(constraint_usages)
     }
 

--- a/src/vtab/mod.rs
+++ b/src/vtab/mod.rs
@@ -381,6 +381,7 @@ pub struct BestIndex {
 }
 
 /// `feature = "vtab"`
+#[derive(Clone)]
 pub struct IndexConstraintIter<'a> {
     iter: slice::Iter<'a, ffi::sqlite3_index_constraint>,
 }
@@ -470,6 +471,7 @@ impl IndexConstraintUsage<'_> {
 }
 
 /// `feature = "vtab"`
+#[derive(Clone)]
 pub struct OrderByIter<'a> {
     iter: slice::Iter<'a, ffi::sqlite3_index_info_sqlite3_index_orderby>,
 }

--- a/src/vtab/mod.rs
+++ b/src/vtab/mod.rs
@@ -198,7 +198,7 @@ impl VTabConnection {
 /// #[repr(C)]
 /// struct MyTab {
 ///    /// Base class. Must be first
-///    base: ffi::sqlite3_vtab,
+///    base: rusqlite::vtab::sqlite3_vtab,
 ///    /* Virtual table implementations will typically add additional fields */
 /// }
 /// ```
@@ -488,7 +488,7 @@ impl OrderBy<'_> {
 /// #[repr(C)]
 /// struct MyTabCursor {
 ///    /// Base class. Must be first
-///    base: ffi::sqlite3_vtab_cursor,
+///    base: rusqlite::vtab::sqlite3_vtab_cursor,
 ///    /* Virtual table implementations will typically add additional fields */
 /// }
 /// ```

--- a/src/vtab/mod.rs
+++ b/src/vtab/mod.rs
@@ -364,6 +364,7 @@ impl<'a> IndexInfo<'a> {
 }
 
 /// The return type of VTab::best_index
+#[derive(Copy, Clone, Debug, Default)]
 pub struct BestIndex {
     /// Number used to identify the index
     pub idx_num: c_int,

--- a/src/vtab/series.rs
+++ b/src/vtab/series.rs
@@ -10,10 +10,8 @@ use std::os::raw::c_int;
 use crate::ffi;
 use crate::types::Type;
 use crate::vtab::{
-    eponymous_only_module, Context, IndexConstraintOp,
-    IndexInfo, IndexConstraintUsages, BestIndex,
-    VTab, VTabConnection, VTabCursor,
-    Values,
+    eponymous_only_module, BestIndex, Context, IndexConstraintOp, IndexConstraintUsages, IndexInfo,
+    VTab, VTabConnection, VTabCursor, Values,
 };
 use crate::{Connection, Error, Result};
 
@@ -75,7 +73,7 @@ unsafe impl<'vtab> VTab<'vtab> for SeriesTab {
     fn best_index(
         &self,
         info: &IndexInfo,
-        constraint_usages: &mut IndexConstraintUsages
+        constraint_usages: &mut IndexConstraintUsages,
     ) -> Result<BestIndex> {
         // The query plan bitmask
         let mut idx_num: QueryPlanFlags = QueryPlanFlags::empty();
@@ -117,7 +115,9 @@ unsafe impl<'vtab> VTab<'vtab> for SeriesTab {
             ));
         }
 
-        let mut ret = BestIndex { ..Default::default() };
+        let mut ret = BestIndex {
+            ..Default::default()
+        };
         if idx_num.contains(QueryPlanFlags::BOTH) {
             // Both start= and stop= boundaries are available.
             ret.estimated_cost = f64::from(

--- a/tests/vtab.rs
+++ b/tests/vtab.rs
@@ -4,9 +4,8 @@
 #[test]
 fn test_dummy_module() -> rusqlite::Result<()> {
     use rusqlite::vtab::{
-        eponymous_only_module, sqlite3_vtab, sqlite3_vtab_cursor, Context,
-        IndexInfo, IndexConstraintUsages, BestIndex,
-        VTab, VTabConnection, VTabCursor, Values,
+        eponymous_only_module, sqlite3_vtab, sqlite3_vtab_cursor, BestIndex, Context,
+        IndexConstraintUsages, IndexInfo, VTab, VTabConnection, VTabCursor, Values,
     };
     use rusqlite::{version_number, Connection, Result};
     use std::marker::PhantomData;
@@ -38,7 +37,7 @@ fn test_dummy_module() -> rusqlite::Result<()> {
         fn best_index(
             &self,
             _info: &IndexInfo,
-            _constraint_usages: &mut IndexConstraintUsages
+            _constraint_usages: &mut IndexConstraintUsages,
         ) -> Result<BestIndex> {
             Ok(BestIndex {
                 idx_num: 0,

--- a/tests/vtab.rs
+++ b/tests/vtab.rs
@@ -4,8 +4,9 @@
 #[test]
 fn test_dummy_module() -> rusqlite::Result<()> {
     use rusqlite::vtab::{
-        eponymous_only_module, sqlite3_vtab, sqlite3_vtab_cursor, Context, IndexInfo, VTab,
-        VTabConnection, VTabCursor, Values,
+        eponymous_only_module, sqlite3_vtab, sqlite3_vtab_cursor, Context,
+        IndexInfo, IndexConstraintUsages, BestIndex,
+        VTab, VTabConnection, VTabCursor, Values,
     };
     use rusqlite::{version_number, Connection, Result};
     use std::marker::PhantomData;
@@ -34,9 +35,17 @@ fn test_dummy_module() -> rusqlite::Result<()> {
             Ok(("CREATE TABLE x(value)".to_owned(), vtab))
         }
 
-        fn best_index(&self, info: &mut IndexInfo) -> Result<()> {
-            info.set_estimated_cost(1.);
-            Ok(())
+        fn best_index(
+            &self,
+            _info: &IndexInfo,
+            _constraint_usages: &mut IndexConstraintUsages
+        ) -> Result<BestIndex> {
+            Ok(BestIndex {
+                idx_num: 0,
+                order_by_consumed: false,
+                estimated_cost: 1.,
+                estimated_rows: i64::MAX,
+            })
         }
 
         fn open(&'vtab self) -> Result<DummyTabCursor<'vtab>> {


### PR DESCRIPTION
This PR depends on the PR #1000 .

Mixing mutable and immutable data has several problems, one is that you cannot loop over `IndexConstraintIter` while setting respective `IndexConstraintUsage`.

This makes it hard to implement `VTab::best_index`.

Another problem is that it is confusing, as programmer do not know which part is for reading and which part is required to be set for the `VTab::best_index` implementation to works.

This commit separates mutable from the immutable, by passing additional param `constraint_usages` and makes `info` to be immutable, and requires the implementation to returns a `BestIndex` so that these fields will always be explicitly initialized.

~~param `constraint_usages` also automatically sets each `IndexConstraintUsage` to some sane values before passing it to `VTab::best_index` implementation.~~

Signed-off-by: Jiahao XU <Jiahao_XU@outlook.com>