### PR TITLE
Link libatomic on Android x86

### DIFF
--- a/libsqlite3-sys/build.rs
+++ b/libsqlite3-sys/build.rs
@@ -180,6 +180,12 @@ mod build_bundled {
             if cfg!(feature = "bundled-sqlcipher-vendored-openssl") {
                 cfg.include(std::env::var("DEP_OPENSSL_INCLUDE").unwrap());
                 // cargo will resolve downstream to the static lib in openssl-sys
+                
+                // on android x86 since openssl 3.0.0 we need to link -latomic
+                // https://github.com/openssl/openssl/issues/14083
+                if super::android_target() {
+                    println!("cargo:rustc-link-lib=dylib=atomic");
+                }
             } else if is_windows {
                 // Windows without `-vendored-openssl` takes this to link against a prebuilt OpenSSL lib
                 cfg.include(inc_dir.to_string_lossy().as_ref());


### PR DESCRIPTION
Related to https://github.com/openssl/openssl/issues/14083

You can reproduce the following error by running
```bash
git clone https://github.com/rusqlite/rusqlite
cd rusqlite
cargo ndk --target x86 --platform 29 -- test --no-run --features bundled-sqlcipher-vendored-openssl
```
output
```bash
  = note: ld: error: undefined symbol: __atomic_is_lock_free
          >>> referenced by threads_pthread.c:219 (crypto/threads_pthread.c:219)
          >>>               libcrypto-lib-threads_pthread.o:(CRYPTO_atomic_or) in archive /home/ecy/git/rusqlite/target/i686-linux-android/debug/deps/libopenssl_sys-f48403a73893547d.rlib
          >>> referenced by threads_pthread.c:244 (crypto/threads_pthread.c:244)
          >>>               libcrypto-lib-threads_pthread.o:(CRYPTO_atomic_load) in archive /home/ecy/git/rusqlite/target/i686-linux-android/debug/deps/libopenssl_sys-f48403a73893547d.rlib
          
          ld: error: undefined symbol: __atomic_fetch_or_8
          >>> referenced by threads_pthread.c:220 (crypto/threads_pthread.c:220)
          >>>               libcrypto-lib-threads_pthread.o:(CRYPTO_atomic_or) in archive /home/ecy/git/rusqlite/target/i686-linux-android/debug/deps/libopenssl_sys-f48403a73893547d.rlib
          
          ld: error: undefined symbol: __atomic_load
          >>> referenced by threads_pthread.c:245 (crypto/threads_pthread.c:245)
          >>>               libcrypto-lib-threads_pthread.o:(CRYPTO_atomic_load) in archive /home/ecy/git/rusqlite/target/i686-linux-android/debug/deps/libopenssl_sys-f48403a73893547d.rlib
          clang: error: linker command failed with exit code 1 (use -v to see invocation)
          

error: build failed

```