### PR TITLE
libsqlite3-sys: darwin: fix crypto link framework

### DIFF
--- a/libsqlite3-sys/build.rs
+++ b/libsqlite3-sys/build.rs
@@ -192,7 +192,7 @@ mod build_bundled {
                 println!("cargo:rustc-link-search={}", lib_dir.to_string_lossy());
             } else if is_apple {
                 cfg.flag("-DSQLCIPHER_CRYPTO_CC");
-                println!("cargo:rustc-link-lib=framework=SecurityFoundation");
+                println!("cargo:rustc-link-lib=framework=Security");
                 println!("cargo:rustc-link-lib=framework=CoreFoundation");
             } else {
                 // branch not taken on Windows, just `crypto` is fine.


### PR DESCRIPTION
SecurityFoundation.framework is an unrelated macOS framework which does not directly provide cryptography functions. This framework also doesn't exist on iOS, which breaks linking This commit changes to link against Security.framework instead, as noted in the SQLCipher [docs](https://www.zetetic.net/blog/2013/6/27/sqlcipher-220-release.html).