### PR TITLE
bundled-sqlcipher-vendored-openssl doesn't compile on windows

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rusqlite"
-version = "0.26.0"
+version = "0.26.1"
 authors = ["The rusqlite developers"]
 edition = "2018"
 description = "Ergonomic wrapper for SQLite"

--- a/libsqlite3-sys/build.rs
+++ b/libsqlite3-sys/build.rs
@@ -181,10 +181,15 @@ mod build_bundled {
 
             if cfg!(feature = "bundled-sqlcipher-vendored-openssl") {
                 cfg.include(std::env::var("DEP_OPENSSL_INCLUDE").unwrap());
-                println!("cargo:rustc-link-lib=static=crypto"); // cargo will
-                                                                // resolve downstream
-                                                                // to the static
-                                                                // lib in openssl-sys
+                if is_windows {
+                    println!("cargo:rustc-link-lib=static=libcrypto");
+                }
+                else {
+                    println!("cargo:rustc-link-lib=static=crypto"); // cargo will
+                                                                    // resolve downstream
+                                                                    // to the static
+                                                                    // lib in openssl-sys
+                }
             } else if is_windows {
                 // FIXME README says that bundled-sqlcipher is Unix only, and the sources are
                 // configured on a Unix machine. So maybe this should be made unreachable.


### PR DESCRIPTION
My solution to https://github.com/rusqlite/rusqlite/issues/1025