### PR TITLE
Force use of buildtime_bindgen under winsqlite3 for now

### DIFF
--- a/libsqlite3-sys/Cargo.toml
+++ b/libsqlite3-sys/Cargo.toml
@@ -36,7 +36,7 @@ in_gecko = []
 with-asan = []
 wasm32-wasi-vfs = []
 # lowest version shipped with Windows 10.0.10586 was 3.8.8.3
-winsqlite3 = ["min_sqlite_version_3_7_16"]
+winsqlite3 = ["min_sqlite_version_3_7_16", "buildtime_bindgen"]
 
 [dependencies]
 openssl-sys = { version = "0.9", optional = true }


### PR DESCRIPTION
It seems like winsqlite3's declarations are stdcall not cdecl (`extern "system"` vs `extern "C"`). Those are different ABIs, and it won't generally work (It will work on x86_64, but not on 32-bit x86, for example). I have a better fix incoming (maybe later this weekend -- an overhaul to libsqlite3-sys), but for now this will do.

Sadly, windows is not a platform where `buildtime_bindgen` is actually easy to use, so this may annoy people who use winsqlite3. It's only a build-time requirement, and I don't think there are many of users of this feature.