### PR TITLE
Fix shell scripts

### DIFF
--- a/libsqlite3-sys/upgrade.sh
+++ b/libsqlite3-sys/upgrade.sh
@@ -1,7 +1,6 @@
-#!/bin/bash -e
+#!/bin/sh -e
 
-SCRIPT_DIR=$(cd "$(dirname "$_")" && pwd)
-CUR_DIR=$(pwd -P)
+SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
 echo "$SCRIPT_DIR"
 cd "$SCRIPT_DIR" || { echo "fatal error" >&2; exit 1; }
 cargo clean

--- a/libsqlite3-sys/upgrade_sqlcipher.sh
+++ b/libsqlite3-sys/upgrade_sqlcipher.sh
@@ -1,7 +1,6 @@
-#!/bin/bash -e
+#!/bin/sh -e
 
-SCRIPT_DIR=$(cd "$(dirname "$_")" && pwd)
-CUR_DIR=$(pwd -P)
+SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
 echo "$SCRIPT_DIR"
 cd "$SCRIPT_DIR" || { echo "fatal error" >&2; exit 1; }
 cargo clean


### PR DESCRIPTION
Replace `$_` by `$0` because `$_` doesn't work when using `sh upgrade.sh`.
Replace `bash` by `sh` because we should not depend on bash.
And also remove unused `CUR_DIR` variable.