### PR TITLE
[HELP WANTED] Add `VTabSafe` and `CreateVTabSafe` so that `unsafe impl` is no longer required

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -136,6 +136,7 @@ name = "deny_single_threaded_sqlite_config"
 
 [[test]]
 name = "vtab"
+required-features = ["vtab"]
 
 [[bench]]
 name = "cache"

--- a/src/vtab/array.rs
+++ b/src/vtab/array.rs
@@ -98,7 +98,7 @@ unsafe impl<'vtab> VTab<'vtab> for ArrayTab {
     ) -> Result<BestIndex> {
         // Index of the pointer= constraint
         let mut ptr_idx = None;
-        for (i, constraint) in info.constraints().enumerate() {
+        for (i, constraint) in info.constraints().clone().enumerate() {
             if !constraint.is_usable() {
                 continue;
             }

--- a/src/vtab/array.rs
+++ b/src/vtab/array.rs
@@ -34,10 +34,8 @@ use std::rc::Rc;
 use crate::ffi;
 use crate::types::{ToSql, ToSqlOutput, Value};
 use crate::vtab::{
-    eponymous_only_module, Context, IndexConstraintOp,
-    IndexInfo, IndexConstraintUsages, BestIndex,
-    VTab, VTabConnection, VTabCursor,
-    Values,
+    eponymous_only_module, BestIndex, Context, IndexConstraintOp, IndexConstraintUsages, IndexInfo,
+    VTab, VTabConnection, VTabCursor, Values,
 };
 use crate::{Connection, Result};
 
@@ -94,7 +92,7 @@ unsafe impl<'vtab> VTab<'vtab> for ArrayTab {
     fn best_index(
         &self,
         info: &IndexInfo,
-        constraint_usages: &mut IndexConstraintUsages
+        constraint_usages: &mut IndexConstraintUsages,
     ) -> Result<BestIndex> {
         // Index of the pointer= constraint
         let mut ptr_idx = None;
@@ -115,14 +113,14 @@ unsafe impl<'vtab> VTab<'vtab> for ArrayTab {
                 constraint_usage.set_argv_index(1);
                 constraint_usage.set_omit(true);
             }
-            Ok(BestIndex{
+            Ok(BestIndex {
                 idx_num: 1,
                 order_by_consumed: false,
                 estimated_cost: 1f64,
                 estimated_rows: 100,
             })
         } else {
-            Ok(BestIndex{
+            Ok(BestIndex {
                 idx_num: 0,
                 order_by_consumed: false,
                 estimated_cost: 2_147_483_647f64,

--- a/src/vtab/array.rs
+++ b/src/vtab/array.rs
@@ -34,10 +34,8 @@ use std::rc::Rc;
 use crate::ffi;
 use crate::types::{ToSql, ToSqlOutput, Value};
 use crate::vtab::{
-    eponymous_only_module_safe, Context, IndexConstraintOp,
-    IndexInfo, IndexConstraintUsages, BestIndex,
-    VTabSafe, VTabConnection, VTabCursor,
-    Values,
+    eponymous_only_module_safe, BestIndex, Context, IndexConstraintOp, IndexConstraintUsages,
+    IndexInfo, VTabConnection, VTabCursor, VTabSafe, Values,
 };
 use crate::{Connection, Result};
 

--- a/src/vtab/csvtab.rs
+++ b/src/vtab/csvtab.rs
@@ -30,10 +30,8 @@ use std::str;
 use crate::ffi;
 use crate::types::Null;
 use crate::vtab::{
-    read_only_module, Context, dequote, parse_boolean, escape_double_quote, CreateVTab,
-    IndexInfo, IndexConstraintUsages, BestIndex,
-    VTab, VTabConnection, VTabCursor,
-    Values,
+    dequote, escape_double_quote, parse_boolean, read_only_module, BestIndex, Context, CreateVTab,
+    IndexConstraintUsages, IndexInfo, VTab, VTabConnection, VTabCursor, Values,
 };
 use crate::{Connection, Error, Result};
 
@@ -259,9 +257,9 @@ unsafe impl<'vtab> VTab<'vtab> for CsvTab {
     fn best_index(
         &self,
         _info: &IndexInfo,
-        _constraint_usages: &mut IndexConstraintUsages
+        _constraint_usages: &mut IndexConstraintUsages,
     ) -> Result<BestIndex> {
-        Ok(BestIndex{
+        Ok(BestIndex {
             idx_num: 0,
             order_by_consumed: false,
             estimated_cost: 1_000_000.,

--- a/src/vtab/csvtab.rs
+++ b/src/vtab/csvtab.rs
@@ -30,10 +30,8 @@ use std::str;
 use crate::ffi;
 use crate::types::Null;
 use crate::vtab::{
-    read_only_module_safe, Context, dequote, parse_boolean, escape_double_quote,
-    CreateVTabSafe, IndexInfo, IndexConstraintUsages, BestIndex,
-    VTabSafe, VTabConnection, VTabCursor,
-    Values,
+    dequote, escape_double_quote, parse_boolean, read_only_module_safe, BestIndex, Context,
+    CreateVTabSafe, IndexConstraintUsages, IndexInfo, VTabConnection, VTabCursor, VTabSafe, Values,
 };
 use crate::{Connection, Error, Result};
 

--- a/src/vtab/csvtab.rs
+++ b/src/vtab/csvtab.rs
@@ -30,8 +30,10 @@ use std::str;
 use crate::ffi;
 use crate::types::Null;
 use crate::vtab::{
-    dequote, escape_double_quote, parse_boolean, read_only_module, Context, CreateVTab, IndexInfo,
-    VTab, VTabConnection, VTabCursor, Values,
+    read_only_module, Context, dequote, parse_boolean, escape_double_quote, CreateVTab,
+    IndexInfo, IndexConstraintUsages, BestIndex,
+    VTab, VTabConnection, VTabCursor,
+    Values,
 };
 use crate::{Connection, Error, Result};
 
@@ -253,10 +255,18 @@ unsafe impl<'vtab> VTab<'vtab> for CsvTab {
         Ok((schema.unwrap(), vtab))
     }
 
-    // Only a forward full table scan is supported.
-    fn best_index(&self, info: &mut IndexInfo) -> Result<()> {
-        info.set_estimated_cost(1_000_000.);
-        Ok(())
+    /// Only a forward full table scan is supported.
+    fn best_index(
+        &self,
+        _info: &IndexInfo,
+        _constraint_usages: &mut IndexConstraintUsages
+    ) -> Result<BestIndex> {
+        Ok(BestIndex{
+            idx_num: 0,
+            order_by_consumed: false,
+            estimated_cost: 1_000_000.,
+            estimated_rows: 1_000_000,
+        })
     }
 
     fn open(&self) -> Result<CsvTabCursor<'_>> {

--- a/src/vtab/mod.rs
+++ b/src/vtab/mod.rs
@@ -432,13 +432,6 @@ impl<'a> IndexConstraintUsages<'a> {
             slice::from_raw_parts_mut(info.aConstraintUsage, info.nConstraint as usize)
         };
 
-        // Initialize constraint_usages to some sane default value
-        for (index, each) in constraint_usages.iter_mut().enumerate() {
-            let mut each = IndexConstraintUsage(each);
-            each.set_argv_index(index as i32);
-            each.set_omit(false);
-        }
-
         Self(constraint_usages)
     }
 

--- a/src/vtab/mod.rs
+++ b/src/vtab/mod.rs
@@ -381,6 +381,7 @@ pub struct BestIndex {
 }
 
 /// `feature = "vtab"`
+#[derive(Clone)]
 pub struct IndexConstraintIter<'a> {
     iter: slice::Iter<'a, ffi::sqlite3_index_constraint>,
 }
@@ -470,6 +471,7 @@ impl IndexConstraintUsage<'_> {
 }
 
 /// `feature = "vtab"`
+#[derive(Clone)]
 pub struct OrderByIter<'a> {
     iter: slice::Iter<'a, ffi::sqlite3_index_info_sqlite3_index_orderby>,
 }

--- a/src/vtab/mod.rs
+++ b/src/vtab/mod.rs
@@ -198,7 +198,7 @@ impl VTabConnection {
 /// #[repr(C)]
 /// struct MyTab {
 ///    /// Base class. Must be first
-///    base: ffi::sqlite3_vtab,
+///    base: rusqlite::vtab::sqlite3_vtab,
 ///    /* Virtual table implementations will typically add additional fields */
 /// }
 /// ```
@@ -488,7 +488,7 @@ impl OrderBy<'_> {
 /// #[repr(C)]
 /// struct MyTabCursor {
 ///    /// Base class. Must be first
-///    base: ffi::sqlite3_vtab_cursor,
+///    base: rusqlite::vtab::sqlite3_vtab_cursor,
 ///    /* Virtual table implementations will typically add additional fields */
 /// }
 /// ```

--- a/src/vtab/mod.rs
+++ b/src/vtab/mod.rs
@@ -125,9 +125,8 @@ pub fn read_only_module<'vtab, T: CreateVTab<'vtab>>() -> &'static Module<'vtab,
 /// Create a read-only virtual table implementation.
 ///
 /// Step 2 of [Creating New Virtual Table Implementations](https://sqlite.org/vtab.html#creating_new_virtual_table_implementations).
-pub fn read_only_module_safe<'vtab, T: CreateVTabSafe<'vtab>>()
-    -> &'static Module<'vtab, SafeCreateVTabWrapper<'vtab, T>>
-{
+pub fn read_only_module_safe<'vtab, T: CreateVTabSafe<'vtab>>(
+) -> &'static Module<'vtab, SafeCreateVTabWrapper<'vtab, T>> {
     read_only_module::<'_, SafeCreateVTabWrapper<'_, T>>()
 }
 
@@ -173,9 +172,8 @@ pub fn eponymous_only_module<'vtab, T: VTab<'vtab>>() -> &'static Module<'vtab, 
 /// Create an eponymous only virtual table implementation.
 ///
 /// Step 2 of [Creating New Virtual Table Implementations](https://sqlite.org/vtab.html#creating_new_virtual_table_implementations).
-pub fn eponymous_only_module_safe<'vtab, T: VTabSafe<'vtab>>()
-    -> &'static Module<'vtab, SafeVTabWrapper<'vtab, T>>
-{
+pub fn eponymous_only_module_safe<'vtab, T: VTabSafe<'vtab>>(
+) -> &'static Module<'vtab, SafeVTabWrapper<'vtab, T>> {
     eponymous_only_module::<'_, SafeVTabWrapper<'_, T>>()
 }
 
@@ -302,7 +300,7 @@ pub trait VTabSafe<'vtab>: Sized {
     fn best_index(
         &self,
         info: &IndexInfo,
-        constraint_usages: &mut IndexConstraintUsages
+        constraint_usages: &mut IndexConstraintUsages,
     ) -> Result<BestIndex>;
 
     /// Create a new cursor used for accessing a virtual table.
@@ -313,11 +311,11 @@ pub trait VTabSafe<'vtab>: Sized {
 /// Wrapper for `VTabSafe` that implements `VTab`
 #[repr(C)]
 pub struct SafeVTabWrapper<'vtab, T: VTabSafe<'vtab>> {
-   /// Base class. Must be first
-   base: sqlite3_vtab,
-   /* Virtual table implementations will typically add additional fields */
-   inner: T,
-   phantom: PhantomData<&'vtab ()>,
+    /// Base class. Must be first
+    base: sqlite3_vtab,
+    /* Virtual table implementations will typically add additional fields */
+    inner: T,
+    phantom: PhantomData<&'vtab ()>,
 }
 unsafe impl<'vtab, T: VTabSafe<'vtab>> VTab<'vtab> for SafeVTabWrapper<'vtab, T> {
     type Aux = <T as VTabSafe<'vtab>>::Aux;
@@ -331,14 +329,18 @@ unsafe impl<'vtab, T: VTabSafe<'vtab>> VTab<'vtab> for SafeVTabWrapper<'vtab, T>
         let (sql_dec, inner) = T::connect(db, aux, args)?;
         Ok((
             sql_dec,
-            Self { inner, phantom: PhantomData, base: Default::default() },
+            Self {
+                inner,
+                phantom: PhantomData,
+                base: Default::default(),
+            },
         ))
     }
 
     fn best_index(
         &self,
         info: &IndexInfo,
-        constraint_usages: &mut IndexConstraintUsages
+        constraint_usages: &mut IndexConstraintUsages,
     ) -> Result<BestIndex> {
         self.inner.best_index(info, constraint_usages)
     }
@@ -380,11 +382,11 @@ pub trait CreateVTabSafe<'vtab>: VTabSafe<'vtab> {
 /// Wrapper for `CreateVTabVTabSafe` that implements `CreateVTab`
 #[repr(C)]
 pub struct SafeCreateVTabWrapper<'vtab, T: CreateVTabSafe<'vtab>> {
-   /// Base class. Must be first
-   base: sqlite3_vtab,
-   /* Virtual table implementations will typically add additional fields */
-   inner: T,
-   phantom: PhantomData<&'vtab ()>,
+    /// Base class. Must be first
+    base: sqlite3_vtab,
+    /* Virtual table implementations will typically add additional fields */
+    inner: T,
+    phantom: PhantomData<&'vtab ()>,
 }
 unsafe impl<'vtab, T: CreateVTabSafe<'vtab>> VTab<'vtab> for SafeCreateVTabWrapper<'vtab, T> {
     type Aux = <T as VTabSafe<'vtab>>::Aux;
@@ -398,14 +400,18 @@ unsafe impl<'vtab, T: CreateVTabSafe<'vtab>> VTab<'vtab> for SafeCreateVTabWrapp
         let (sql_dec, inner) = T::connect(db, aux, args)?;
         Ok((
             sql_dec,
-            Self { inner, phantom: PhantomData, base: Default::default() },
+            Self {
+                inner,
+                phantom: PhantomData,
+                base: Default::default(),
+            },
         ))
     }
 
     fn best_index(
         &self,
         info: &IndexInfo,
-        constraint_usages: &mut IndexConstraintUsages
+        constraint_usages: &mut IndexConstraintUsages,
     ) -> Result<BestIndex> {
         self.inner.best_index(info, constraint_usages)
     }
@@ -424,7 +430,11 @@ impl<'vtab, T: CreateVTabSafe<'vtab>> CreateVTab<'vtab> for SafeCreateVTabWrappe
         let (sql_dec, inner) = T::create(db, aux, args)?;
         Ok((
             sql_dec,
-            Self { inner, phantom: PhantomData, base: Default::default() },
+            Self {
+                inner,
+                phantom: PhantomData,
+                base: Default::default(),
+            },
         ))
     }
 

--- a/src/vtab/mod.rs
+++ b/src/vtab/mod.rs
@@ -364,6 +364,7 @@ impl<'a> IndexInfo<'a> {
 }
 
 /// The return type of VTab::best_index
+#[derive(Copy, Clone, Debug, Default)]
 pub struct BestIndex {
     /// Number used to identify the index
     pub idx_num: c_int,

--- a/src/vtab/series.rs
+++ b/src/vtab/series.rs
@@ -10,17 +10,19 @@ use std::os::raw::c_int;
 use crate::ffi;
 use crate::types::Type;
 use crate::vtab::{
-    eponymous_only_module_safe, Context, IndexConstraintOp,
-    IndexInfo, IndexConstraintUsages, BestIndex,
-    VTabSafe, VTabConnection, VTabCursor,
-    Values,
+    eponymous_only_module_safe, BestIndex, Context, IndexConstraintOp, IndexConstraintUsages,
+    IndexInfo, VTabConnection, VTabCursor, VTabSafe, Values,
 };
 use crate::{Connection, Error, Result};
 
 /// Register the "generate_series" module.
 pub fn load_module(conn: &Connection) -> Result<()> {
     let aux: Option<()> = None;
-    conn.create_module("generate_series", eponymous_only_module_safe::<SeriesTab>(), aux)
+    conn.create_module(
+        "generate_series",
+        eponymous_only_module_safe::<SeriesTab>(),
+        aux,
+    )
 }
 
 // Column numbers

--- a/src/vtab/series.rs
+++ b/src/vtab/series.rs
@@ -10,10 +10,8 @@ use std::os::raw::c_int;
 use crate::ffi;
 use crate::types::Type;
 use crate::vtab::{
-    eponymous_only_module, Context, IndexConstraintOp,
-    IndexInfo, IndexConstraintUsages, BestIndex,
-    VTab, VTabConnection, VTabCursor,
-    Values,
+    eponymous_only_module, BestIndex, Context, IndexConstraintOp, IndexConstraintUsages, IndexInfo,
+    VTab, VTabConnection, VTabCursor, Values,
 };
 use crate::{Connection, Error, Result};
 
@@ -75,7 +73,7 @@ unsafe impl<'vtab> VTab<'vtab> for SeriesTab {
     fn best_index(
         &self,
         info: &IndexInfo,
-        constraint_usages: &mut IndexConstraintUsages
+        constraint_usages: &mut IndexConstraintUsages,
     ) -> Result<BestIndex> {
         // The query plan bitmask
         let mut idx_num: QueryPlanFlags = QueryPlanFlags::empty();
@@ -117,7 +115,9 @@ unsafe impl<'vtab> VTab<'vtab> for SeriesTab {
             ));
         }
 
-        let mut ret = BestIndex { ..Default::default() };
+        let mut ret = BestIndex {
+            ..Default::default()
+        };
         if idx_num.contains(QueryPlanFlags::BOTH) {
             // Both start= and stop= boundaries are available.
             ret.estimated_cost = f64::from(

--- a/tests/vtab.rs
+++ b/tests/vtab.rs
@@ -4,9 +4,8 @@
 #[test]
 fn test_dummy_module() -> rusqlite::Result<()> {
     use rusqlite::vtab::{
-        eponymous_only_module, sqlite3_vtab, sqlite3_vtab_cursor, Context,
-        IndexInfo, IndexConstraintUsages, BestIndex,
-        VTab, VTabConnection, VTabCursor, Values,
+        eponymous_only_module, sqlite3_vtab, sqlite3_vtab_cursor, BestIndex, Context,
+        IndexConstraintUsages, IndexInfo, VTab, VTabConnection, VTabCursor, Values,
     };
     use rusqlite::{version_number, Connection, Result};
     use std::marker::PhantomData;
@@ -38,7 +37,7 @@ fn test_dummy_module() -> rusqlite::Result<()> {
         fn best_index(
             &self,
             _info: &IndexInfo,
-            _constraint_usages: &mut IndexConstraintUsages
+            _constraint_usages: &mut IndexConstraintUsages,
         ) -> Result<BestIndex> {
             Ok(BestIndex {
                 idx_num: 0,

--- a/tests/vtab.rs
+++ b/tests/vtab.rs
@@ -4,8 +4,9 @@
 #[test]
 fn test_dummy_module() -> rusqlite::Result<()> {
     use rusqlite::vtab::{
-        eponymous_only_module, sqlite3_vtab, sqlite3_vtab_cursor, Context, IndexInfo, VTab,
-        VTabConnection, VTabCursor, Values,
+        eponymous_only_module, sqlite3_vtab, sqlite3_vtab_cursor, Context,
+        IndexInfo, IndexConstraintUsages, BestIndex,
+        VTab, VTabConnection, VTabCursor, Values,
     };
     use rusqlite::{version_number, Connection, Result};
     use std::marker::PhantomData;
@@ -34,9 +35,17 @@ fn test_dummy_module() -> rusqlite::Result<()> {
             Ok(("CREATE TABLE x(value)".to_owned(), vtab))
         }
 
-        fn best_index(&self, info: &mut IndexInfo) -> Result<()> {
-            info.set_estimated_cost(1.);
-            Ok(())
+        fn best_index(
+            &self,
+            _info: &IndexInfo,
+            _constraint_usages: &mut IndexConstraintUsages
+        ) -> Result<BestIndex> {
+            Ok(BestIndex {
+                idx_num: 0,
+                order_by_consumed: false,
+                estimated_cost: 1.,
+                estimated_rows: i64::MAX,
+            })
         }
 
         fn open(&'vtab self) -> Result<DummyTabCursor<'vtab>> {


### PR DESCRIPTION
This PR depends on #1001 .

This PR adds `VTabSafe` and `CreateVTabSafe` which are trait without `unsafe` and modules can be created using `read_only_module_safe` and `eponymous_only_module_safe` respectively.

This would make it much easier to implement without the hassle of `sqlite3_vtab` and `#[repr(C)]`, which user of this crate might forget to add to their own vtable implementation.

**HELP WANTED**

After updating `csvtab` to use `CreateVTabSafe`, it failed to open `test.csv`, which is extremely confusing for me and I failed to fixed it.

I would appreciate if anyone can help me fix the error!