### PR TITLE
Implement `Params` for tuples, improve documentation some.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "rusqlite"
+# Note: Update version in README.md when you change this.
 version = "0.27.0"
 authors = ["The rusqlite developers"]
 edition = "2018"

--- a/README.md
+++ b/README.md
@@ -88,45 +88,34 @@ newer SQLite version; see details below.
 Rusqlite provides several features that are behind [Cargo
 features](https://doc.rust-lang.org/cargo/reference/manifest.html#the-features-section). They are:
 
-* [`load_extension`](https://docs.rs/rusqlite/latest/rusqlite/struct.LoadExtensionGuard.html)
+* [`load_extension`](https://docs.rs/rusqlite/~0/rusqlite/struct.LoadExtensionGuard.html)
   allows loading dynamic library-based SQLite extensions.
-
-* [`backup`](https://docs.rs/rusqlite/latest/rusqlite/backup/index.html)
+* [`backup`](https://docs.rs/rusqlite/~0/rusqlite/backup/index.html)
   allows use of SQLite's online backup API. Note: This feature requires SQLite 3.6.11 or later.
-
-* [`functions`](https://docs.rs/rusqlite/latest/rusqlite/functions/index.html)
+* [`functions`](https://docs.rs/rusqlite/~0/rusqlite/functions/index.html)
   allows you to load Rust closures into SQLite connections for use in queries.
   Note: This feature requires SQLite 3.7.3 or later.
-
 * `window` for [window function](https://www.sqlite.org/windowfunctions.html) support (`fun(...) OVER ...`). (Implies `functions`.)
-
-* [`trace`](https://docs.rs/rusqlite/latest/rusqlite/trace/index.html)
+* [`trace`](https://docs.rs/rusqlite/~0/rusqlite/trace/index.html)
   allows hooks into SQLite's tracing and profiling APIs. Note: This feature
   requires SQLite 3.6.23 or later.
-
-* [`blob`](https://docs.rs/rusqlite/latest/rusqlite/blob/index.html)
+* [`blob`](https://docs.rs/rusqlite/~0/rusqlite/blob/index.html)
   gives `std::io::{Read, Write, Seek}` access to SQL BLOBs. Note: This feature
   requires SQLite 3.7.4 or later.
-
-* [`limits`](https://docs.rs/rusqlite/latest/rusqlite/struct.Connection.html#method.limit)
+* [`limits`](https://docs.rs/rusqlite/~0/rusqlite/struct.Connection.html#method.limit)
   allows you to set and retrieve SQLite's per connection limits.
-
-* `chrono` implements [`FromSql`](https://docs.rs/rusqlite/latest/rusqlite/types/trait.FromSql.html)
-  and [`ToSql`](https://docs.rs/rusqlite/latest/rusqlite/types/trait.ToSql.html) for various
+* `chrono` implements [`FromSql`](https://docs.rs/rusqlite/~0/rusqlite/types/trait.FromSql.html)
+  and [`ToSql`](https://docs.rs/rusqlite/~0/rusqlite/types/trait.ToSql.html) for various
   types from the [`chrono` crate](https://crates.io/crates/chrono).
-
-* `serde_json` implements [`FromSql`](https://docs.rs/rusqlite/latest/rusqlite/types/trait.FromSql.html)
-  and [`ToSql`](https://docs.rs/rusqlite/latest/rusqlite/types/trait.ToSql.html) for the
+* `serde_json` implements [`FromSql`](https://docs.rs/rusqlite/~0/rusqlite/types/trait.FromSql.html)
+  and [`ToSql`](https://docs.rs/rusqlite/~0/rusqlite/types/trait.ToSql.html) for the
   `Value` type from the [`serde_json` crate](https://crates.io/crates/serde_json).
-
-* `time` implements [`FromSql`](https://docs.rs/rusqlite/latest/rusqlite/types/trait.FromSql.html)
-   and [`ToSql`](https://docs.rs/rusqlite/latest/rusqlite/types/trait.ToSql.html) for the
+* `time` implements [`FromSql`](https://docs.rs/rusqlite/~0/rusqlite/types/trait.FromSql.html)
+   and [`ToSql`](https://docs.rs/rusqlite/~0/rusqlite/types/trait.ToSql.html) for the
    `time::OffsetDateTime` type from the [`time` crate](https://crates.io/crates/time).
-
-* `url` implements [`FromSql`](https://docs.rs/rusqlite/latest/rusqlite/types/trait.FromSql.html)
-  and [`ToSql`](https://docs.rs/rusqlite/latest/rusqlite/types/trait.ToSql.html) for the
+* `url` implements [`FromSql`](https://docs.rs/rusqlite/~0/rusqlite/types/trait.FromSql.html)
+  and [`ToSql`](https://docs.rs/rusqlite/~0/rusqlite/types/trait.ToSql.html) for the
   `Url` type from the [`url` crate](https://crates.io/crates/url).
-
 * `bundled` uses a bundled version of SQLite.  This is a good option for cases where linking to SQLite is complicated, such as Windows.
 * `sqlcipher` looks for the SQLCipher library to link against instead of SQLite. This feature overrides `bundled`.
 * `bundled-sqlcipher` uses a bundled version of SQLCipher. This searches for and links against a system-installed crypto library to provide the crypto implementation.

--- a/README.md
+++ b/README.md
@@ -26,11 +26,11 @@ fn main() -> Result<()> {
 
     conn.execute(
         "CREATE TABLE person (
-                  id              INTEGER PRIMARY KEY,
-                  name            TEXT NOT NULL,
-                  data            BLOB
-                  )",
-        [],
+            id    INTEGER PRIMARY KEY,
+            name  TEXT NOT NULL,
+            data  BLOB
+        )",
+        [], // empty list of parameters.
     )?;
     let me = Person {
         id: 0,
@@ -69,34 +69,45 @@ newer SQLite version; see details below.
 Rusqlite provides several features that are behind [Cargo
 features](https://doc.rust-lang.org/cargo/reference/manifest.html#the-features-section). They are:
 
-* [`load_extension`](https://docs.rs/rusqlite/~0/rusqlite/struct.LoadExtensionGuard.html)
+* [`load_extension`](https://docs.rs/rusqlite/latest/rusqlite/struct.LoadExtensionGuard.html)
   allows loading dynamic library-based SQLite extensions.
-* [`backup`](https://docs.rs/rusqlite/~0/rusqlite/backup/index.html)
+
+* [`backup`](https://docs.rs/rusqlite/latest/rusqlite/backup/index.html)
   allows use of SQLite's online backup API. Note: This feature requires SQLite 3.6.11 or later.
-* [`functions`](https://docs.rs/rusqlite/~0/rusqlite/functions/index.html)
+
+* [`functions`](https://docs.rs/rusqlite/latest/rusqlite/functions/index.html)
   allows you to load Rust closures into SQLite connections for use in queries.
   Note: This feature requires SQLite 3.7.3 or later.
+
 * `window` for [window function](https://www.sqlite.org/windowfunctions.html) support (`fun(...) OVER ...`). (Implies `functions`.)
-* [`trace`](https://docs.rs/rusqlite/~0/rusqlite/trace/index.html)
+
+* [`trace`](https://docs.rs/rusqlite/latest/rusqlite/trace/index.html)
   allows hooks into SQLite's tracing and profiling APIs. Note: This feature
   requires SQLite 3.6.23 or later.
-* [`blob`](https://docs.rs/rusqlite/~0/rusqlite/blob/index.html)
+
+* [`blob`](https://docs.rs/rusqlite/latest/rusqlite/blob/index.html)
   gives `std::io::{Read, Write, Seek}` access to SQL BLOBs. Note: This feature
   requires SQLite 3.7.4 or later.
-* [`limits`](https://docs.rs/rusqlite/~0/rusqlite/struct.Connection.html#method.limit)
+
+* [`limits`](https://docs.rs/rusqlite/latest/rusqlite/struct.Connection.html#method.limit)
   allows you to set and retrieve SQLite's per connection limits.
-* `chrono` implements [`FromSql`](https://docs.rs/rusqlite/~0/rusqlite/types/trait.FromSql.html)
-  and [`ToSql`](https://docs.rs/rusqlite/~0/rusqlite/types/trait.ToSql.html) for various
+
+* `chrono` implements [`FromSql`](https://docs.rs/rusqlite/latest/rusqlite/types/trait.FromSql.html)
+  and [`ToSql`](https://docs.rs/rusqlite/latest/rusqlite/types/trait.ToSql.html) for various
   types from the [`chrono` crate](https://crates.io/crates/chrono).
-* `serde_json` implements [`FromSql`](https://docs.rs/rusqlite/~0/rusqlite/types/trait.FromSql.html)
-  and [`ToSql`](https://docs.rs/rusqlite/~0/rusqlite/types/trait.ToSql.html) for the
+
+* `serde_json` implements [`FromSql`](https://docs.rs/rusqlite/latest/rusqlite/types/trait.FromSql.html)
+  and [`ToSql`](https://docs.rs/rusqlite/latest/rusqlite/types/trait.ToSql.html) for the
   `Value` type from the [`serde_json` crate](https://crates.io/crates/serde_json).
-* `time` implements [`FromSql`](https://docs.rs/rusqlite/~0/rusqlite/types/trait.FromSql.html)
-   and [`ToSql`](https://docs.rs/rusqlite/~0/rusqlite/types/trait.ToSql.html) for the
+
+* `time` implements [`FromSql`](https://docs.rs/rusqlite/latest/rusqlite/types/trait.FromSql.html)
+   and [`ToSql`](https://docs.rs/rusqlite/latest/rusqlite/types/trait.ToSql.html) for the
    `time::OffsetDateTime` type from the [`time` crate](https://crates.io/crates/time).
-* `url` implements [`FromSql`](https://docs.rs/rusqlite/~0/rusqlite/types/trait.FromSql.html)
-  and [`ToSql`](https://docs.rs/rusqlite/~0/rusqlite/types/trait.ToSql.html) for the
+
+* `url` implements [`FromSql`](https://docs.rs/rusqlite/latest/rusqlite/types/trait.FromSql.html)
+  and [`ToSql`](https://docs.rs/rusqlite/latest/rusqlite/types/trait.ToSql.html) for the
   `Url` type from the [`url` crate](https://crates.io/crates/url).
+
 * `bundled` uses a bundled version of SQLite.  This is a good option for cases where linking to SQLite is complicated, such as Windows.
 * `sqlcipher` looks for the SQLCipher library to link against instead of SQLite. This feature overrides `bundled`.
 * `bundled-sqlcipher` uses a bundled version of SQLCipher. This searches for and links against a system-installed crypto library to provide the crypto implementation.

--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@
 
 Rusqlite is an ergonomic wrapper for using SQLite from Rust.
 
+Historically, the API was based on the one from [`rust-postgres`](https://github.com/sfackler/rust-postgres). However, the two have diverged in many ways, and no compatibility between the two is intended.
+
 ## Usage
 
 In your Cargo.toml:

--- a/README.md
+++ b/README.md
@@ -17,13 +17,14 @@ In your Cargo.toml:
 ```toml
 [dependencies]
 # `bundled` causes us to automatically compile and link in an up to date
-# version of SQLite for you, which avoids many common build issues, and
-# avoids depending on the version of SQLite on the users system, which may
-# be old or missing. However, it's not ideal for all scenarios and in
-# particular, generic libraries built around `rusqlite` should probably
-# not enable it; it's a choice that should *usually* be left up to
-# the application that actually manages the database, which is why it
-# is not a default feature.
+# version of SQLite for you. This avoids many common build issues, and
+# avoids depending on the version of SQLite on the users system (or your
+# system), which may be old or missing. It's the right choice for most
+# programs that control their own SQLite databases.
+#
+# That said, it's not ideal for all scenarios and in particular, generic
+# libraries built around `rusqlite` should probably not enable it, which
+# is why it is not a default feature -- it could become hard to disable.
 rusqlite = { version = "0.27.0", features = ["bundled"] }
 ```
 

--- a/README.md
+++ b/README.md
@@ -8,11 +8,29 @@
 [![Dependency Status](https://deps.rs/repo/github/rusqlite/rusqlite/status.svg)](https://deps.rs/repo/github/rusqlite/rusqlite)
 [![Discord Chat](https://img.shields.io/discord/927966344266256434.svg?logo=discord)](https://discord.gg/nFYfGPB8g4)
 
-Rusqlite is an ergonomic wrapper for using SQLite from Rust. It attempts to expose
-an interface similar to [rust-postgres](https://github.com/sfackler/rust-postgres).
+Rusqlite is an ergonomic wrapper for using SQLite from Rust.
+
+## Usage
+
+In your Cargo.toml:
+
+```toml
+[dependencies]
+# `bundled` causes us to automatically compile and link in an up to date
+# version of SQLite for you, which avoids many common build issues, and
+# avoids depending on the version of SQLite on the users system, which may
+# be old or missing. However, it's not ideal for all scenarios and in
+# particular, generic libraries built around `rusqlite` should probably
+# not enable it; it's a choice that should *usually* be left up to
+# the application that actually manages the database, which is why it
+# is not a default feature.
+rusqlite = { version = "0.27.0", features = ["bundled"] }
+```
+
+Simple example usage:
 
 ```rust
-use rusqlite::{params, Connection, Result};
+use rusqlite::{Connection, Result};
 
 #[derive(Debug)]
 struct Person {
@@ -30,7 +48,7 @@ fn main() -> Result<()> {
             name  TEXT NOT NULL,
             data  BLOB
         )",
-        [], // empty list of parameters.
+        (), // empty list of parameters.
     )?;
     let me = Person {
         id: 0,
@@ -39,7 +57,7 @@ fn main() -> Result<()> {
     };
     conn.execute(
         "INSERT INTO person (name, data) VALUES (?1, ?2)",
-        params![me.name, me.data],
+        (&me.name, &me.data),
     )?;
 
     let mut stmt = conn.prepare("SELECT id, name, data FROM person")?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,10 +16,10 @@
 //!
 //!     conn.execute(
 //!         "CREATE TABLE person (
-//!                   id              INTEGER PRIMARY KEY,
-//!                   name            TEXT NOT NULL,
-//!                   data            BLOB
-//!                   )",
+//!             id   INTEGER PRIMARY KEY,
+//!             name TEXT NOT NULL,
+//!             data BLOB
+//!         )",
 //!         [],
 //!     )?;
 //!     let me = Person {
@@ -29,7 +29,7 @@
 //!     };
 //!     conn.execute(
 //!         "INSERT INTO person (name, data) VALUES (?1, ?2)",
-//!         params![me.name, me.data],
+//!         (me.name, me.data),
 //!     )?;
 //!
 //!     let mut stmt = conn.prepare("SELECT id, name, data FROM person")?;
@@ -145,7 +145,7 @@ const STATEMENT_CACHE_DEFAULT_CAPACITY: usize = 16;
 #[deprecated = "Use an empty array instead; `stmt.execute(NO_PARAMS)` => `stmt.execute([])`"]
 pub const NO_PARAMS: &[&dyn ToSql] = &[];
 
-/// A macro making it more convenient to pass heterogeneous or long lists of
+/// A macro making it more convenient to longer lists of
 /// parameters as a `&[&dyn ToSql]`.
 ///
 /// # Example
@@ -161,8 +161,7 @@ pub const NO_PARAMS: &[&dyn ToSql] = &[];
 ///
 /// fn add_person(conn: &Connection, person: &Person) -> Result<()> {
 ///     conn.execute(
-///         "INSERT INTO person (name, age_in_years, data)
-///                   VALUES (?1, ?2, ?3)",
+///         "INSERT INTO person(name, age_in_years, data) VALUES (?1, ?2, ?3)",
 ///         params![person.name, person.age_in_years, person.data],
 ///     )?;
 ///     Ok(())

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,7 +20,7 @@
 //!             name TEXT NOT NULL,
 //!             data BLOB
 //!         )",
-//!         [],
+//!         (), // empty list of parameters.
 //!     )?;
 //!     let me = Person {
 //!         id: 0,
@@ -29,7 +29,7 @@
 //!     };
 //!     conn.execute(
 //!         "INSERT INTO person (name, data) VALUES (?1, ?2)",
-//!         (me.name, me.data),
+//!         (&me.name, &me.data),
 //!     )?;
 //!
 //!     let mut stmt = conn.prepare("SELECT id, name, data FROM person")?;


### PR DESCRIPTION
Someone pointed out to me that rusqlite should support passing tuples in, which would make `params!` mostly redundant. So I did that.

This also improves the README:

1. Remove the comment about `rust-postgres`. We're not very close to their API at all anymore, and haven't been for a long time, so it's just misleading.

2. Point people towards bundled. The number 1 question I see about rusqlite is about build issues. In practice, most folks are better off using bundled unless they're building a generic library. I don't think it should be on by default though, since default features are very hard to turn off.

This probably should be a separate PR, but it came from the same feedback I got, and I was already there.

@gwenn do you agree?