### PR TITLE
Only use minimal features for `chrono` crate.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -100,7 +100,7 @@ bundled-full = ["modern-full", "bundled"]
 time = { version = "0.3.0", features = ["formatting", "macros", "parsing"], optional = true }
 bitflags = "1.2"
 hashlink = "0.7"
-chrono = { version = "0.4", optional = true }
+chrono = { version = "0.4", optional = true, default-features = false, features = ["clock"] }
 serde_json = { version = "1.0", optional = true }
 csv = { version = "1.1", optional = true }
 url = { version = "2.1", optional = true }


### PR DESCRIPTION
The default features for `chrono` include the `oldtime` feature,
which provides compatibility with `time` version 0.1.43.  But
old versions of the `time` are affected by RUSTSEC-2020-0071.html ,
which causes any crate built with rustsql's `chrono` feature to fail
a cargo-audit check.

This patch minimizes the features used from `chrono` to include only
the `clock` feature, which appears to be sufficient to get the tests
to pass.

(I don't believe that the bug in `time` reflects an actual
vulnerability in `rusqlite`, since even when `chrono` is using
`time`, it only does so in order to expose the same `Duration`
type.)