### PR TITLE
Undo transition to edition 2021, prep release 0.26.3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "rusqlite"
-version = "0.26.2"
+version = "0.26.3"
 authors = ["The rusqlite developers"]
-edition = "2021"
+edition = "2018"
 description = "Ergonomic wrapper for SQLite"
 repository = "https://github.com/rusqlite/rusqlite"
 documentation = "http://docs.rs/rusqlite/"

--- a/src/blob/mod.rs
+++ b/src/blob/mod.rs
@@ -272,6 +272,7 @@ impl Blob<'_> {
     /// Return the current size in bytes of the BLOB.
     #[inline]
     pub fn len(&self) -> usize {
+        use std::convert::TryInto;
         self.size().try_into().unwrap()
     }
 

--- a/src/util/sqlite_string.rs
+++ b/src/util/sqlite_string.rs
@@ -103,6 +103,7 @@ impl SqliteMallocString {
     /// This means it's safe to use in extern "C" functions even outside of
     /// catch_unwind.
     pub(crate) fn from_str(s: &str) -> Self {
+        use std::convert::TryFrom;
         let s = if s.as_bytes().contains(&0) {
             std::borrow::Cow::Owned(make_nonnull(s))
         } else {


### PR DESCRIPTION
Let's wait til 0.27.0 for this (at least).

Fixes https://github.com/rusqlite/rusqlite/issues/1056