### PR TITLE
Add as_type_or_null to ValueRef

### DIFF
--- a/src/types/value_ref.rs
+++ b/src/types/value_ref.rs
@@ -45,6 +45,19 @@ impl<'a> ValueRef<'a> {
         }
     }
 
+    /// If `self` is case `Null` returns None.
+    /// If `self` is case `Integer`, returns the integral value.
+    /// Otherwise returns [`Err(Error::InvalidColumnType)`](crate::Error::
+    /// InvalidColumnType).
+    #[inline]
+    pub fn as_i64_or_null(&self) -> FromSqlResult<Option<i64>> {
+        match *self {
+            ValueRef::Null => Ok(None),
+            ValueRef::Integer(i) => Ok(Some(i)),
+            _ => Err(FromSqlError::InvalidType),
+        }
+    }
+
     /// If `self` is case `Real`, returns the floating point value. Otherwise,
     /// returns [`Err(Error::InvalidColumnType)`](crate::Error::
     /// InvalidColumnType).
@@ -52,6 +65,19 @@ impl<'a> ValueRef<'a> {
     pub fn as_f64(&self) -> FromSqlResult<f64> {
         match *self {
             ValueRef::Real(f) => Ok(f),
+            _ => Err(FromSqlError::InvalidType),
+        }
+    }
+
+    /// If `self` is case `Null` returns None.
+    /// If `self` is case `Real`, returns the floating point value.
+    /// Otherwise returns [`Err(Error::InvalidColumnType)`](crate::Error::
+    /// InvalidColumnType).
+    #[inline]
+    pub fn as_f64_or_null(&self) -> FromSqlResult<Option<f64>> {
+        match *self {
+            ValueRef::Null => Ok(None),
+            ValueRef::Real(f) => Ok(Some(f)),
             _ => Err(FromSqlError::InvalidType),
         }
     }
@@ -68,6 +94,21 @@ impl<'a> ValueRef<'a> {
         }
     }
 
+    /// If `self` is case `Null` returns None.
+    /// If `self` is case `Text`, returns the string value.
+    /// Otherwise returns [`Err(Error::InvalidColumnType)`](crate::Error::
+    /// InvalidColumnType).
+    #[inline]
+    pub fn as_str_or_null(&self) -> FromSqlResult<Option<&'a str>> {
+        match *self {
+            ValueRef::Null => Ok(None),
+            ValueRef::Text(t) => std::str::from_utf8(t)
+                .map_err(|e| FromSqlError::Other(Box::new(e)))
+                .map(Some),
+            _ => Err(FromSqlError::InvalidType),
+        }
+    }
+
     /// If `self` is case `Blob`, returns the byte slice. Otherwise, returns
     /// [`Err(Error::InvalidColumnType)`](crate::Error::InvalidColumnType).
     #[inline]
@@ -78,12 +119,37 @@ impl<'a> ValueRef<'a> {
         }
     }
 
+    /// If `self` is case `Null` returns None.
+    /// If `self` is case `Blob`, returns the byte slice.
+    /// Otherwise returns [`Err(Error::InvalidColumnType)`](crate::Error::
+    /// InvalidColumnType).
+    #[inline]
+    pub fn as_blob_or_null(&self) -> FromSqlResult<Option<&'a [u8]>> {
+        match *self {
+            ValueRef::Null => Ok(None),
+            ValueRef::Blob(b) => Ok(Some(b)),
+            _ => Err(FromSqlError::InvalidType),
+        }
+    }
+
     /// Returns the byte slice that makes up this ValueRef if it's either
     /// [`ValueRef::Blob`] or [`ValueRef::Text`].
     #[inline]
     pub fn as_bytes(&self) -> FromSqlResult<&'a [u8]> {
         match self {
             ValueRef::Text(s) | ValueRef::Blob(s) => Ok(s),
+            _ => Err(FromSqlError::InvalidType),
+        }
+    }
+
+    /// If `self` is case `Null` returns None.
+    /// If `self` is [`ValueRef::Blob`] or [`ValueRef::Text`] returns the byte
+    /// slice that makes up this value
+    #[inline]
+    pub fn as_bytes_or_null(&self) -> FromSqlResult<Option<&'a [u8]>> {
+        match *self {
+            ValueRef::Null => Ok(None),
+            ValueRef::Text(s) | ValueRef::Blob(s) => Ok(Some(s)),
             _ => Err(FromSqlError::InvalidType),
         }
     }


### PR DESCRIPTION
In most cases a column will contain just single type, like `Text` or `Real`.
However very often it will contain mixed `Nulls` with non null values.

Typical use case for non-null column from `test_get_raw`:
```
        while let Some(row) = rows.next()? {
            let i: i64 = row.get_ref(0)?.as_i64()?;
        }
```

Current approach if column can be either i64 or null:
```
        while let Some(row) = rows.next()? {
            let i: Option<i64> = match row.get_ref(0)? {
                ValueRef::Null => None,
                ValueRef::Integer(i) => Ok(Some(i)),
                _ => return Err(FromSqlError::InvalidType),
            }
        }
```

New approach allows:
```
        while let Some(row) = rows.next()? {
            let i: Option<i64> = row.get_ref(0)?.as_i64_or_null()?;
        }
```