### PR TITLE
Include varying positional param types in docs

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -513,7 +513,7 @@ impl Connection {
     /// ### With positional params of varying types
     ///
     /// ```rust,no_run
-    /// # use rusqlite::{Connection};
+    /// # use rusqlite::{params, Connection};
     /// fn update_rows(conn: &Connection) {
     ///     match conn.execute("UPDATE foo SET bar = 'baz' WHERE qux = ?1 AND quux = ?2", params![1i32, 1.5f64]) {
     ///         Ok(updated) => println!("{} rows were updated", updated),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -515,7 +515,7 @@ impl Connection {
     /// ```rust,no_run
     /// # use rusqlite::{Connection};
     /// fn update_rows(conn: &Connection) {
-    ///     match conn.execute("UPDATE foo SET bar = 'baz' WHERE qux = ?", [1i32]) {
+    ///     match conn.execute("UPDATE foo SET bar = 'baz' WHERE qux = ?1 AND quux = ?2", params![1i32, 1.5f64]) {
     ///         Ok(updated) => println!("{} rows were updated", updated),
     ///         Err(err) => println!("update failed: {}", err),
     ///     }


### PR DESCRIPTION
Resolves #1029.

Currently the documentation for `lib::execute` has the same examples for both `With positional params` and `With positional params of varying types`.

In this PR I updated the documentation with a more helpful example.

Disclaimer: I am new to both Rust and `rusqlite` so apologies in advance if this is not the best method to go about this 🙃 