### PR TITLE
Expose `sqlite3_changes` (or `sqlite3_changes64` if available)

### DIFF
--- a/src/inner_connection.rs
+++ b/src/inner_connection.rs
@@ -277,14 +277,14 @@ impl InnerConnection {
     }
 
     #[inline]
-    pub fn changes(&self) -> usize {
+    pub fn changes(&self) -> u64 {
         #[cfg(not(feature = "modern_sqlite"))]
         unsafe {
-            ffi::sqlite3_changes(self.db()) as usize
+            ffi::sqlite3_changes(self.db()) as u64
         }
         #[cfg(feature = "modern_sqlite")] // 3.37.0
         unsafe {
-            ffi::sqlite3_changes64(self.db()) as usize
+            ffi::sqlite3_changes64(self.db()) as u64
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,9 @@
-//! Rusqlite is an ergonomic wrapper for using SQLite from Rust. It attempts to
-//! expose an interface similar to [rust-postgres](https://github.com/sfackler/rust-postgres).
+//! Rusqlite is an ergonomic wrapper for using SQLite from Rust.
+//!
+//! Historically, the API was based on the one from
+//! [`rust-postgres`](https://github.com/sfackler/rust-postgres). However, the
+//! two have diverged in many ways, and no compatibility between the two is
+//! intended.
 //!
 //! ```rust
 //! use rusqlite::{params, Connection, Result};
@@ -901,8 +905,10 @@ impl Connection {
     /// Return the number of rows modified, inserted or deleted by the most
     /// recently completed INSERT, UPDATE or DELETE statement on the database
     /// connection.
+    ///
+    /// See <https://www.sqlite.org/c3ref/changes.html>
     #[inline]
-    fn changes(&self) -> usize {
+    pub fn changes(&self) -> u64 {
         self.db.borrow().changes()
     }
 

--- a/src/statement.rs
+++ b/src/statement.rs
@@ -778,7 +778,7 @@ impl Statement<'_> {
         let r = self.stmt.step();
         self.stmt.reset();
         match r {
-            ffi::SQLITE_DONE => Ok(self.conn.changes()),
+            ffi::SQLITE_DONE => Ok(self.conn.changes() as usize),
             ffi::SQLITE_ROW => Err(Error::ExecuteReturnedResults),
             _ => Err(self.conn.decode_result(r).unwrap_err()),
         }


### PR DESCRIPTION
This was not public, but can be useful. I made it always return u64 as well, since in theory you could change more than 4B rows even if your build is 32 bit. (That said, I don't feel that strongly about this part, since it seems pretty unlikely to me)