### PR TITLE
Fix clippy warning

### DIFF
--- a/src/cache.rs
+++ b/src/cache.rs
@@ -60,6 +60,9 @@ impl Connection {
 // #[derive(Debug)] // FIXME: https://github.com/kyren/hashlink/pull/4
 pub struct StatementCache(RefCell<LruCache<Arc<str>, RawStatement>>);
 
+#[allow(clippy::non_send_fields_in_send_ty)]
+unsafe impl Send for StatementCache {}
+
 /// Cacheable statement.
 ///
 /// Statement will return automatically to the cache by default.

--- a/src/inner_connection.rs
+++ b/src/inner_connection.rs
@@ -38,6 +38,8 @@ pub struct InnerConnection {
     owned: bool,
 }
 
+unsafe impl Send for InnerConnection {}
+
 impl InnerConnection {
     #[allow(clippy::mutex_atomic)]
     #[inline]


### PR DESCRIPTION
warning: this implementation is unsound, as some fields in `Connection` are `!Send`
   --> src/lib.rs:339:1
339 | unsafe impl Send for Connection {}