### PR TITLE
Move Limits enum from libsqlite3-sys into rusqlite

### DIFF
--- a/libsqlite3-sys/src/lib.rs
+++ b/libsqlite3-sys/src/lib.rs
@@ -22,42 +22,6 @@ pub fn SQLITE_TRANSIENT() -> sqlite3_destructor_type {
     Some(unsafe { mem::transmute(-1_isize) })
 }
 
-/// Run-Time Limit Categories
-#[repr(i32)]
-#[non_exhaustive]
-#[allow(clippy::upper_case_acronyms)]
-pub enum Limit {
-    /// The maximum size of any string or BLOB or table row, in bytes.
-    SQLITE_LIMIT_LENGTH = SQLITE_LIMIT_LENGTH,
-    /// The maximum length of an SQL statement, in bytes.
-    SQLITE_LIMIT_SQL_LENGTH = SQLITE_LIMIT_SQL_LENGTH,
-    /// The maximum number of columns in a table definition or in the result set
-    /// of a SELECT or the maximum number of columns in an index or in an
-    /// ORDER BY or GROUP BY clause.
-    SQLITE_LIMIT_COLUMN = SQLITE_LIMIT_COLUMN,
-    /// The maximum depth of the parse tree on any expression.
-    SQLITE_LIMIT_EXPR_DEPTH = SQLITE_LIMIT_EXPR_DEPTH,
-    /// The maximum number of terms in a compound SELECT statement.
-    SQLITE_LIMIT_COMPOUND_SELECT = SQLITE_LIMIT_COMPOUND_SELECT,
-    /// The maximum number of instructions in a virtual machine program used to
-    /// implement an SQL statement.
-    SQLITE_LIMIT_VDBE_OP = SQLITE_LIMIT_VDBE_OP,
-    /// The maximum number of arguments on a function.
-    SQLITE_LIMIT_FUNCTION_ARG = SQLITE_LIMIT_FUNCTION_ARG,
-    /// The maximum number of attached databases.
-    SQLITE_LIMIT_ATTACHED = SQLITE_LIMIT_ATTACHED,
-    /// The maximum length of the pattern argument to the LIKE or GLOB
-    /// operators.
-    SQLITE_LIMIT_LIKE_PATTERN_LENGTH = SQLITE_LIMIT_LIKE_PATTERN_LENGTH,
-    /// The maximum index number of any parameter in an SQL statement.
-    SQLITE_LIMIT_VARIABLE_NUMBER = SQLITE_LIMIT_VARIABLE_NUMBER,
-    /// The maximum depth of recursion for triggers.
-    SQLITE_LIMIT_TRIGGER_DEPTH = 10,
-    /// The maximum number of auxiliary worker threads that a single prepared
-    /// statement may start.
-    SQLITE_LIMIT_WORKER_THREADS = 11,
-}
-
 #[allow(clippy::all)]
 mod bindings {
     include!(concat!(env!("OUT_DIR"), "/bindgen.rs"));

--- a/src/limits.rs
+++ b/src/limits.rs
@@ -1,23 +1,63 @@
 //! Run-Time Limits
 
+use crate::{ffi, Connection};
 use std::os::raw::c_int;
 
-use crate::ffi;
-pub use crate::ffi::Limit;
-
-use crate::Connection;
+/// Run-Time limit categories, for use with [`Connection::limit`] and
+/// [`Connection::set_limit`].
+///
+/// See the official documentation for more information:
+/// - <https://www.sqlite.org/c3ref/c_limit_attached.html>
+/// - <https://www.sqlite.org/limits.html>
+#[repr(i32)]
+#[non_exhaustive]
+#[allow(clippy::upper_case_acronyms, non_camel_case_types)]
+#[cfg_attr(docsrs, doc(cfg(feature = "limits")))]
+pub enum Limit {
+    /// The maximum size of any string or BLOB or table row, in bytes.
+    SQLITE_LIMIT_LENGTH = ffi::SQLITE_LIMIT_LENGTH,
+    /// The maximum length of an SQL statement, in bytes.
+    SQLITE_LIMIT_SQL_LENGTH = ffi::SQLITE_LIMIT_SQL_LENGTH,
+    /// The maximum number of columns in a table definition or in the result set
+    /// of a SELECT or the maximum number of columns in an index or in an
+    /// ORDER BY or GROUP BY clause.
+    SQLITE_LIMIT_COLUMN = ffi::SQLITE_LIMIT_COLUMN,
+    /// The maximum depth of the parse tree on any expression.
+    SQLITE_LIMIT_EXPR_DEPTH = ffi::SQLITE_LIMIT_EXPR_DEPTH,
+    /// The maximum number of terms in a compound SELECT statement.
+    SQLITE_LIMIT_COMPOUND_SELECT = ffi::SQLITE_LIMIT_COMPOUND_SELECT,
+    /// The maximum number of instructions in a virtual machine program used to
+    /// implement an SQL statement.
+    SQLITE_LIMIT_VDBE_OP = ffi::SQLITE_LIMIT_VDBE_OP,
+    /// The maximum number of arguments on a function.
+    SQLITE_LIMIT_FUNCTION_ARG = ffi::SQLITE_LIMIT_FUNCTION_ARG,
+    /// The maximum number of attached databases.
+    SQLITE_LIMIT_ATTACHED = ffi::SQLITE_LIMIT_ATTACHED,
+    /// The maximum length of the pattern argument to the LIKE or GLOB
+    /// operators.
+    SQLITE_LIMIT_LIKE_PATTERN_LENGTH = ffi::SQLITE_LIMIT_LIKE_PATTERN_LENGTH,
+    /// The maximum index number of any parameter in an SQL statement.
+    SQLITE_LIMIT_VARIABLE_NUMBER = ffi::SQLITE_LIMIT_VARIABLE_NUMBER,
+    /// The maximum depth of recursion for triggers.
+    SQLITE_LIMIT_TRIGGER_DEPTH = 10,
+    /// The maximum number of auxiliary worker threads that a single prepared
+    /// statement may start.
+    SQLITE_LIMIT_WORKER_THREADS = 11,
+}
 
 impl Connection {
-    /// Returns the current value of a limit.
+    /// Returns the current value of a [`Limit`].
     #[inline]
+    #[cfg_attr(docsrs, doc(cfg(feature = "limits")))]
     pub fn limit(&self, limit: Limit) -> i32 {
         let c = self.db.borrow();
         unsafe { ffi::sqlite3_limit(c.db(), limit as c_int, -1) }
     }
 
-    /// Changes the limit to `new_val`, returning the prior
+    /// Changes the [`Limit`] to `new_val`, returning the prior
     /// value of the limit.
     #[inline]
+    #[cfg_attr(docsrs, doc(cfg(feature = "limits")))]
     pub fn set_limit(&self, limit: Limit, new_val: i32) -> i32 {
         let c = self.db.borrow_mut();
         unsafe { ffi::sqlite3_limit(c.db(), limit as c_int, new_val) }
@@ -26,8 +66,62 @@ impl Connection {
 
 #[cfg(test)]
 mod test {
-    use crate::ffi::Limit;
+    use super::*;
     use crate::{Connection, Result};
+
+    #[test]
+    fn test_limit_values() {
+        assert_eq!(
+            Limit::SQLITE_LIMIT_LENGTH as i32,
+            ffi::SQLITE_LIMIT_LENGTH as i32,
+        );
+        assert_eq!(
+            Limit::SQLITE_LIMIT_SQL_LENGTH as i32,
+            ffi::SQLITE_LIMIT_SQL_LENGTH as i32,
+        );
+        assert_eq!(
+            Limit::SQLITE_LIMIT_COLUMN as i32,
+            ffi::SQLITE_LIMIT_COLUMN as i32,
+        );
+        assert_eq!(
+            Limit::SQLITE_LIMIT_EXPR_DEPTH as i32,
+            ffi::SQLITE_LIMIT_EXPR_DEPTH as i32,
+        );
+        assert_eq!(
+            Limit::SQLITE_LIMIT_COMPOUND_SELECT as i32,
+            ffi::SQLITE_LIMIT_COMPOUND_SELECT as i32,
+        );
+        assert_eq!(
+            Limit::SQLITE_LIMIT_VDBE_OP as i32,
+            ffi::SQLITE_LIMIT_VDBE_OP as i32,
+        );
+        assert_eq!(
+            Limit::SQLITE_LIMIT_FUNCTION_ARG as i32,
+            ffi::SQLITE_LIMIT_FUNCTION_ARG as i32,
+        );
+        assert_eq!(
+            Limit::SQLITE_LIMIT_ATTACHED as i32,
+            ffi::SQLITE_LIMIT_ATTACHED as i32,
+        );
+        assert_eq!(
+            Limit::SQLITE_LIMIT_LIKE_PATTERN_LENGTH as i32,
+            ffi::SQLITE_LIMIT_LIKE_PATTERN_LENGTH as i32,
+        );
+        assert_eq!(
+            Limit::SQLITE_LIMIT_VARIABLE_NUMBER as i32,
+            ffi::SQLITE_LIMIT_VARIABLE_NUMBER as i32,
+        );
+        #[cfg(feature = "bundled")]
+        assert_eq!(
+            Limit::SQLITE_LIMIT_TRIGGER_DEPTH as i32,
+            ffi::SQLITE_LIMIT_TRIGGER_DEPTH as i32,
+        );
+        #[cfg(feature = "bundled")]
+        assert_eq!(
+            Limit::SQLITE_LIMIT_WORKER_THREADS as i32,
+            ffi::SQLITE_LIMIT_WORKER_THREADS as i32,
+        );
+    }
 
     #[test]
     fn test_limit() -> Result<()> {


### PR DESCRIPTION
This is really not something that belongs in the -sys crate.