### PR TITLE
Add `Connection::release_memory` method

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,6 +43,8 @@ collation = []
 functions = ["libsqlite3-sys/min_sqlite_version_3_7_7"]
 # sqlite3_log: 3.6.23 (2010-03-09)
 trace = ["libsqlite3-sys/min_sqlite_version_3_6_23"]
+# sqlite3_db_release_memory: 3.7.10 (2012-01-16)
+release_memory = ["libsqlite3-sys/min_sqlite_version_3_7_16"]
 bundled = ["libsqlite3-sys/bundled", "modern_sqlite"]
 bundled-sqlcipher = ["libsqlite3-sys/bundled-sqlcipher", "bundled"]
 bundled-sqlcipher-vendored-openssl = ["libsqlite3-sys/bundled-sqlcipher-vendored-openssl", "bundled-sqlcipher"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -595,6 +595,21 @@ impl Connection {
         self.path.as_deref()
     }
 
+    /// Attempts to free as much heap memory as possible from the database
+    /// connection.
+    ///
+    /// This calls [`sqlite3_db_release_memory`](https://www.sqlite.org/c3ref/db_release_memory.html).
+    #[inline]
+    #[cfg(feature = "release_memory")]
+    pub fn release_memory(&self) -> Result<()> {
+        unsafe {
+            match crate::ffi::sqlite3_db_release_memory(self.handle()) {
+                ffi::SQLITE_OK => Ok(()),
+                error => Err(error_from_sqlite_code(error)),
+            }
+        }
+    }
+
     /// Convenience method to prepare and execute a single SQL statement with
     /// named parameter(s).
     ///


### PR DESCRIPTION
This is behind a new `release_memory` feature flag. It simply calls [`sqlite3_db_release_memory`](https://www.sqlite.org/c3ref/db_release_memory.html) on the raw handle.

Open questions:
- How should we expose [`sqlite3_release_memory`](https://www.sqlite.org/c3ref/release_memory.html)?
- Can we add `#[doc(alias = "sqlite3_db_release_memory")]`? It would require at least Rust 1.48. This can perhaps be its own issue/PR.
- Should types with exclusive access to `Connection` expose this operation? Or expose the underlying connection reference?