### PR TITLE
Replace Gitter with Discord

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![Build Status](https://github.com/rusqlite/rusqlite/workflows/CI/badge.svg)](https://github.com/rusqlite/rusqlite/actions)
 [![dependency status](https://deps.rs/repo/github/rusqlite/rusqlite/status.svg)](https://deps.rs/repo/github/rusqlite/rusqlite)
 [![Latest Version](https://img.shields.io/crates/v/rusqlite.svg)](https://crates.io/crates/rusqlite)
-[![Gitter](https://badges.gitter.im/rusqlite.svg)](https://gitter.im/rusqlite/community?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge)
+[![Discord Chat](https://img.shields.io/discord/927966344266256434.svg?logo=discord)](https://discord.gg/G6Se6Yzw)
 [![Docs](https://docs.rs/rusqlite/badge.svg)](https://docs.rs/rusqlite)
 [![codecov](https://codecov.io/gh/rusqlite/rusqlite/branch/master/graph/badge.svg)](https://codecov.io/gh/rusqlite/rusqlite)
 
@@ -212,7 +212,7 @@ here: https://github.com/rusqlite/rusqlite/graphs/contributors
 
 ## Community
 
-Currently there's a gitter channel set up for rusqlite [here](https://gitter.im/rusqlite/community).
+Feel free to join the [Rusqlite Discord Server](https://discord.gg/G6Se6Yzw) to discuss or get help with `rusqlite` or `libsqlite3-sys`.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -1,13 +1,12 @@
 # Rusqlite
 
-[![Travis Build Status](https://api.travis-ci.org/rusqlite/rusqlite.svg?branch=master)](https://travis-ci.org/rusqlite/rusqlite)
-[![AppVeyor Build Status](https://ci.appveyor.com/api/projects/status/github/rusqlite/rusqlite?branch=master&svg=true)](https://ci.appveyor.com/project/rusqlite/rusqlite)
-[![Build Status](https://github.com/rusqlite/rusqlite/workflows/CI/badge.svg)](https://github.com/rusqlite/rusqlite/actions)
-[![dependency status](https://deps.rs/repo/github/rusqlite/rusqlite/status.svg)](https://deps.rs/repo/github/rusqlite/rusqlite)
 [![Latest Version](https://img.shields.io/crates/v/rusqlite.svg)](https://crates.io/crates/rusqlite)
+[![Documentation](https://docs.rs/rusqlite/badge.svg)](https://docs.rs/rusqlite)
+[![Build Status (GitHub)](https://github.com/rusqlite/rusqlite/workflows/CI/badge.svg)](https://github.com/rusqlite/rusqlite/actions)
+[![Build Status (AppVeyor)](https://ci.appveyor.com/api/projects/status/github/rusqlite/rusqlite?branch=master&svg=true)](https://ci.appveyor.com/project/rusqlite/rusqlite)
+[![Code Coverage](https://codecov.io/gh/rusqlite/rusqlite/branch/master/graph/badge.svg)](https://codecov.io/gh/rusqlite/rusqlite)
+[![Dependency Status](https://deps.rs/repo/github/rusqlite/rusqlite/status.svg)](https://deps.rs/repo/github/rusqlite/rusqlite)
 [![Discord Chat](https://img.shields.io/discord/927966344266256434.svg?logo=discord)](https://discord.gg/G6Se6Yzw)
-[![Docs](https://docs.rs/rusqlite/badge.svg)](https://docs.rs/rusqlite)
-[![codecov](https://codecov.io/gh/rusqlite/rusqlite/branch/master/graph/badge.svg)](https://codecov.io/gh/rusqlite/rusqlite)
 
 Rusqlite is an ergonomic wrapper for using SQLite from Rust. It attempts to expose
 an interface similar to [rust-postgres](https://github.com/sfackler/rust-postgres).


### PR DESCRIPTION
So, I don't really like using Gitter, and only use it for Rusqlite. There's a much larger Rust community on Discord, and it's a chat service that I use regularly (and in practice I get more questions about `rusqlite` in various Rust servers than I do on Gitter).

So, I think we should switch away from Gitter, and have made a Discord server. I'm assuming that @gwenn doesn't care very much one way or another (given the comments in https://github.com/rusqlite/rusqlite/issues/738), so this is mostly because it will make my life easier[^1]. Of course, you're more than welcome to join if I've misjudged.

[^1]: I also hope that it will be better for users too — Discord is far more widely used, especially within Rust.

The invite link for the server is here: https://discord.gg/G6Se6Yzw. It's not *fully* set up to do everything I'd like yet[^2], but it's basically there. In the next week or so I'll figure out what to do with the Gitter server (how to retire it, since I don't think mirroring it would be nearly worth the trouble), but for now this is a start.

Also, the badges list had grown quite stale and somewhat misleading, so I cleaned it up while I'm here.

[^2]: Thankfully @khionu (discord wizard and member of the official Rust moderation team) has helped me set it up. They'll also be helping me manage the server, but this doesn't impact this repository in any way.