### PR TITLE
Do not use Connection::handle()

### DIFF
--- a/src/inner_connection.rs
+++ b/src/inner_connection.rs
@@ -360,6 +360,12 @@ impl InnerConnection {
             )),
         }
     }
+
+    #[inline]
+    #[cfg(feature = "release_memory")]
+    pub fn release_memory(&self) -> Result<()> {
+        self.decode_result(unsafe { ffi::sqlite3_db_release_memory(self.db) })
+    }
 }
 
 impl Drop for InnerConnection {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -602,12 +602,7 @@ impl Connection {
     #[inline]
     #[cfg(feature = "release_memory")]
     pub fn release_memory(&self) -> Result<()> {
-        unsafe {
-            match crate::ffi::sqlite3_db_release_memory(self.handle()) {
-                ffi::SQLITE_OK => Ok(()),
-                error => Err(error_from_sqlite_code(error)),
-            }
-        }
+        self.db.borrow_mut().release_memory()
     }
 
     /// Convenience method to prepare and execute a single SQL statement with


### PR DESCRIPTION
https://docs.rs/rusqlite/latest/rusqlite/struct.Connection.html#method.handle
```
You should not need to use this function...
```
And use `decode_result`...