### PR TITLE
CI: Temporarially disable coverage for features that require bindgen

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -185,7 +185,12 @@ jobs:
       - name: Run cargo-tarpaulin
         uses: actions-rs/tarpaulin@v0.1
         with:
-          args: '--features "bundled-full session buildtime_bindgen"'
+          # FIXME: Uncomment to re-enable `session` feature once the situation
+          # with bitvec and tarpaulin is resolved:
+          # https://github.com/rusqlite/rusqlite/issues/1004
+          #
+          # args: '--features "bundled-full session buildtime_bindgen"'
+          args: "--features bundled-full"
 
       - name: Upload to codecov.io
         uses: codecov/codecov-action@v1


### PR DESCRIPTION
I'm tired of getting emails about this failure.

See #1004.