### PR TITLE
Updated simple example for current release

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ rusqlite = { version = "0.27.0", features = ["bundled"] }
 Simple example usage:
 
 ```rust
-use rusqlite::{Connection, Result};
+use rusqlite::{params, Connection, Result};
 
 #[derive(Debug)]
 struct Person {
@@ -47,11 +47,11 @@ fn main() -> Result<()> {
 
     conn.execute(
         "CREATE TABLE person (
-            id    INTEGER PRIMARY KEY,
-            name  TEXT NOT NULL,
-            data  BLOB
-        )",
-        (), // empty list of parameters.
+                  id              INTEGER PRIMARY KEY,
+                  name            TEXT NOT NULL,
+                  data            BLOB
+                  )",
+        [],
     )?;
     let me = Person {
         id: 0,
@@ -60,7 +60,7 @@ fn main() -> Result<()> {
     };
     conn.execute(
         "INSERT INTO person (name, data) VALUES (?1, ?2)",
-        (&me.name, &me.data),
+        params![me.name, me.data],
     )?;
 
     let mut stmt = conn.prepare("SELECT id, name, data FROM person")?;
@@ -77,6 +77,7 @@ fn main() -> Result<()> {
     }
     Ok(())
 }
+
 ```
 
 ### Supported SQLite Versions


### PR DESCRIPTION
The simple example in the readme file didn't work with the latest release. I don't know when it broke, but I copied the version from [here](https://docs.rs/rusqlite/latest/rusqlite/) to github.