### PR TITLE
Make the empty placeholder params be Send + Sync

### DIFF
--- a/src/params.rs
+++ b/src/params.rs
@@ -169,8 +169,8 @@ pub trait Params: Sealed {
 // Explicitly impl for empty array. Critically, for `conn.execute([])` to be
 // unambiguous, this must be the *only* implementation for an empty array. This
 // avoids `NO_PARAMS` being a necessary part of the API.
-impl Sealed for [&dyn ToSql; 0] {}
-impl Params for [&dyn ToSql; 0] {
+impl Sealed for [&(dyn ToSql + Send + Sync); 0] {}
+impl Params for [&(dyn ToSql + Send + Sync); 0] {
     #[inline]
     fn __bind_in(self, stmt: &mut Statement<'_>) -> Result<()> {
         // Note: Can't just return `Ok(())` — `Statement::bind_parameters`


### PR DESCRIPTION
This shouldn't break any code, I think (since `&(dyn ToSql + Send + Sync)` is also `&dyn ToSql`), and should allow people to send empty params arrays to other threads.