### PR TITLE
Fix compiler target check for wasm32-wasi

### DIFF
--- a/libsqlite3-sys/build.rs
+++ b/libsqlite3-sys/build.rs
@@ -242,7 +242,7 @@ mod build_bundled {
             cfg.flag("-DHAVE_LOCALTIME_R");
         }
         // Target wasm32-wasi can't compile the default VFS
-        if is_compiler("wasm32-wasi") {
+        if env::var("TARGET") == Ok("wasm32-wasi".to_string()) {
             cfg.flag("-DSQLITE_OS_OTHER")
                 // https://github.com/rust-lang/rust/issues/74393
                 .flag("-DLONGDOUBLE_TYPE=double");


### PR DESCRIPTION
When building with:

```sh
cargo build --lib --target wasm32-wasi --features bundled,wasm32-wasi-vfs
```

The `CARGO_CFG_TARGET_ENV` is an empty string.

The change can be verified by running the command above with and without this change. The build is failing in both cases (#827), but without this change, the [`wasm32-wasi`-specific flags](https://github.com/rusqlite/rusqlite/blob/ddb7141c6dee4b8956af85b2e4a01a28e5fdbacc/libsqlite3-sys/build.rs#L246): `-DSQLITE_OS_OTHER` and `DLONGDOUBLE_TYPE` are not being used by `clang`