### PR TITLE
Update readme, prep for a cutting a libsqlite3-sys@v0.23.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ features](https://doc.rust-lang.org/cargo/reference/manifest.html#the-features-s
   `Url` type from the [`url` crate](https://crates.io/crates/url).
 * `bundled` uses a bundled version of SQLite.  This is a good option for cases where linking to SQLite is complicated, such as Windows.
 * `sqlcipher` looks for the SQLCipher library to link against instead of SQLite. This feature overrides `bundled`.
-* `bundled-sqlcipher` uses a bundled version of SQLCipher (more or less Unix only at the moment). This searches for and links against a system-installed crypto library to provide the crypto implementation.
+* `bundled-sqlcipher` uses a bundled version of SQLCipher. This searches for and links against a system-installed crypto library to provide the crypto implementation.
 * `bundled-sqlcipher-vendored-openssl` allows using bundled-sqlcipher with a vendored version of OpenSSL (via the `openssl-sys` crate) as the crypto provider.
   - As the name implies this depends on the `bundled-sqlcipher` feature, and automatically turns it on.
   - If turned on, this uses the [`openssl-sys`](https://crates.io/crates/openssl-sys) crate, with the `vendored` feature enabled in order to build and bundle the OpenSSL crypto library.

--- a/libsqlite3-sys/Cargo.toml
+++ b/libsqlite3-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libsqlite3-sys"
-version = "0.23.0"
+version = "0.23.1"
 authors = ["The rusqlite developers"]
 edition = "2018"
 repository = "https://github.com/rusqlite/rusqlite"


### PR DESCRIPTION
I think everything is compatible, so we only need a patch release 0.23.1, and only for the -sys. This just fixes the bundled-sqlcipher and -vendored-openssl logic so that it 

Thanks to @douloiha for (even unintentionally) reminding me about the fact I this should get into a followup https://github.com/rusqlite/rusqlite/pull/860#issuecomment-853304210, and to @BlackHoleFox for actually doing the work after I whined about nonesense elsewhere online.

(Also thanks to @dubiousjim for doing the initial version of the feature, and sorry its so long before it became usable)