### PR TITLE
Remove the SQLite version check

### DIFF
--- a/src/inner_connection.rs
+++ b/src/inner_connection.rs
@@ -63,8 +63,6 @@ impl InnerConnection {
         flags: OpenFlags,
         vfs: Option<&CStr>,
     ) -> Result<InnerConnection> {
-        #[cfg(not(feature = "bundled"))]
-        ensure_valid_sqlite_version();
         ensure_safe_sqlite_threading_mode()?;
 
         // Replicate the check for sane open flags from SQLite, because the check in
@@ -324,55 +322,6 @@ impl Drop for InnerConnection {
             }
         }
     }
-}
-
-#[cfg(not(feature = "bundled"))]
-static SQLITE_VERSION_CHECK: std::sync::Once = std::sync::Once::new();
-#[cfg(not(feature = "bundled"))]
-pub static BYPASS_VERSION_CHECK: AtomicBool = AtomicBool::new(false);
-
-#[cfg(not(feature = "bundled"))]
-fn ensure_valid_sqlite_version() {
-    use crate::version::version;
-
-    SQLITE_VERSION_CHECK.call_once(|| {
-        let version_number = version_number();
-
-        // Check our hard floor.
-        if version_number < 3_006_008 {
-            panic!("rusqlite requires SQLite 3.6.8 or newer");
-        }
-
-        // Check that the major version number for runtime and buildtime match.
-        let buildtime_major = ffi::SQLITE_VERSION_NUMBER / 1_000_000;
-        let runtime_major = version_number / 1_000_000;
-        if buildtime_major != runtime_major {
-            panic!(
-                "rusqlite was built against SQLite {} but is running with SQLite {}",
-                str::from_utf8(ffi::SQLITE_VERSION).unwrap(),
-                version()
-            );
-        }
-
-        if BYPASS_VERSION_CHECK.load(Ordering::Relaxed) {
-            return;
-        }
-
-        // Check that the runtime version number is compatible with the version number
-        // we found at build-time.
-        if version_number < ffi::SQLITE_VERSION_NUMBER {
-            panic!(
-                "\
-rusqlite was built against SQLite {} but the runtime SQLite version is {}. To fix this, either:
-* Recompile rusqlite and link against the SQLite version you are using at runtime, or
-* Call rusqlite::bypass_sqlite_version_check() prior to your first connection attempt. Doing this
-  means you're sure everything will work correctly even though the runtime version is older than
-  the version we found at build time.",
-                str::from_utf8(ffi::SQLITE_VERSION).unwrap(),
-                version()
-            );
-        }
-    });
 }
 
 #[cfg(not(any(target_arch = "wasm32")))]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1064,21 +1064,6 @@ pub unsafe fn bypass_sqlite_initialization() {
     BYPASS_SQLITE_INIT.store(true, Ordering::Relaxed);
 }
 
-/// rusqlite performs a one-time check that the runtime SQLite version is at
-/// least as new as the version of SQLite found when rusqlite was built.
-/// Bypassing this check may be dangerous; e.g., if you use features of SQLite
-/// that are not present in the runtime version.
-///
-/// # Safety
-///
-/// If you are sure the runtime version is compatible with the
-/// build-time version for your usage, you can bypass the version check by
-/// calling this function before your first connection attempt.
-pub unsafe fn bypass_sqlite_version_check() {
-    #[cfg(not(feature = "bundled"))]
-    inner_connection::BYPASS_VERSION_CHECK.store(true, Ordering::Relaxed);
-}
-
 /// Allows interrupting a long-running computation.
 pub struct InterruptHandle {
     db_lock: Arc<Mutex<*mut ffi::sqlite3>>,


### PR DESCRIPTION
This will be required to implement the plan in https://github.com/rusqlite/rusqlite/issues/706#issuecomment-854002318.

Additionally, it's not actually unsafe. The comment says something like it could be dangerous "if you use features of SQLite that are not present in the runtime version", but this would either cause an error when linking (when static linking) or loading (when dynamic linking) the rusqlite-using program. The only safety issues this can cause are when using libraries that do not follow good ABI-stability practices, but SQLite is *extremely* well behaved in this regard.

Furthermore, if it *were* unsafe, we'd have a soundness hole. That is: we skip the version check when the `bundled` feature is enabled, but a user could enable the bundled feature, and then [use a custom `.cargo/config{,.toml}`](https://doc.rust-lang.org/cargo/reference/config.html#targettriplelinks) to choose we link with ("overriding" the decision of the build.rs)... (Actually, this could be done even more easily just by enabling the `bundled` and `in-gecko` features).

That's all to say, if we *did* have a case where this was actually dangerous, I'd consider it a serious issue, but we don't.