### PR TITLE
Trimming whitespaces on named_params args.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -215,7 +215,7 @@ macro_rules! named_params {
     // Note: It's a lot more work to support this as part of the same macro as
     // `params!`, unfortunately.
     ($($param_name:literal: $param_val:expr),+ $(,)?) => {
-        &[$(($param_name, &$param_val as &dyn $crate::ToSql)),+] as &[(&str, &dyn $crate::ToSql)]
+        &[$((($param_name).replace(" ", ""), &$param_val as &dyn $crate::ToSql)),+] as &[(&str, &dyn $crate::ToSql)]
     };
 }
 


### PR DESCRIPTION
It's really annoying that i have to perfectly sanitize whitespaces when using this. 

Example:
```rust       
    conn.execute(
        "INSERT INTO accounts (
            address                   ,
            num_entered_as_signed_rw  ,
            num_entered_as_signed_r   ,
            num_entered_as_unsigned_rw,
            num_entered_as_unsigned_r ,
            tx_top_mentions           ,
            ix_mentions               ,
            is_pda                    ,
            num_call_to               ,
            is_program                ,
            total_data_length         ,
            total_data_occurences     ,
            num_zero_len_data        
        ) values (
            :address                   ,
            :num_entered_as_signed_rw  ,
            :num_entered_as_signed_r   ,
            :num_entered_as_unsigned_rw,
            :num_entered_as_unsigned_r ,
            :tx_top_mentions           ,
            :ix_mentions               ,
            :is_pda                    ,
            :num_call_to               ,
            :is_program                ,
            :total_data_length         ,
            :total_data_occurences     ,
            :num_zero_len_data        
        )",
        named_params! {
            ":address "                    :address_hash                            ,
            ":num_entered_as_signed_rw"   :accprofile   .num_entered_as_signed_rw  ,
            ":num_entered_as_signed_r"    :accprofile   .num_entered_as_signed_r   ,
            ":num_entered_as_unsigned_rw" :accprofile   .num_entered_as_unsigned_rw,
            ":num_entered_as_unsigned_r"  :accprofile   .num_entered_as_unsigned_r ,
            ":tx_top_mentions"            :accprofile   .tx_top_mentions           ,
            ":ix_mentions"                :accprofile   .ix_mentions               ,
            ":is_pda"                     :accprofile   .is_pda                    ,
            ":num_call_to"                :accprofile   .num_call_to               ,
            ":is_program"                 :accprofile   .is_program                ,
            ":total_data_length"          :accprofile   .arg_data.total_length     ,
            ":total_data_occurences"      :accprofile   .arg_data.num_occurences   ,
            ":num_zero_len_data"          :accprofile   .num_zero_len_data         ,
        },
    )?;
```

Fails with ```thread 'main' panicked at 'called `Result::unwrap()` on an `Err` value: InvalidParameterName(":address ")', src/sqlite_main.rs:36:42
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace```.