### PR TITLE
Fix non-bundled tests against macOS system SQLite

### DIFF
--- a/src/pragma.rs
+++ b/src/pragma.rs
@@ -406,18 +406,20 @@ mod test {
         let db = Connection::open_in_memory()?;
         let journal_mode: String =
             db.pragma_update_and_check(None, "journal_mode", "OFF", |row| row.get(0))?;
-        assert_eq!("off", &journal_mode);
+        assert!(
+            journal_mode == "off" || journal_mode == "memory",
+            "mode: {:?}",
+            journal_mode,
+        );
         // Sanity checks to ensure the move to a generic `ToSql` wasn't breaking
-        assert_eq!(
-            "off",
-            db.pragma_update_and_check(None, "journal_mode", &"OFF", |row| row
-                .get::<_, String>(0))?,
-        );
+        let mode = db
+            .pragma_update_and_check(None, "journal_mode", &"OFF", |row| row.get::<_, String>(0))?;
+        assert!(mode == "off" || mode == "memory", "mode: {:?}", mode);
+
         let param: &dyn crate::ToSql = &"OFF";
-        assert_eq!(
-            "off",
-            db.pragma_update_and_check(None, "journal_mode", param, |row| row.get::<_, String>(0))?,
-        );
+        let mode =
+            db.pragma_update_and_check(None, "journal_mode", param, |row| row.get::<_, String>(0))?;
+        assert!(mode == "off" || mode == "memory", "mode: {:?}", mode);
         Ok(())
     }
 

--- a/tests/deny_single_threaded_sqlite_config.rs
+++ b/tests/deny_single_threaded_sqlite_config.rs
@@ -5,17 +5,16 @@ use rusqlite::ffi;
 use rusqlite::Connection;
 
 #[test]
-#[should_panic]
 fn test_error_when_singlethread_mode() {
     // put SQLite into single-threaded mode
     unsafe {
+        // Note: macOS system SQLite seems to return an error if you attempt to
+        // reconfigure to single-threaded mode.
         if ffi::sqlite3_config(ffi::SQLITE_CONFIG_SINGLETHREAD) != ffi::SQLITE_OK {
             return;
         }
-        if ffi::sqlite3_initialize() != ffi::SQLITE_OK {
-            return;
-        }
+        assert_eq!(ffi::sqlite3_initialize(), ffi::SQLITE_OK);
     }
-
-    let _ = Connection::open_in_memory().unwrap();
+    let res = Connection::open_in_memory();
+    assert!(res.is_err());
 }


### PR DESCRIPTION
On macOS we fail some tests when they're run against system SQLite. These may be bugs in the macOS system SQLite (since `PRAGMA compile_options` says that `BUG_COMPATIBLE_20160819` is enabled, which seems a little ominous), but the fixes for these are easy enough.

I only bothered checking that the mode behaves as expected for bundled in `test_pragma_query_row` and not in `pragma_update_and_check`, since the latter seems to be mostly about testing that compilation doesn't fail.