### PR TITLE
Revert "CI: Temporarially disable coverage for features that require bindgen"

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -185,12 +185,7 @@ jobs:
       - name: Run cargo-tarpaulin
         uses: actions-rs/tarpaulin@v0.1
         with:
-          # FIXME: Uncomment to re-enable `session` feature once the situation
-          # with bitvec and tarpaulin is resolved:
-          # https://github.com/rusqlite/rusqlite/issues/1004
-          #
-          # args: '--features "bundled-full session buildtime_bindgen"'
-          args: "--features bundled-full"
+          args: '--features "bundled-full session buildtime_bindgen"'
 
       - name: Upload to codecov.io
         uses: codecov/codecov-action@v1


### PR DESCRIPTION
This reverts commit a55101fbfae46a79d15229890413f5ba3f3aaa53.

Fix #1004