### PR TITLE
Run to completion doesn't allow full copy

### DIFF
--- a/src/backup.rs
+++ b/src/backup.rs
@@ -278,6 +278,8 @@ impl Backup<'_, '_> {
     /// current progress of the backup. Note that is possible the progress may
     /// not change if the step returns `Busy` or `Locked` even though the
     /// backup is still running.
+    /// 
+    /// If `pages_per_step` is `-1` the entire database will be copied in a single step.
     ///
     /// # Failure
     ///
@@ -291,7 +293,7 @@ impl Backup<'_, '_> {
     ) -> Result<()> {
         use self::StepResult::{Busy, Done, Locked, More};
 
-        assert!(pages_per_step > 0, "pages_per_step must be positive");
+        assert!(pages_per_step > 0 || pages_per_step == -1, "pages_per_step must be positive or -1 to indicate unlimited");
 
         loop {
             let r = self.step(pages_per_step)?;


### PR DESCRIPTION
The sqlite backup step function allows using -1 as the page size to indicate to copy the entire database in a single step. This is usefull when trying to load a database into memory from a file.

## Previous Behaviour
### Input
```rust
let filedb = Connection::open(&tdb_file).unwrap();
let filedb = Connection::open(&file_path).unwrap();
let mut memory_db = Connection::open_in_memory().unwrap();
let backup = backup::Backup::new(&filedb, &mut memory_db );
match backup {
    Ok(backup) => {
        let _ =backup.run_to_completion(-1, std::time::Duration::from_millis(0), None);
        println!("load of {} into memory is complete", &file_path.display());
    },
    Err(_) => todo!(),
}
```
### Result
Panic at backup.rs line 296 "pages_per_step must be positive"

## New Behaviour
### Input
```rust
let filedb = Connection::open(&tdb_file).unwrap();
let filedb = Connection::open(&file_path).unwrap();
let mut memory_db = Connection::open_in_memory().unwrap();
let backup = backup::Backup::new(&filedb, &mut memory_db );
match backup {
    Ok(backup) => {
        let _ =backup.run_to_completion(-1, std::time::Duration::from_millis(0), None);
        println!("load of {} into memory is complete", &file_path.display());
    },
    Err(_) => todo!(),
}
```
### Result
Database is backed up into memory successfully