### PR TITLE
Adding support for rust_decimal

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -77,6 +77,7 @@ modern-full = [
     "collation",
     "column_decltype",
     "csvtab",
+    "rust_decimal",
     "extra_check",
     "functions",
     "hooks",
@@ -110,6 +111,7 @@ fallible-iterator = "0.2"
 fallible-streaming-iterator = "0.1"
 memchr = "2.3"
 uuid = { version = "0.8", optional = true }
+rust_decimal = { version = "1.18.0", optional = true }
 smallvec = "1.6.1"
 
 [dev-dependencies]

--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ features](https://doc.rust-lang.org/cargo/reference/manifest.html#the-features-s
 * [`csvtab`](https://sqlite.org/csv.html), CSV virtual table written in Rust. (Implies `vtab`.)
 * [`array`](https://sqlite.org/carray.html), The `rarray()` Table-Valued Function. (Implies `vtab`.)
 * `i128_blob` allows storing values of type `i128` type in SQLite databases. Internally, the data is stored as a 16 byte big-endian blob, with the most significant bit flipped, which allows ordering and comparison between different blobs storing i128s to work as expected.
+* `rust_decimal` allows storing and retrieving `Decimal` values from the [`rust_decimal`](https://docs.rs/rust_decimal/) crate.
 * `uuid` allows storing and retrieving `Uuid` values from the [`uuid`](https://docs.rs/uuid/) crate using blobs.
 * [`session`](https://sqlite.org/sessionintro.html), Session module extension. Requires `buildtime_bindgen` feature. (Implies `hooks`.)
 * `extra_check` fail when a query passed to execute is readonly or has a column count > 0.

--- a/src/row.rs
+++ b/src/row.rs
@@ -302,6 +302,12 @@ impl<'stmt> Row<'stmt> {
                 self.stmt.column_name_unwrap(idx).into(),
                 value.data_type(),
             ),
+            #[cfg(feature = "rust_decimal")]
+            FromSqlError::InvalidDecimal(_) => Error::InvalidColumnType(
+                idx,
+                self.stmt.column_name_unwrap(idx).into(),
+                value.data_type(),
+            ),
         })
     }
 

--- a/src/types/decimal.rs
+++ b/src/types/decimal.rs
@@ -1,0 +1,79 @@
+//! [`ToSql`] and [`FromSql`] implementation for [`rust_decimal::Decimal`].
+use crate::types::{FromSql, FromSqlError, FromSqlResult, ToSql, ToSqlOutput, ValueRef};
+use crate::Result;
+use rust_decimal::Decimal;
+use std::str::FromStr;
+
+fn parse_from_str(s: &str) -> Result<Decimal, FromSqlError> {
+    Decimal::from_str(s).map_err(FromSqlError::InvalidDecimal)
+}
+
+/// Serialize `Decimal` to text.
+impl ToSql for Decimal {
+    #[inline]
+    fn to_sql(&self) -> Result<ToSqlOutput<'_>> {
+        Ok(ToSqlOutput::from(self.to_string()))
+    }
+}
+
+/// Deserialize to `Decimal`.
+impl FromSql for Decimal {
+    #[inline]
+    fn column_result(value: ValueRef<'_>) -> FromSqlResult<Self> {
+        match value {
+            ValueRef::Integer(x) => Ok(Decimal::from(x)),
+            //Note: Parsing straight from f64 could cause loss of precision, when parsing from text works fine
+            // like for example f64::MAX
+            ValueRef::Real(x) => parse_from_str(&x.to_string()),
+            ValueRef::Text(_) => value.as_str().and_then(parse_from_str),
+            _ => Err(FromSqlError::InvalidType),
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::types::Type;
+    use crate::{params, Connection, Error, Result};
+
+    fn checked_memory_handle() -> Result<Connection> {
+        let db = Connection::open_in_memory()?;
+        db.execute_batch("CREATE TABLE Decimals (i INTEGER, v DECIMAL)")?;
+        Ok(db)
+    }
+
+    fn get_decimal(db: &Connection, id: i64) -> Result<Decimal> {
+        db.query_row("SELECT v FROM Decimals WHERE i = ?", [id], |r| r.get(0))
+    }
+
+    #[test]
+    fn test_sql_decimal() -> Result<()> {
+        let db = &checked_memory_handle()?;
+
+        let zero = Decimal::from(0);
+        let max_float = Decimal::from_str(&f64::MAX.to_string()).unwrap();
+        let max_decimal = Decimal::MAX;
+
+        db.execute(
+            "INSERT INTO Decimals (i, v) VALUES (0, ?), (1, ?), (2, ?), (3, ?)",
+            // also insert invalid data that will fail to decode to decimal
+            params![0, f64::MAX, max_decimal, "illegal"],
+        )?;
+
+        assert_eq!(get_decimal(db, 0)?, zero);
+        assert_eq!(get_decimal(db, 1)?, max_float);
+        // Currently the round-trip from Decimal::MAX can fail... The real error is a overflow
+        assert_eq!(
+            get_decimal(db, 2),
+            Err(Error::InvalidColumnType(0, "v".into(), Type::Real))
+        );
+        //This is in fact a parsing error...
+        assert_eq!(
+            get_decimal(db, 3),
+            Err(Error::InvalidColumnType(0, "v".into(), Type::Text))
+        );
+
+        Ok(())
+    }
+}

--- a/src/types/from_sql.rs
+++ b/src/types/from_sql.rs
@@ -28,6 +28,12 @@ pub enum FromSqlError {
     #[cfg_attr(docsrs, doc(cfg(feature = "uuid")))]
     InvalidUuidSize(usize),
 
+    /// Error returned when reading a `Decimal`. Only available when the `rust_decimal`
+    /// feature is enabled.
+    #[cfg(feature = "rust_decimal")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "rust_decimal")))]
+    InvalidDecimal(rust_decimal::Error),
+
     /// An error case available for implementors of the [`FromSql`] trait.
     Other(Box<dyn Error + Send + Sync + 'static>),
 }
@@ -41,6 +47,8 @@ impl PartialEq for FromSqlError {
             (FromSqlError::InvalidI128Size(s1), FromSqlError::InvalidI128Size(s2)) => s1 == s2,
             #[cfg(feature = "uuid")]
             (FromSqlError::InvalidUuidSize(s1), FromSqlError::InvalidUuidSize(s2)) => s1 == s2,
+            #[cfg(feature = "rust_decimal")]
+            (FromSqlError::InvalidDecimal(e1), FromSqlError::InvalidDecimal(e2)) => e1 == e2,
             (..) => false,
         }
     }
@@ -58,6 +66,10 @@ impl fmt::Display for FromSqlError {
             #[cfg(feature = "uuid")]
             FromSqlError::InvalidUuidSize(s) => {
                 write!(f, "Cannot read UUID value out of {} byte blob", s)
+            }
+            #[cfg(feature = "rust_decimal")]
+            FromSqlError::InvalidDecimal(ref x) => {
+                write!(f, "Cannot read Decimal value out of {} data", x)
             }
             FromSqlError::Other(ref err) => err.fmt(f),
         }

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -79,6 +79,9 @@ use std::fmt;
 #[cfg(feature = "chrono")]
 #[cfg_attr(docsrs, doc(cfg(feature = "chrono")))]
 mod chrono;
+#[cfg(feature = "rust_decimal")]
+#[cfg_attr(docsrs, doc(cfg(feature = "rust_decimal")))]
+mod decimal;
 mod from_sql;
 #[cfg(feature = "serde_json")]
 #[cfg_attr(docsrs, doc(cfg(feature = "serde_json")))]


### PR DESCRIPTION
Adding initial support [for decimal type ](https://github.com/rusqlite/rusqlite/issues/1059).

NOTE: Round-trip from [Decimal::MAX](https://docs.rs/rust_decimal/1.18.0/rust_decimal/struct.Decimal.html#associatedconstant.MAX) currently fail. 