### PR TITLE
Params for 28-length arrays

### DIFF
--- a/src/params.rs
+++ b/src/params.rs
@@ -327,7 +327,7 @@ macro_rules! impl_for_array_ref {
 // don't really think it matters -- users who hit that can use `params!` anyway.
 impl_for_array_ref!(
     1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17
-    18 19 20 21 22 23 24 25 26 27 29 30 31 32
+    18 19 20 21 22 23 24 25 26 27 28 29 30 31 32
 );
 
 /// Adapter type which allows any iterator over [`ToSql`] values to implement


### PR DESCRIPTION
Fix #1162