### PR TITLE
Enable `modern-full` feature for docs.rs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -146,7 +146,7 @@ name = "exec"
 harness = false
 
 [package.metadata.docs.rs]
-features = [ "array", "backup", "blob", "chrono", "collation", "functions", "limits", "load_extension", "serde_json", "time", "trace", "url", "vtab", "window", "modern_sqlite", "column_decltype" ]
+features = ["modern-full"]
 all-features = false
 no-default-features = true
 default-target = "x86_64-unknown-linux-gnu"


### PR DESCRIPTION
I got a ping on https://users.rust-lang.org/t/implementation-of-fnonce-is-not-general-enough/68294/3 that rusqlite doesn't have `hooks` enabled on docs.rs. It also was missing a few others.

I think this change should fix that moving forward, although I don't remember why it doesn't use it already...