### PR TITLE
MSVC: Allow static linking against the Visual C++ Runtime 

### DIFF
--- a/libsqlite3-sys/build.rs
+++ b/libsqlite3-sys/build.rs
@@ -221,6 +221,11 @@ mod build_bundled {
             cfg.flag("-fsanitize=address");
         }
 
+        // If explicitly requested: enable static linking against the Microsoft Visual C++ Runtime to avoid dependencies on vcruntime140.dll and similar libraries.
+        if cfg!(target_feature = "crt-static") && is_compiler("msvc") {
+            cfg.static_crt(true);
+        }
+
         // Older versions of visual studio don't support c99 (including isnan), which
         // causes a build failure when the linker fails to find the `isnan`
         // function. `sqlite` provides its own implementation, using the fact


### PR DESCRIPTION
This small contributution enables static linking against the Microsoft Visual C++ Runtime [if it is explicitely requested by the user](https://github.com/rust-lang/rfcs/blob/master/text/1721-crt-static.md). Without the flag for MSVC, the linking may fail given the implicit dependency on _vcruntime140.dll_ when using "bundled-" features.