### PR TITLE
Rename enum variants to Rust-friendly names

### DIFF
--- a/src/hooks.rs
+++ b/src/hooks.rs
@@ -16,23 +16,37 @@ use crate::{Connection, InnerConnection};
 #[allow(clippy::upper_case_acronyms)]
 pub enum Action {
     /// Unsupported / unexpected action
-    UNKNOWN = -1,
+    Unknown = -1,
     /// DELETE command
-    SQLITE_DELETE = ffi::SQLITE_DELETE,
+    Delete = ffi::SQLITE_DELETE,
     /// INSERT command
-    SQLITE_INSERT = ffi::SQLITE_INSERT,
+    Insert = ffi::SQLITE_INSERT,
     /// UPDATE command
-    SQLITE_UPDATE = ffi::SQLITE_UPDATE,
+    Update = ffi::SQLITE_UPDATE,
+}
+
+impl Action {
+    /// An alias for [`Action::Delete`], provided for compatibility with the C API.
+    pub const SQLITE_DELETE: Self = Self::Delete;
+    /// An alias for [`Action::Delete`], provided for compatibility with the C API.
+    pub const SQLITE_INSERT: Self = Self::Insert;
+    /// An alias for [`Action::Update`], provided for compatibility with the C API.
+    pub const SQLITE_UPDATE: Self = Self::Update;
+
+    /// Unsupported / unexpected action. Provided for backwards-compatibility.
+    #[deprecated = "Renamed to `Action::Unknown`"]
+    #[doc(hidden)]
+    pub const UNKNOWN: Self = Self::Unknown;
 }
 
 impl From<i32> for Action {
     #[inline]
     fn from(code: i32) -> Action {
         match code {
-            ffi::SQLITE_DELETE => Action::SQLITE_DELETE,
-            ffi::SQLITE_INSERT => Action::SQLITE_INSERT,
-            ffi::SQLITE_UPDATE => Action::SQLITE_UPDATE,
-            _ => Action::UNKNOWN,
+            ffi::SQLITE_DELETE => Action::Delete,
+            ffi::SQLITE_INSERT => Action::Insert,
+            ffi::SQLITE_UPDATE => Action::Update,
+            _ => Action::Unknown,
         }
     }
 }

--- a/src/limits.rs
+++ b/src/limits.rs
@@ -11,38 +11,124 @@ use std::os::raw::c_int;
 /// - <https://www.sqlite.org/limits.html>
 #[repr(i32)]
 #[non_exhaustive]
-#[allow(clippy::upper_case_acronyms, non_camel_case_types)]
 #[cfg_attr(docsrs, doc(cfg(feature = "limits")))]
 pub enum Limit {
     /// The maximum size of any string or BLOB or table row, in bytes.
-    SQLITE_LIMIT_LENGTH = ffi::SQLITE_LIMIT_LENGTH,
+    ///
+    /// This is equivalent to `SQLITE_LIMIT_LENGTH` from the C api.
+    Length = ffi::SQLITE_LIMIT_LENGTH,
     /// The maximum length of an SQL statement, in bytes.
-    SQLITE_LIMIT_SQL_LENGTH = ffi::SQLITE_LIMIT_SQL_LENGTH,
+    ///
+    /// This is equivalent to `SQLITE_LIMIT_SQL_LENGTH` from the C api.
+    SqlLength = ffi::SQLITE_LIMIT_SQL_LENGTH,
     /// The maximum number of columns in a table definition or in the result set
     /// of a SELECT or the maximum number of columns in an index or in an
     /// ORDER BY or GROUP BY clause.
-    SQLITE_LIMIT_COLUMN = ffi::SQLITE_LIMIT_COLUMN,
+    ///
+    /// This is equivalent to `SQLITE_LIMIT_COLUMN` from the C api.
+    Columns = ffi::SQLITE_LIMIT_COLUMN,
     /// The maximum depth of the parse tree on any expression.
-    SQLITE_LIMIT_EXPR_DEPTH = ffi::SQLITE_LIMIT_EXPR_DEPTH,
+    ///
+    /// This is equivalent to `SQLITE_LIMIT_EXPR_DEPTH` from the C api.
+    ExprDepth = ffi::SQLITE_LIMIT_EXPR_DEPTH,
     /// The maximum number of terms in a compound SELECT statement.
-    SQLITE_LIMIT_COMPOUND_SELECT = ffi::SQLITE_LIMIT_COMPOUND_SELECT,
+    ///
+    /// This is equivalent to `SQLITE_LIMIT_COMPOUND_SELECT` from the C api.
+    CompoundSelectTerms = ffi::SQLITE_LIMIT_COMPOUND_SELECT,
     /// The maximum number of instructions in a virtual machine program used to
     /// implement an SQL statement.
-    SQLITE_LIMIT_VDBE_OP = ffi::SQLITE_LIMIT_VDBE_OP,
+    ///
+    /// This is equivalent to `SQLITE_LIMIT_VDBE_OP` from the C api.
+    VdbeInstructions = ffi::SQLITE_LIMIT_VDBE_OP,
     /// The maximum number of arguments on a function.
-    SQLITE_LIMIT_FUNCTION_ARG = ffi::SQLITE_LIMIT_FUNCTION_ARG,
+    ///
+    /// This is equivalent to `SQLITE_LIMIT_FUNCTION_ARG` from the C api.
+    FunctionArgs = ffi::SQLITE_LIMIT_FUNCTION_ARG,
     /// The maximum number of attached databases.
-    SQLITE_LIMIT_ATTACHED = ffi::SQLITE_LIMIT_ATTACHED,
+    ///
+    /// This is equivalent to `SQLITE_LIMIT_ATTACHED` from the C api.
+    AttachedDatabases = ffi::SQLITE_LIMIT_ATTACHED,
     /// The maximum length of the pattern argument to the LIKE or GLOB
     /// operators.
-    SQLITE_LIMIT_LIKE_PATTERN_LENGTH = ffi::SQLITE_LIMIT_LIKE_PATTERN_LENGTH,
+    ///
+    /// This is equivalent to `SQLITE_LIMIT_LIKE_PATTERN_LENGTH` from the C api.
+    LikePatternLength = ffi::SQLITE_LIMIT_LIKE_PATTERN_LENGTH,
     /// The maximum index number of any parameter in an SQL statement.
-    SQLITE_LIMIT_VARIABLE_NUMBER = ffi::SQLITE_LIMIT_VARIABLE_NUMBER,
+    ///
+    /// This is equivalent to `SQLITE_LIMIT_VARIABLE_NUMBER` from the C api.
+    NumParams = ffi::SQLITE_LIMIT_VARIABLE_NUMBER,
     /// The maximum depth of recursion for triggers.
-    SQLITE_LIMIT_TRIGGER_DEPTH = 10,
+    ///
+    /// This is equivalent to `SQLITE_LIMIT_TRIGGER_DEPTH` from the C api.
+    TriggerDepth = 10,
     /// The maximum number of auxiliary worker threads that a single prepared
     /// statement may start.
-    SQLITE_LIMIT_WORKER_THREADS = 11,
+    ///
+    /// This is equivalent to `SQLITE_LIMIT_WORKER_THREADS` from the C api.
+    WorkerThreads = 11,
+}
+
+impl Limit {
+    /// An alias for [`Limit::Length`].
+    ///
+    /// Provided for compatibility with the C API (as well as older versions of
+    /// `rusqlite`)
+    pub const SQLITE_LIMIT_LENGTH: Self = Self::Length;
+    /// An alias for [`Limit::SqlLength`].
+    ///
+    /// Provided for compatibility with the C API (as well as older versions of
+    /// `rusqlite`)
+    pub const SQLITE_LIMIT_SQL_LENGTH: Self = Self::SqlLength;
+    /// An alias for [`Limit::Columns`].
+    ///
+    /// Provided for compatibility with the C API (as well as older versions of
+    /// `rusqlite`)
+    pub const SQLITE_LIMIT_COLUMN: Self = Self::Columns;
+    /// An alias for [`Limit::ExprDepth`].
+    ///
+    /// Provided for compatibility with the C API (as well as older versions of
+    /// `rusqlite`)
+    pub const SQLITE_LIMIT_EXPR_DEPTH: Self = Self::ExprDepth;
+    /// An alias for [`Limit::CompoundSelectTerms`].
+    ///
+    /// Provided for compatibility with the C API (as well as older versions of
+    /// `rusqlite`)
+    pub const SQLITE_LIMIT_COMPOUND_SELECT: Self = Self::CompoundSelectTerms;
+    /// An alias for [`Limit::VdbeInstructions`].
+    ///
+    /// Provided for compatibility with the C API (as well as older versions of
+    /// `rusqlite`)
+    pub const SQLITE_LIMIT_VDBE_OP: Self = Self::VdbeInstructions;
+    /// An alias for [`Limit::FunctionArgs`].
+    ///
+    /// Provided for compatibility with the C API (as well as older versions of
+    /// `rusqlite`)
+    pub const SQLITE_LIMIT_FUNCTION_ARG: Self = Self::FunctionArgs;
+    /// An alias for [`Limit::AttachedDatabases`].
+    ///
+    /// Provided for compatibility with the C API (as well as older versions of
+    /// `rusqlite`)
+    pub const SQLITE_LIMIT_ATTACHED: Self = Self::AttachedDatabases;
+    /// An alias for [`Limit::LikePatternLength`].
+    ///
+    /// Provided for compatibility with the C API (as well as older versions of
+    /// `rusqlite`)
+    pub const SQLITE_LIMIT_LIKE_PATTERN_LENGTH: Self = Self::LikePatternLength;
+    /// An alias for [`Limit::NumParams`].
+    ///
+    /// Provided for compatibility with the C API (as well as older versions of
+    /// `rusqlite`)
+    pub const SQLITE_LIMIT_VARIABLE_NUMBER: Self = Self::NumParams;
+    /// An alias for [`Limit::TriggerDepth`].
+    ///
+    /// Provided for compatibility with the C API (as well as older versions of
+    /// `rusqlite`)
+    pub const SQLITE_LIMIT_TRIGGER_DEPTH: Self = Self::TriggerDepth;
+    /// An alias for [`Limit::WorkerThreads`].
+    ///
+    /// Provided for compatibility with the C API (as well as older versions of
+    /// `rusqlite`)
+    pub const SQLITE_LIMIT_WORKER_THREADS: Self = Self::WorkerThreads;
 }
 
 impl Connection {
@@ -54,7 +140,7 @@ impl Connection {
         unsafe { ffi::sqlite3_limit(c.db(), limit as c_int, -1) }
     }
 
-    /// Changes the [`Limit`] to `new_val`, returning the prior
+    /// Changes the [`Limit`]'s value to `new_val`, returning the prior
     /// value of the limit.
     #[inline]
     #[cfg_attr(docsrs, doc(cfg(feature = "limits")))]
@@ -70,99 +156,78 @@ mod test {
     use crate::{Connection, Result};
 
     #[test]
+    #[cfg(feature = "bundled")]
     fn test_limit_values() {
-        assert_eq!(
-            Limit::SQLITE_LIMIT_LENGTH as i32,
-            ffi::SQLITE_LIMIT_LENGTH as i32,
-        );
-        assert_eq!(
-            Limit::SQLITE_LIMIT_SQL_LENGTH as i32,
-            ffi::SQLITE_LIMIT_SQL_LENGTH as i32,
-        );
-        assert_eq!(
-            Limit::SQLITE_LIMIT_COLUMN as i32,
-            ffi::SQLITE_LIMIT_COLUMN as i32,
-        );
-        assert_eq!(
-            Limit::SQLITE_LIMIT_EXPR_DEPTH as i32,
-            ffi::SQLITE_LIMIT_EXPR_DEPTH as i32,
-        );
-        assert_eq!(
-            Limit::SQLITE_LIMIT_COMPOUND_SELECT as i32,
-            ffi::SQLITE_LIMIT_COMPOUND_SELECT as i32,
-        );
-        assert_eq!(
-            Limit::SQLITE_LIMIT_VDBE_OP as i32,
-            ffi::SQLITE_LIMIT_VDBE_OP as i32,
-        );
-        assert_eq!(
-            Limit::SQLITE_LIMIT_FUNCTION_ARG as i32,
-            ffi::SQLITE_LIMIT_FUNCTION_ARG as i32,
-        );
-        assert_eq!(
-            Limit::SQLITE_LIMIT_ATTACHED as i32,
-            ffi::SQLITE_LIMIT_ATTACHED as i32,
-        );
-        assert_eq!(
-            Limit::SQLITE_LIMIT_LIKE_PATTERN_LENGTH as i32,
-            ffi::SQLITE_LIMIT_LIKE_PATTERN_LENGTH as i32,
-        );
-        assert_eq!(
-            Limit::SQLITE_LIMIT_VARIABLE_NUMBER as i32,
-            ffi::SQLITE_LIMIT_VARIABLE_NUMBER as i32,
-        );
-        #[cfg(feature = "bundled")]
-        assert_eq!(
-            Limit::SQLITE_LIMIT_TRIGGER_DEPTH as i32,
-            ffi::SQLITE_LIMIT_TRIGGER_DEPTH as i32,
-        );
-        #[cfg(feature = "bundled")]
-        assert_eq!(
-            Limit::SQLITE_LIMIT_WORKER_THREADS as i32,
-            ffi::SQLITE_LIMIT_WORKER_THREADS as i32,
-        );
+        macro_rules! check_all {
+            ($(($RustName:ident, $SQLITE_NAME:ident)),+ $(,)?) => {{
+                // Hack to force a compile failure if we add a DbConfig variant
+                // without updating this test.
+                const _: fn(Limit) = |r| match r { $(Limit::$RustName => {}),+ };
+                $({
+                    assert_eq!(Limit::$RustName as i32, crate::ffi::$SQLITE_NAME as i32);
+                    assert_eq!(
+                        Limit::$SQLITE_NAME as i32,
+                        crate::ffi::$SQLITE_NAME as i32,
+                    );
+                })+
+            }};
+        }
+        check_all![
+            (Length, SQLITE_LIMIT_LENGTH),
+            (SqlLength, SQLITE_LIMIT_SQL_LENGTH),
+            (Columns, SQLITE_LIMIT_COLUMN),
+            (ExprDepth, SQLITE_LIMIT_EXPR_DEPTH),
+            (CompoundSelectTerms, SQLITE_LIMIT_COMPOUND_SELECT),
+            (VdbeInstructions, SQLITE_LIMIT_VDBE_OP),
+            (FunctionArgs, SQLITE_LIMIT_FUNCTION_ARG),
+            (AttachedDatabases, SQLITE_LIMIT_ATTACHED),
+            (LikePatternLength, SQLITE_LIMIT_LIKE_PATTERN_LENGTH),
+            (NumParams, SQLITE_LIMIT_VARIABLE_NUMBER),
+            (TriggerDepth, SQLITE_LIMIT_TRIGGER_DEPTH),
+            (WorkerThreads, SQLITE_LIMIT_WORKER_THREADS),
+        ];
     }
 
     #[test]
     fn test_limit() -> Result<()> {
         let db = Connection::open_in_memory()?;
-        db.set_limit(Limit::SQLITE_LIMIT_LENGTH, 1024);
-        assert_eq!(1024, db.limit(Limit::SQLITE_LIMIT_LENGTH));
+        db.set_limit(Limit::Length, 1024);
+        assert_eq!(1024, db.limit(Limit::Length));
 
-        db.set_limit(Limit::SQLITE_LIMIT_SQL_LENGTH, 1024);
-        assert_eq!(1024, db.limit(Limit::SQLITE_LIMIT_SQL_LENGTH));
+        db.set_limit(Limit::SqlLength, 1024);
+        assert_eq!(1024, db.limit(Limit::SqlLength));
 
-        db.set_limit(Limit::SQLITE_LIMIT_COLUMN, 64);
-        assert_eq!(64, db.limit(Limit::SQLITE_LIMIT_COLUMN));
+        db.set_limit(Limit::Columns, 64);
+        assert_eq!(64, db.limit(Limit::Columns));
 
-        db.set_limit(Limit::SQLITE_LIMIT_EXPR_DEPTH, 256);
-        assert_eq!(256, db.limit(Limit::SQLITE_LIMIT_EXPR_DEPTH));
+        db.set_limit(Limit::ExprDepth, 256);
+        assert_eq!(256, db.limit(Limit::ExprDepth));
 
-        db.set_limit(Limit::SQLITE_LIMIT_COMPOUND_SELECT, 32);
-        assert_eq!(32, db.limit(Limit::SQLITE_LIMIT_COMPOUND_SELECT));
+        db.set_limit(Limit::CompoundSelectTerms, 32);
+        assert_eq!(32, db.limit(Limit::CompoundSelectTerms));
 
-        db.set_limit(Limit::SQLITE_LIMIT_FUNCTION_ARG, 32);
-        assert_eq!(32, db.limit(Limit::SQLITE_LIMIT_FUNCTION_ARG));
+        db.set_limit(Limit::NumParams, 32);
+        assert_eq!(32, db.limit(Limit::NumParams));
 
-        db.set_limit(Limit::SQLITE_LIMIT_ATTACHED, 2);
-        assert_eq!(2, db.limit(Limit::SQLITE_LIMIT_ATTACHED));
+        db.set_limit(Limit::AttachedDatabases, 2);
+        assert_eq!(2, db.limit(Limit::AttachedDatabases));
 
-        db.set_limit(Limit::SQLITE_LIMIT_LIKE_PATTERN_LENGTH, 128);
-        assert_eq!(128, db.limit(Limit::SQLITE_LIMIT_LIKE_PATTERN_LENGTH));
+        db.set_limit(Limit::LikePatternLength, 128);
+        assert_eq!(128, db.limit(Limit::LikePatternLength));
 
-        db.set_limit(Limit::SQLITE_LIMIT_VARIABLE_NUMBER, 99);
-        assert_eq!(99, db.limit(Limit::SQLITE_LIMIT_VARIABLE_NUMBER));
+        db.set_limit(Limit::NumParams, 99);
+        assert_eq!(99, db.limit(Limit::NumParams));
 
         // SQLITE_LIMIT_TRIGGER_DEPTH was added in SQLite 3.6.18.
         if crate::version_number() >= 3_006_018 {
-            db.set_limit(Limit::SQLITE_LIMIT_TRIGGER_DEPTH, 32);
-            assert_eq!(32, db.limit(Limit::SQLITE_LIMIT_TRIGGER_DEPTH));
+            db.set_limit(Limit::TriggerDepth, 32);
+            assert_eq!(32, db.limit(Limit::TriggerDepth));
         }
 
         // SQLITE_LIMIT_WORKER_THREADS was added in SQLite 3.8.7.
         if crate::version_number() >= 3_008_007 {
-            db.set_limit(Limit::SQLITE_LIMIT_WORKER_THREADS, 2);
-            assert_eq!(2, db.limit(Limit::SQLITE_LIMIT_WORKER_THREADS));
+            db.set_limit(Limit::WorkerThreads, 2);
+            assert_eq!(2, db.limit(Limit::WorkerThreads));
         }
         Ok(())
     }

--- a/src/vtab/array.rs
+++ b/src/vtab/array.rs
@@ -96,7 +96,7 @@ unsafe impl<'vtab> VTab<'vtab> for ArrayTab {
             if !constraint.is_usable() {
                 continue;
             }
-            if constraint.operator() != IndexConstraintOp::SQLITE_INDEX_CONSTRAINT_EQ {
+            if constraint.operator() != IndexConstraintOp::Eq {
                 continue;
             }
             if let CARRAY_COLUMN_POINTER = constraint.column() {

--- a/src/vtab/mod.rs
+++ b/src/vtab/mod.rs
@@ -171,11 +171,11 @@ pub fn eponymous_only_module<'vtab, T: VTab<'vtab>>() -> &'static Module<'vtab, 
 #[cfg(feature = "modern_sqlite")] // 3.7.7
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub enum VTabConfig {
-    /// Equivalent to SQLITE_VTAB_CONSTRAINT_SUPPORT
+    /// Equivalent to `SQLITE_VTAB_CONSTRAINT_SUPPORT`
     ConstraintSupport = 1,
-    /// Equivalent to SQLITE_VTAB_INNOCUOUS
+    /// Equivalent to `SQLITE_VTAB_INNOCUOUS`
     Innocuous = 2,
-    /// Equivalent to SQLITE_VTAB_DIRECTONLY
+    /// Equivalent to `SQLITE_VTAB_DIRECTONLY`
     DirectOnly = 3,
 }
 
@@ -280,51 +280,153 @@ pub trait CreateVTab<'vtab>: VTab<'vtab> {
     }
 }
 
-/// Index constraint operator.
-/// See [Virtual Table Constraint Operator Codes](https://sqlite.org/c3ref/c_index_constraint_eq.html) for details.
-#[derive(Debug, PartialEq)]
-#[allow(non_snake_case, non_camel_case_types, missing_docs)]
-#[allow(clippy::upper_case_acronyms)]
+/// Index constraint operator. See [Virtual Table Constraint Operator
+/// Codes](https://sqlite.org/c3ref/c_index_constraint_eq.html) for details.
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum IndexConstraintOp {
-    SQLITE_INDEX_CONSTRAINT_EQ,
-    SQLITE_INDEX_CONSTRAINT_GT,
-    SQLITE_INDEX_CONSTRAINT_LE,
-    SQLITE_INDEX_CONSTRAINT_LT,
-    SQLITE_INDEX_CONSTRAINT_GE,
-    SQLITE_INDEX_CONSTRAINT_MATCH,
-    SQLITE_INDEX_CONSTRAINT_LIKE,         // 3.10.0
-    SQLITE_INDEX_CONSTRAINT_GLOB,         // 3.10.0
-    SQLITE_INDEX_CONSTRAINT_REGEXP,       // 3.10.0
-    SQLITE_INDEX_CONSTRAINT_NE,           // 3.21.0
-    SQLITE_INDEX_CONSTRAINT_ISNOT,        // 3.21.0
-    SQLITE_INDEX_CONSTRAINT_ISNOTNULL,    // 3.21.0
-    SQLITE_INDEX_CONSTRAINT_ISNULL,       // 3.21.0
-    SQLITE_INDEX_CONSTRAINT_IS,           // 3.21.0
-    SQLITE_INDEX_CONSTRAINT_LIMIT,        // 3.38.0
-    SQLITE_INDEX_CONSTRAINT_OFFSET,       // 3.38.0
-    SQLITE_INDEX_CONSTRAINT_FUNCTION(u8), // 3.25.0
+    /// Equivalent to `SQLITE_INDEX_CONSTRAINT_EQ` in the C API.
+    Eq,
+    /// Equivalent to `SQLITE_INDEX_CONSTRAINT_GT` in the C API.
+    Gt,
+    /// Equivalent to `SQLITE_INDEX_CONSTRAINT_LE` in the C API.
+    Le,
+    /// Equivalent to `SQLITE_INDEX_CONSTRAINT_LT` in the C API.
+    Lt,
+    /// Equivalent to `SQLITE_INDEX_CONSTRAINT_GE` in the C API.
+    Ge,
+    /// Equivalent to `SQLITE_INDEX_CONSTRAINT_MATCH` in the C API.
+    Match,
+    /// Equivalent to `SQLITE_INDEX_CONSTRAINT_LIKE` in the C API.
+    ///
+    /// Requires SQLite version 3.10.0 or later.
+    Like,
+    /// Equivalent to `SQLITE_INDEX_CONSTRAINT_GLOB` in the C API.
+    ///
+    /// Requires SQLite version 3.10.0 or later.
+    Glob,
+    /// Equivalent to `SQLITE_INDEX_CONSTRAINT_REGEXP` in the C API.
+    ///
+    /// Requires SQLite version 3.10.0 or later.
+    Regexp,
+    /// Equivalent to `SQLITE_INDEX_CONSTRAINT_NE` in the C API.
+    ///
+    /// Requires SQLite version 3.21.0 or later.
+    Ne,
+    /// Equivalent to `SQLITE_INDEX_CONSTRAINT_ISNOT` in the C API.
+    ///
+    /// Requires SQLite version 3.21.0 or later.
+    IsNot,
+    /// Equivalent to `SQLITE_INDEX_CONSTRAINT_ISNOTNULL` in the C API.
+    ///
+    /// Requires SQLite version 3.21.0 or later.
+    IsNotNull,
+    /// Equivalent to `SQLITE_INDEX_CONSTRAINT_ISNULL` in the C API.
+    ///
+    /// Requires SQLite version 3.21.0 or later.
+    IsNull,
+    /// Equivalent to `SQLITE_INDEX_CONSTRAINT_IS` in the C API.
+    ///
+    /// Requires SQLite version 3.21.0 or later.
+    Is,
+    /// Equivalent to `SQLITE_INDEX_CONSTRAINT_LIMIT` in the C API.
+    ///
+    /// Requires SQLite version 3.38.0 or later.
+    Limit,
+    /// Equivalent to `SQLITE_INDEX_CONSTRAINT_OFFSET` in the C API.
+    ///
+    /// Requires SQLite version 3.38.0 or later.
+    Offset,
+    /// A function which has been overloaded by
+    /// [`xFindFunction`](https://sqlite.org/vtab.html#xfindfunction).
+    ///
+    /// Should be between 150 and 255, but this is not enforced, so it also may
+    /// be possible to use this as a catch-all/escape-hatch for variants which
+    /// are not yet supported.
+    ///
+    /// Note: `xFindFunction` is not currently exposed by `rusqlite`.
+    #[doc(alias = "SQLITE_INDEX_CONSTRAINT_FUNCTION")]
+    Function(
+        /// Indicates which function. Should be greater or equal to
+        /// [`IndexConstraintOp::FUNCTION_MIN`].
+        u8,
+    ),
+}
+
+impl IndexConstraintOp {
+    /// An alias for [`IndexConstraintOp::Eq`], provided for compatibility with
+    /// the C API.
+    pub const SQLITE_INDEX_CONSTRAINT_EQ: Self = Self::Eq;
+    /// An alias for [`IndexConstraintOp::Gt`], provided for compatibility with
+    /// the C API.
+    pub const SQLITE_INDEX_CONSTRAINT_GT: Self = Self::Gt;
+    /// An alias for [`IndexConstraintOp::Le`], provided for compatibility with
+    /// the C API.
+    pub const SQLITE_INDEX_CONSTRAINT_LE: Self = Self::Le;
+    /// An alias for [`IndexConstraintOp::Lt`], provided for compatibility with
+    /// the C API.
+    pub const SQLITE_INDEX_CONSTRAINT_LT: Self = Self::Lt;
+    /// An alias for [`IndexConstraintOp::Ge`], provided for compatibility with
+    /// the C API.
+    pub const SQLITE_INDEX_CONSTRAINT_GE: Self = Self::Ge;
+    /// An alias for [`IndexConstraintOp::Match`], provided for compatibility
+    /// with the C API.
+    pub const SQLITE_INDEX_CONSTRAINT_MATCH: Self = Self::Match;
+    /// An alias for [`IndexConstraintOp::Like`], provided for compatibility
+    /// with the C API.
+    pub const SQLITE_INDEX_CONSTRAINT_LIKE: Self = Self::Like;
+    /// An alias for [`IndexConstraintOp::Glob`], provided for compatibility
+    /// with the C API.
+    pub const SQLITE_INDEX_CONSTRAINT_GLOB: Self = Self::Glob;
+    /// An alias for [`IndexConstraintOp::Regexp`], provided for compatibility
+    /// with the C API.
+    pub const SQLITE_INDEX_CONSTRAINT_REGEXP: Self = Self::Regexp;
+    /// An alias for [`IndexConstraintOp::Ne`], provided for compatibility with
+    /// the C API.
+    pub const SQLITE_INDEX_CONSTRAINT_NE: Self = Self::Ne;
+    /// An alias for [`IndexConstraintOp::IsNot`], provided for compatibility
+    /// with the C API.
+    pub const SQLITE_INDEX_CONSTRAINT_ISNOT: Self = Self::IsNot;
+    /// An alias for [`IndexConstraintOp::IsNotNull`], provided for
+    /// compatibility with the C API.
+    pub const SQLITE_INDEX_CONSTRAINT_ISNOTNULL: Self = Self::IsNotNull;
+    /// An alias for [`IndexConstraintOp::IsNull`], provided for compatibility
+    /// with the C API.
+    pub const SQLITE_INDEX_CONSTRAINT_ISNULL: Self = Self::IsNull;
+    /// An alias for [`IndexConstraintOp::Is`], provided for compatibility with
+    /// the C API.
+    pub const SQLITE_INDEX_CONSTRAINT_IS: Self = Self::Is;
+    /// An alias for [`IndexConstraintOp::Limit`], provided for compatibility
+    /// with the C API.
+    pub const SQLITE_INDEX_CONSTRAINT_LIMIT: Self = Self::Limit;
+    /// An alias for [`IndexConstraintOp::Offset`], provided for compatibility
+    /// with the C API.
+    pub const SQLITE_INDEX_CONSTRAINT_OFFSET: Self = Self::Offset;
+
+    /// The lowest value that should be used with `IndexConstraintOp::Function`,
+    /// (but note that this is not enforced).
+    pub const FUNCTION_MIN: u8 = 150;
 }
 
 impl From<u8> for IndexConstraintOp {
     fn from(code: u8) -> IndexConstraintOp {
         match code {
-            2 => IndexConstraintOp::SQLITE_INDEX_CONSTRAINT_EQ,
-            4 => IndexConstraintOp::SQLITE_INDEX_CONSTRAINT_GT,
-            8 => IndexConstraintOp::SQLITE_INDEX_CONSTRAINT_LE,
-            16 => IndexConstraintOp::SQLITE_INDEX_CONSTRAINT_LT,
-            32 => IndexConstraintOp::SQLITE_INDEX_CONSTRAINT_GE,
-            64 => IndexConstraintOp::SQLITE_INDEX_CONSTRAINT_MATCH,
-            65 => IndexConstraintOp::SQLITE_INDEX_CONSTRAINT_LIKE,
-            66 => IndexConstraintOp::SQLITE_INDEX_CONSTRAINT_GLOB,
-            67 => IndexConstraintOp::SQLITE_INDEX_CONSTRAINT_REGEXP,
-            68 => IndexConstraintOp::SQLITE_INDEX_CONSTRAINT_NE,
-            69 => IndexConstraintOp::SQLITE_INDEX_CONSTRAINT_ISNOT,
-            70 => IndexConstraintOp::SQLITE_INDEX_CONSTRAINT_ISNOTNULL,
-            71 => IndexConstraintOp::SQLITE_INDEX_CONSTRAINT_ISNULL,
-            72 => IndexConstraintOp::SQLITE_INDEX_CONSTRAINT_IS,
-            73 => IndexConstraintOp::SQLITE_INDEX_CONSTRAINT_LIMIT,
-            74 => IndexConstraintOp::SQLITE_INDEX_CONSTRAINT_OFFSET,
-            v => IndexConstraintOp::SQLITE_INDEX_CONSTRAINT_FUNCTION(v),
+            2 => IndexConstraintOp::Eq,
+            4 => IndexConstraintOp::Gt,
+            8 => IndexConstraintOp::Le,
+            16 => IndexConstraintOp::Lt,
+            32 => IndexConstraintOp::Ge,
+            64 => IndexConstraintOp::Match,
+            65 => IndexConstraintOp::Like,
+            66 => IndexConstraintOp::Glob,
+            67 => IndexConstraintOp::Regexp,
+            68 => IndexConstraintOp::Ne,
+            69 => IndexConstraintOp::IsNot,
+            70 => IndexConstraintOp::IsNotNull,
+            71 => IndexConstraintOp::IsNull,
+            72 => IndexConstraintOp::Is,
+            73 => IndexConstraintOp::Limit,
+            74 => IndexConstraintOp::Offset,
+            v => IndexConstraintOp::Function(v),
         }
     }
 }
@@ -1256,5 +1358,57 @@ mod test {
         assert_eq!(Some(false), super::parse_boolean("no"));
         assert_eq!(Some(false), super::parse_boolean("off"));
         assert_eq!(Some(false), super::parse_boolean("false"));
+    }
+    // SQLcipher bundled is behind SQLite. We can remove this when the bundled
+    // SQLcipher has caught up to 3.38.0.
+    #[test]
+    #[cfg(all(feature = "bundled", not(feature = "bundled-sqlcipher")))]
+    fn test_index_constraint_op_values() {
+        use super::IndexConstraintOp;
+        macro_rules! check_all {
+            ($(($RustName:ident, $SQLITE_NAME:ident)),+ $(,)?) => {{
+                // Hack to force a compile failure if we add a variant without
+                // updating this test.
+                const _: fn(IndexConstraintOp) = |r| match r {
+                    IndexConstraintOp::Function(_) => {},
+                    $(IndexConstraintOp::$RustName => {})+
+                };
+                $({
+                    assert_eq!(
+                        IndexConstraintOp::$RustName,
+                        IndexConstraintOp::$SQLITE_NAME,
+                    );
+                    assert_eq!(
+                        IndexConstraintOp::from(crate::ffi::$SQLITE_NAME as u8),
+                        IndexConstraintOp::$RustName,
+                    );
+                })+
+            }};
+        }
+        check_all![
+            (Eq, SQLITE_INDEX_CONSTRAINT_EQ),
+            (Gt, SQLITE_INDEX_CONSTRAINT_GT),
+            (Le, SQLITE_INDEX_CONSTRAINT_LE),
+            (Lt, SQLITE_INDEX_CONSTRAINT_LT),
+            (Ge, SQLITE_INDEX_CONSTRAINT_GE),
+            (Match, SQLITE_INDEX_CONSTRAINT_MATCH),
+            (Like, SQLITE_INDEX_CONSTRAINT_LIKE),
+            (Glob, SQLITE_INDEX_CONSTRAINT_GLOB),
+            (Regexp, SQLITE_INDEX_CONSTRAINT_REGEXP),
+            (Ne, SQLITE_INDEX_CONSTRAINT_NE),
+            (IsNot, SQLITE_INDEX_CONSTRAINT_ISNOT),
+            (IsNotNull, SQLITE_INDEX_CONSTRAINT_ISNOTNULL),
+            (IsNull, SQLITE_INDEX_CONSTRAINT_ISNULL),
+            (Is, SQLITE_INDEX_CONSTRAINT_IS),
+            (Limit, SQLITE_INDEX_CONSTRAINT_LIMIT),
+            (Offset, SQLITE_INDEX_CONSTRAINT_OFFSET),
+        ];
+        assert_eq!(
+            IndexConstraintOp::FUNCTION_MIN as i32,
+            crate::ffi::SQLITE_INDEX_CONSTRAINT_FUNCTION,
+        );
+        for i in IndexConstraintOp::FUNCTION_MIN..=255 {
+            assert_eq!(IndexConstraintOp::from(i), IndexConstraintOp::Function(i));
+        }
     }
 }

--- a/src/vtab/series.rs
+++ b/src/vtab/series.rs
@@ -92,7 +92,7 @@ unsafe impl<'vtab> VTab<'vtab> for SeriesTab {
             };
             if !constraint.is_usable() {
                 unusable_mask |= i_mask;
-            } else if constraint.operator() == IndexConstraintOp::SQLITE_INDEX_CONSTRAINT_EQ {
+            } else if constraint.operator() == IndexConstraintOp::Eq {
                 idx_num |= i_mask;
                 a_idx[i_col] = Some(i);
             }


### PR DESCRIPTION
Fixes #1095.

I think this is technically breaking, because you can `use` an enum's variant to bring it into scope, but this is not allowed for constants. So code that does this would break:

```rs
use rusqlite::DbConfig::SQLITE_DBCONFIG_ENABLE_FKEY;
conn.db_config(SQLITE_DBCONFIG_ENABLE_FKEY)
```

~~Short of that, other cases should not be broken.~~ EDIT: This was not possible for `IndexConstraintOp`, since it had the `SQLITE_INDEX_CONSTRAINT_FUNCTION` variant. I doubt many people use this, because we don't expose `xFindFunction`, so I just renamed it.

Other notes:

1. Cases which don't correspond to SQLite's constants (for example, `UNKNOWN` variants) are present as associated constants, but have had the capitalized versions deprecated, since the "compatibility with SQLite C API" argument doesn't hold. Some of these probably also should be `TryFrom` impls rather than `From`.

2. Some DbConfig values were gated on `feature = "modern_sqlite"`. This has been removed, in favor of noting that they will fail if you try to use it in an unsupported version. This is useful if you want to toggle the feature if it's supported, but do nothing if not. For example, it seems reasonable to allow code like the following:

    ```rs
    if let Err(e) = conn.set_db_config(rusqlite::DbConfig::Defensive, true) {
        // Might be in an old version of SQLite, continue anyway...
        log::warn!("Failed to enable defensive mode: {:?}", e);
    }
    ```

3. I only bothered with the value tests for cases where there were a large number of variants.

4. In several cases, I also tried to improve the docs.