### PR TITLE
Use stable rust for doc checking in CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -43,8 +43,13 @@ jobs:
         with:
           rust-version: stable${{ matrix.host }}
           targets: ${{ matrix.target }}
+      # The `{ sharedKey: ... }` allows different actions to share the cache.
+      # We're using a `fullBuild` key mostly as a "this needs to do the
+      # complete" that needs to do the complete build (that is, including
+      # `--features 'bundled-full session buildtime_bindgen`), which is very
+      # slow, and has several deps.
       - uses: Swatinem/rust-cache@v1
-        with: { sharedKey: fullTests }
+        with: { sharedKey: fullBuild }
 
       - run: cargo build --features bundled --workspace --all-targets --verbose
       - run: cargo test --features bundled --workspace --all-targets --verbose
@@ -83,7 +88,7 @@ jobs:
           rust-version: stable${{ matrix.host }}
           targets: ${{ matrix.target }}
       - uses: Swatinem/rust-cache@v1
-        with: { sharedKey: fullTests }
+        with: { sharedKey: fullBuild }
 
       - run: cargo test --features 'bundled-sqlcipher' --workspace --all-targets --verbose
       - run: cargo test --features 'bundled-sqlcipher' --workspace --doc --verbose
@@ -185,7 +190,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: hecrj/setup-rust-action@v1
       - uses: Swatinem/rust-cache@v1
-        with: { sharedKey: fullTests }
+        with: { sharedKey: fullBuild }
       - run: cargo doc --features 'bundled-full session buildtime_bindgen' --no-deps
         env: { RUSTDOCFLAGS: -Dwarnings }
 
@@ -195,6 +200,9 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: hecrj/setup-rust-action@v1
+      # TODO: we don't use caching here because it's unclear if it will cause
+      # the coverage to get less accurate (this is the case for some coverage
+      # tools, although possibly not tarpaulin?)
       - name: Run cargo-tarpaulin
         uses: actions-rs/tarpaulin@v0.1
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -184,11 +184,10 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: hecrj/setup-rust-action@v1
-        with:
-          rust-version: nightly
-      # Need to use `cargo rustdoc` to actually get it to respect -D
-      # warnings... Note: this also requires nightly.
-      - run: cargo rustdoc --features 'bundled-full session buildtime_bindgen' -- -D warnings
+      - uses: Swatinem/rust-cache@v1
+        with: { sharedKey: fullTests }
+      - run: cargo doc --features 'bundled-full session buildtime_bindgen' --no-deps
+        env: { RUSTDOCFLAGS: -Dwarnings }
 
   codecov:
     name: Generate code coverage


### PR DESCRIPTION
Latest nightly rustdoc seems to have has a bug where it incorrectly flags a link as broken (the link still works if you open the doc).

This action only uses nightly because it was written before the rustdoc linkcheck warnings could be used on stable. They also didn't work through the `cargo doc` subcommand (only `cargo rustdoc`) which meant they had to document dependencies too, which is slow. None of this is true now, so I've fixed it, which should fix the error we're seeing in CI.

While I was here, I also added caching to this action, and renamed+documented the cache key so it's clearer why that's reasonable for this task.