### PR TITLE
Prep libsqlite3-sys release 0.24.1

### DIFF
--- a/libsqlite3-sys/Cargo.toml
+++ b/libsqlite3-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libsqlite3-sys"
-version = "0.24.0"
+version = "0.24.1"
 authors = ["The rusqlite developers"]
 edition = "2018"
 repository = "https://github.com/rusqlite/rusqlite"


### PR DESCRIPTION
This release is just so we get out the updated version of our bundled SQLcipher.

There's no need to change rusqlite for this, since it will be fine with either.