### PR TITLE
Disable winsqlite3 on 32 bit targets

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,6 +72,7 @@ bundled-windows = ["libsqlite3-sys/bundled-windows"]
 with-asan = ["libsqlite3-sys/with-asan"]
 column_decltype = []
 wasm32-wasi-vfs = ["libsqlite3-sys/wasm32-wasi-vfs"]
+# Note: doesn't support 32-bit.
 winsqlite3 = ["libsqlite3-sys/winsqlite3"]
 
 # Helper feature for enabling most non-build-related optional features

--- a/libsqlite3-sys/Cargo.toml
+++ b/libsqlite3-sys/Cargo.toml
@@ -35,8 +35,13 @@ session = ["preupdate_hook", "buildtime_bindgen"]
 in_gecko = []
 with-asan = []
 wasm32-wasi-vfs = []
+
 # lowest version shipped with Windows 10.0.10586 was 3.8.8.3
-winsqlite3 = ["min_sqlite_version_3_7_16", "buildtime_bindgen"]
+#
+# Note that because `winsqlite3.dll` exports SQLite functions using a atypical
+# ABI on 32-bit systems, this is currently unsupported on these. This may change
+# in the future.
+winsqlite3 = ["min_sqlite_version_3_7_16"]
 
 [dependencies]
 openssl-sys = { version = "0.9", optional = true }

--- a/libsqlite3-sys/src/lib.rs
+++ b/libsqlite3-sys/src/lib.rs
@@ -5,6 +5,9 @@
 #[cfg(feature = "bundled-sqlcipher-vendored-openssl")]
 extern crate openssl_sys;
 
+#[cfg(all(windows, feature = "winsqlite3", target_pointer_width = "32"))]
+compile_error!("The `libsqlite3-sys/winsqlite3` feature is not supported on 32 bit targets.");
+
 pub use self::error::*;
 
 use std::default::Default;


### PR DESCRIPTION
`winsqlite3.dll` actually has a totally custom ABI on 32-bit targets which is different than SQLite typically uses on those platforms (and on any other -- literally this is the only time that SQLite uses an ABI other than `extern "C"`, as far as I can tell -- it even would have required modification to SQLite itself (and its header) to do so).

This is what it the bindgen output looks for winsqlite3: https://gist.github.com/thomcc/4bbbecd0bd79e5ed181fcc9960c59e77. Note that this applies both to the exported functions, *and* to callbacks, which makes it very hard for us to support. (On 64 bit targets, the ABI is the same as everywhere else -- `extern "C"`).

In practice, the feature currently doesn't actually work at all on these targets, since we try to pass `extern "C" fn` as callbacks to functions that expect `extern "stdcall"`, which gives a strange compile error. This makes that explicit, by emitting a compile error on these targets, rather than a mysterious error.

Eventually it could be possible to support this, but I think it might require some new Rust features, such as allowing a macro after `extern` (as in `extern abi!() { ... }` and `extern abi!() fn`, so that we could swap `extern "stdcall"` and `extern "C"`)... but this would still be pretty unfortunate, as we'd have a feature that would break code when enabled, which is generally bad form. We could emit wrappers (for non-varargs funcs), but that's a big maintenance burden.

It's very tempting to me to say that we should remove this feature, as it has been the cause of several headaches now, and people should almost certainly just use bundled instead... But I guess it's not really that bad to keep just for 64 bit targets.