### PR TITLE
Clean up unlock_notify code a bit

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -125,6 +125,7 @@ mod statement;
 pub mod trace;
 mod transaction;
 pub mod types;
+#[cfg(feature = "unlock_notify")]
 mod unlock_notify;
 mod version;
 #[cfg(feature = "vtab")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1218,7 +1218,7 @@ mod test {
     fn test_open_failure() {
         let filename = "no_such_file.db";
         let result = Connection::open_with_flags(filename, OpenFlags::SQLITE_OPEN_READ_ONLY);
-        assert!(!result.is_ok());
+        assert!(result.is_err());
         let err = result.err().unwrap();
         if let Error::SqliteFailure(e, Some(msg)) = err {
             assert_eq!(ErrorCode::CannotOpen, e.code);

--- a/src/raw_statement.rs
+++ b/src/raw_statement.rs
@@ -1,5 +1,4 @@
 use super::ffi;
-use super::unlock_notify;
 use super::StatementStatus;
 #[cfg(feature = "modern_sqlite")]
 use crate::util::SqliteMallocString;
@@ -101,25 +100,38 @@ impl RawStatement {
         }
     }
 
-    #[cfg_attr(not(feature = "unlock_notify"), inline)]
+    #[inline]
+    #[cfg(not(feature = "unlock_notify"))]
     pub fn step(&self) -> c_int {
-        if cfg!(feature = "unlock_notify") {
-            let db = unsafe { ffi::sqlite3_db_handle(self.ptr) };
-            let mut rc;
-            loop {
-                rc = unsafe { ffi::sqlite3_step(self.ptr) };
-                if unsafe { !unlock_notify::is_locked(db, rc) } {
-                    break;
+        unsafe { ffi::sqlite3_step(self.ptr) }
+    }
+
+    #[cfg(feature = "unlock_notify")]
+    pub fn step(&self) -> c_int {
+        use crate::unlock_notify;
+        let mut db = core::ptr::null_mut::<ffi::sqlite3>();
+        loop {
+            unsafe {
+                let mut rc = ffi::sqlite3_step(self.ptr);
+                // Bail out early for success and errors unrelated to locking. We
+                // still need check `is_locked` after this, but checking now lets us
+                // avoid one or two (admittedly cheap) calls into SQLite that we
+                // don't need to make.
+                if (rc & 0xff) != ffi::SQLITE_LOCKED {
+                    break rc;
                 }
-                rc = unsafe { unlock_notify::wait_for_unlock_notify(db) };
+                if db.is_null() {
+                    db = ffi::sqlite3_db_handle(self.ptr);
+                }
+                if !unlock_notify::is_locked(db, rc) {
+                    break rc;
+                }
+                rc = unlock_notify::wait_for_unlock_notify(db);
                 if rc != ffi::SQLITE_OK {
-                    break;
+                    break rc;
                 }
                 self.reset();
             }
-            rc
-        } else {
-            unsafe { ffi::sqlite3_step(self.ptr) }
         }
     }
 

--- a/src/unlock_notify.rs
+++ b/src/unlock_notify.rs
@@ -1,22 +1,17 @@
 //! [Unlock Notification](http://sqlite.org/unlock_notify.html)
 
 use std::os::raw::c_int;
-#[cfg(feature = "unlock_notify")]
 use std::os::raw::c_void;
-#[cfg(feature = "unlock_notify")]
 use std::panic::catch_unwind;
-#[cfg(feature = "unlock_notify")]
 use std::sync::{Condvar, Mutex};
 
 use crate::ffi;
 
-#[cfg(feature = "unlock_notify")]
 struct UnlockNotification {
     cond: Condvar,      // Condition variable to wait on
     mutex: Mutex<bool>, // Mutex to protect structure
 }
 
-#[cfg(feature = "unlock_notify")]
 #[allow(clippy::mutex_atomic)]
 impl UnlockNotification {
     fn new() -> UnlockNotification {
@@ -27,21 +22,25 @@ impl UnlockNotification {
     }
 
     fn fired(&self) {
-        let mut flag = self.mutex.lock().unwrap();
+        let mut flag = unpoison(self.mutex.lock());
         *flag = true;
         self.cond.notify_one();
     }
 
     fn wait(&self) {
-        let mut fired = self.mutex.lock().unwrap();
+        let mut fired = unpoison(self.mutex.lock());
         while !*fired {
-            fired = self.cond.wait(fired).unwrap();
+            fired = unpoison(self.cond.wait(fired));
         }
     }
 }
 
+#[inline]
+fn unpoison<T>(r: Result<T, std::sync::PoisonError<T>>) -> T {
+    r.unwrap_or_else(std::sync::PoisonError::into_inner)
+}
+
 /// This function is an unlock-notify callback
-#[cfg(feature = "unlock_notify")]
 unsafe extern "C" fn unlock_notify_cb(ap_arg: *mut *mut c_void, n_arg: c_int) {
     use std::slice::from_raw_parts;
     let args = from_raw_parts(ap_arg as *const &UnlockNotification, n_arg as usize);
@@ -50,7 +49,6 @@ unsafe extern "C" fn unlock_notify_cb(ap_arg: *mut *mut c_void, n_arg: c_int) {
     }
 }
 
-#[cfg(feature = "unlock_notify")]
 pub unsafe fn is_locked(db: *mut ffi::sqlite3, rc: c_int) -> bool {
     rc == ffi::SQLITE_LOCKED_SHAREDCACHE
         || (rc & 0xFF) == ffi::SQLITE_LOCKED
@@ -87,17 +85,6 @@ pub unsafe fn wait_for_unlock_notify(db: *mut ffi::sqlite3) -> c_int {
     rc
 }
 
-#[cfg(not(feature = "unlock_notify"))]
-pub unsafe fn is_locked(_db: *mut ffi::sqlite3, _rc: c_int) -> bool {
-    unreachable!()
-}
-
-#[cfg(not(feature = "unlock_notify"))]
-pub unsafe fn wait_for_unlock_notify(_db: *mut ffi::sqlite3) -> c_int {
-    unreachable!()
-}
-
-#[cfg(feature = "unlock_notify")]
 #[cfg(test)]
 mod test {
     use crate::{Connection, OpenFlags, Result, Transaction, TransactionBehavior};


### PR DESCRIPTION
I was in this file and a couple things bugged me a bit.

- Avoid panicking if something poisons something in the UnlockNotification. This is mostly because we'd ignore the panic anyway — we wrap it in a `catch_unwind` (also, our `catch_unwind` use is a slightly wrong for FFI code, but fixing this is less of a pain).

    This is the main reason I did this, but I noticed the other stuff too while I was in the file.

- Move `#[cfg(feature = "unlock_notify")]` outside `mod unlock_notify`. This means we can get rid of the panicking implementations for when the feature is disabled.

    Also, it makes sure that if we ever need to add any more uses of the code from `mod unlock_notify` we are certain to handle the disabled feature case (admittedly, this is probably a theoretical concern.

- Restructure loop a bit in `RawStatement::step` a little to avoid calling into libsqlite3 more than we need to for the common/success path where we aren't locked.

    The calls this avoids are cheap, but this way enabling `unlock_notify` should have no cost at all unless you have a locking issue.

- Also, I guess nightly clippy got a new lint, so I fixed that too even though it's unrelated.