### PR TITLE
Drop test_layout bindgen tests from stored versions

### DIFF
--- a/libsqlite3-sys/bindgen-bindings/bindgen_3.6.23.rs
+++ b/libsqlite3-sys/bindgen-bindings/bindgen_3.6.23.rs
@@ -349,20 +349,8 @@ pub struct sqlite3_file_sqlite3_io_methods {
                                                           ->
                                                               ::std::os::raw::c_int>,
 }
-#[test]
-fn bindgen_test_layout_sqlite3_file_sqlite3_io_methods() {
-    assert_eq!(::std::mem::size_of::<sqlite3_file_sqlite3_io_methods>() ,
-               104usize);
-    assert_eq!(::std::mem::align_of::<sqlite3_file_sqlite3_io_methods>() ,
-               8usize);
-}
 impl Clone for sqlite3_file_sqlite3_io_methods {
     fn clone(&self) -> Self { *self }
-}
-#[test]
-fn bindgen_test_layout_sqlite3_file() {
-    assert_eq!(::std::mem::size_of::<sqlite3_file>() , 8usize);
-    assert_eq!(::std::mem::align_of::<sqlite3_file>() , 8usize);
 }
 impl Clone for sqlite3_file {
     fn clone(&self) -> Self { *self }
@@ -464,11 +452,6 @@ pub struct sqlite3_vfs {
                                                                       *mut ::std::os::raw::c_char)
                                                  -> ::std::os::raw::c_int>,
 }
-#[test]
-fn bindgen_test_layout_sqlite3_vfs() {
-    assert_eq!(::std::mem::size_of::<sqlite3_vfs>() , 136usize);
-    assert_eq!(::std::mem::align_of::<sqlite3_vfs>() , 8usize);
-}
 impl Clone for sqlite3_vfs {
     fn clone(&self) -> Self { *self }
 }
@@ -518,11 +501,6 @@ pub struct sqlite3_mem_methods {
     pub xShutdown: ::std::option::Option<unsafe extern "C" fn(arg1:
                                                                   *mut ::std::os::raw::c_void)>,
     pub pAppData: *mut ::std::os::raw::c_void,
-}
-#[test]
-fn bindgen_test_layout_sqlite3_mem_methods() {
-    assert_eq!(::std::mem::size_of::<sqlite3_mem_methods>() , 64usize);
-    assert_eq!(::std::mem::align_of::<sqlite3_mem_methods>() , 8usize);
 }
 impl Clone for sqlite3_mem_methods {
     fn clone(&self) -> Self { *self }
@@ -1386,11 +1364,6 @@ pub struct sqlite3_vtab {
     pub nRef: ::std::os::raw::c_int,
     pub zErrMsg: *mut ::std::os::raw::c_char,
 }
-#[test]
-fn bindgen_test_layout_sqlite3_vtab() {
-    assert_eq!(::std::mem::size_of::<sqlite3_vtab>() , 24usize);
-    assert_eq!(::std::mem::align_of::<sqlite3_vtab>() , 8usize);
-}
 impl Clone for sqlite3_vtab {
     fn clone(&self) -> Self { *self }
 }
@@ -1416,13 +1389,6 @@ pub struct sqlite3_index_info_sqlite3_index_constraint {
     pub usable: ::std::os::raw::c_uchar,
     pub iTermOffset: ::std::os::raw::c_int,
 }
-#[test]
-fn bindgen_test_layout_sqlite3_index_info_sqlite3_index_constraint() {
-    assert_eq!(::std::mem::size_of::<sqlite3_index_info_sqlite3_index_constraint>()
-               , 12usize);
-    assert_eq!(::std::mem::align_of::<sqlite3_index_info_sqlite3_index_constraint>()
-               , 4usize);
-}
 impl Clone for sqlite3_index_info_sqlite3_index_constraint {
     fn clone(&self) -> Self { *self }
 }
@@ -1431,13 +1397,6 @@ impl Clone for sqlite3_index_info_sqlite3_index_constraint {
 pub struct sqlite3_index_info_sqlite3_index_orderby {
     pub iColumn: ::std::os::raw::c_int,
     pub desc: ::std::os::raw::c_uchar,
-}
-#[test]
-fn bindgen_test_layout_sqlite3_index_info_sqlite3_index_orderby() {
-    assert_eq!(::std::mem::size_of::<sqlite3_index_info_sqlite3_index_orderby>()
-               , 8usize);
-    assert_eq!(::std::mem::align_of::<sqlite3_index_info_sqlite3_index_orderby>()
-               , 4usize);
 }
 impl Clone for sqlite3_index_info_sqlite3_index_orderby {
     fn clone(&self) -> Self { *self }
@@ -1448,20 +1407,8 @@ pub struct sqlite3_index_info_sqlite3_index_constraint_usage {
     pub argvIndex: ::std::os::raw::c_int,
     pub omit: ::std::os::raw::c_uchar,
 }
-#[test]
-fn bindgen_test_layout_sqlite3_index_info_sqlite3_index_constraint_usage() {
-    assert_eq!(::std::mem::size_of::<sqlite3_index_info_sqlite3_index_constraint_usage>()
-               , 8usize);
-    assert_eq!(::std::mem::align_of::<sqlite3_index_info_sqlite3_index_constraint_usage>()
-               , 4usize);
-}
 impl Clone for sqlite3_index_info_sqlite3_index_constraint_usage {
     fn clone(&self) -> Self { *self }
-}
-#[test]
-fn bindgen_test_layout_sqlite3_index_info() {
-    assert_eq!(::std::mem::size_of::<sqlite3_index_info>() , 72usize);
-    assert_eq!(::std::mem::align_of::<sqlite3_index_info>() , 8usize);
 }
 impl Clone for sqlite3_index_info {
     fn clone(&self) -> Self { *self }
@@ -1470,11 +1417,6 @@ impl Clone for sqlite3_index_info {
 #[derive(Debug, Copy)]
 pub struct sqlite3_vtab_cursor {
     pub pVtab: *mut sqlite3_vtab,
-}
-#[test]
-fn bindgen_test_layout_sqlite3_vtab_cursor() {
-    assert_eq!(::std::mem::size_of::<sqlite3_vtab_cursor>() , 8usize);
-    assert_eq!(::std::mem::align_of::<sqlite3_vtab_cursor>() , 8usize);
 }
 impl Clone for sqlite3_vtab_cursor {
     fn clone(&self) -> Self { *self }
@@ -1600,11 +1542,6 @@ pub struct sqlite3_module {
                                                                 *const ::std::os::raw::c_char)
                                            -> ::std::os::raw::c_int>,
 }
-#[test]
-fn bindgen_test_layout_sqlite3_module() {
-    assert_eq!(::std::mem::size_of::<sqlite3_module>() , 160usize);
-    assert_eq!(::std::mem::align_of::<sqlite3_module>() , 8usize);
-}
 impl Clone for sqlite3_module {
     fn clone(&self) -> Self { *self }
 }
@@ -1727,11 +1664,6 @@ pub struct sqlite3_mutex_methods {
                                                                       *mut sqlite3_mutex)
                                                  -> ::std::os::raw::c_int>,
 }
-#[test]
-fn bindgen_test_layout_sqlite3_mutex_methods() {
-    assert_eq!(::std::mem::size_of::<sqlite3_mutex_methods>() , 72usize);
-    assert_eq!(::std::mem::align_of::<sqlite3_mutex_methods>() , 8usize);
-}
 impl Clone for sqlite3_mutex_methods {
     fn clone(&self) -> Self { *self }
 }
@@ -1828,11 +1760,6 @@ pub struct sqlite3_pcache_methods {
                                                                   ::std::os::raw::c_uint)>,
     pub xDestroy: ::std::option::Option<unsafe extern "C" fn(arg1:
                                                                  *mut sqlite3_pcache)>,
-}
-#[test]
-fn bindgen_test_layout_sqlite3_pcache_methods() {
-    assert_eq!(::std::mem::size_of::<sqlite3_pcache_methods>() , 88usize);
-    assert_eq!(::std::mem::align_of::<sqlite3_pcache_methods>() , 8usize);
 }
 impl Clone for sqlite3_pcache_methods {
     fn clone(&self) -> Self { *self }

--- a/libsqlite3-sys/bindgen-bindings/bindgen_3.6.8.rs
+++ b/libsqlite3-sys/bindgen-bindings/bindgen_3.6.8.rs
@@ -321,20 +321,8 @@ pub struct sqlite3_file_sqlite3_io_methods {
                                                           ->
                                                               ::std::os::raw::c_int>,
 }
-#[test]
-fn bindgen_test_layout_sqlite3_file_sqlite3_io_methods() {
-    assert_eq!(::std::mem::size_of::<sqlite3_file_sqlite3_io_methods>() ,
-               104usize);
-    assert_eq!(::std::mem::align_of::<sqlite3_file_sqlite3_io_methods>() ,
-               8usize);
-}
 impl Clone for sqlite3_file_sqlite3_io_methods {
     fn clone(&self) -> Self { *self }
-}
-#[test]
-fn bindgen_test_layout_sqlite3_file() {
-    assert_eq!(::std::mem::size_of::<sqlite3_file>() , 8usize);
-    assert_eq!(::std::mem::align_of::<sqlite3_file>() , 8usize);
 }
 impl Clone for sqlite3_file {
     fn clone(&self) -> Self { *self }
@@ -436,11 +424,6 @@ pub struct sqlite3_vfs {
                                                                       *mut ::std::os::raw::c_char)
                                                  -> ::std::os::raw::c_int>,
 }
-#[test]
-fn bindgen_test_layout_sqlite3_vfs() {
-    assert_eq!(::std::mem::size_of::<sqlite3_vfs>() , 136usize);
-    assert_eq!(::std::mem::align_of::<sqlite3_vfs>() , 8usize);
-}
 impl Clone for sqlite3_vfs {
     fn clone(&self) -> Self { *self }
 }
@@ -490,11 +473,6 @@ pub struct sqlite3_mem_methods {
     pub xShutdown: ::std::option::Option<unsafe extern "C" fn(arg1:
                                                                   *mut ::std::os::raw::c_void)>,
     pub pAppData: *mut ::std::os::raw::c_void,
-}
-#[test]
-fn bindgen_test_layout_sqlite3_mem_methods() {
-    assert_eq!(::std::mem::size_of::<sqlite3_mem_methods>() , 64usize);
-    assert_eq!(::std::mem::align_of::<sqlite3_mem_methods>() , 8usize);
 }
 impl Clone for sqlite3_mem_methods {
     fn clone(&self) -> Self { *self }
@@ -1368,11 +1346,6 @@ pub struct sqlite3_vtab {
     pub nRef: ::std::os::raw::c_int,
     pub zErrMsg: *mut ::std::os::raw::c_char,
 }
-#[test]
-fn bindgen_test_layout_sqlite3_vtab() {
-    assert_eq!(::std::mem::size_of::<sqlite3_vtab>() , 24usize);
-    assert_eq!(::std::mem::align_of::<sqlite3_vtab>() , 8usize);
-}
 impl Clone for sqlite3_vtab {
     fn clone(&self) -> Self { *self }
 }
@@ -1398,13 +1371,6 @@ pub struct sqlite3_index_info_sqlite3_index_constraint {
     pub usable: ::std::os::raw::c_uchar,
     pub iTermOffset: ::std::os::raw::c_int,
 }
-#[test]
-fn bindgen_test_layout_sqlite3_index_info_sqlite3_index_constraint() {
-    assert_eq!(::std::mem::size_of::<sqlite3_index_info_sqlite3_index_constraint>()
-               , 12usize);
-    assert_eq!(::std::mem::align_of::<sqlite3_index_info_sqlite3_index_constraint>()
-               , 4usize);
-}
 impl Clone for sqlite3_index_info_sqlite3_index_constraint {
     fn clone(&self) -> Self { *self }
 }
@@ -1413,13 +1379,6 @@ impl Clone for sqlite3_index_info_sqlite3_index_constraint {
 pub struct sqlite3_index_info_sqlite3_index_orderby {
     pub iColumn: ::std::os::raw::c_int,
     pub desc: ::std::os::raw::c_uchar,
-}
-#[test]
-fn bindgen_test_layout_sqlite3_index_info_sqlite3_index_orderby() {
-    assert_eq!(::std::mem::size_of::<sqlite3_index_info_sqlite3_index_orderby>()
-               , 8usize);
-    assert_eq!(::std::mem::align_of::<sqlite3_index_info_sqlite3_index_orderby>()
-               , 4usize);
 }
 impl Clone for sqlite3_index_info_sqlite3_index_orderby {
     fn clone(&self) -> Self { *self }
@@ -1430,20 +1389,8 @@ pub struct sqlite3_index_info_sqlite3_index_constraint_usage {
     pub argvIndex: ::std::os::raw::c_int,
     pub omit: ::std::os::raw::c_uchar,
 }
-#[test]
-fn bindgen_test_layout_sqlite3_index_info_sqlite3_index_constraint_usage() {
-    assert_eq!(::std::mem::size_of::<sqlite3_index_info_sqlite3_index_constraint_usage>()
-               , 8usize);
-    assert_eq!(::std::mem::align_of::<sqlite3_index_info_sqlite3_index_constraint_usage>()
-               , 4usize);
-}
 impl Clone for sqlite3_index_info_sqlite3_index_constraint_usage {
     fn clone(&self) -> Self { *self }
-}
-#[test]
-fn bindgen_test_layout_sqlite3_index_info() {
-    assert_eq!(::std::mem::size_of::<sqlite3_index_info>() , 72usize);
-    assert_eq!(::std::mem::align_of::<sqlite3_index_info>() , 8usize);
 }
 impl Clone for sqlite3_index_info {
     fn clone(&self) -> Self { *self }
@@ -1452,11 +1399,6 @@ impl Clone for sqlite3_index_info {
 #[derive(Debug, Copy)]
 pub struct sqlite3_vtab_cursor {
     pub pVtab: *mut sqlite3_vtab,
-}
-#[test]
-fn bindgen_test_layout_sqlite3_vtab_cursor() {
-    assert_eq!(::std::mem::size_of::<sqlite3_vtab_cursor>() , 8usize);
-    assert_eq!(::std::mem::align_of::<sqlite3_vtab_cursor>() , 8usize);
 }
 impl Clone for sqlite3_vtab_cursor {
     fn clone(&self) -> Self { *self }
@@ -1582,11 +1524,6 @@ pub struct sqlite3_module {
                                                                 *const ::std::os::raw::c_char)
                                            -> ::std::os::raw::c_int>,
 }
-#[test]
-fn bindgen_test_layout_sqlite3_module() {
-    assert_eq!(::std::mem::size_of::<sqlite3_module>() , 160usize);
-    assert_eq!(::std::mem::align_of::<sqlite3_module>() , 8usize);
-}
 impl Clone for sqlite3_module {
     fn clone(&self) -> Self { *self }
 }
@@ -1709,11 +1646,6 @@ pub struct sqlite3_mutex_methods {
                                                                       *mut sqlite3_mutex)
                                                  -> ::std::os::raw::c_int>,
 }
-#[test]
-fn bindgen_test_layout_sqlite3_mutex_methods() {
-    assert_eq!(::std::mem::size_of::<sqlite3_mutex_methods>() , 72usize);
-    assert_eq!(::std::mem::align_of::<sqlite3_mutex_methods>() , 8usize);
-}
 impl Clone for sqlite3_mutex_methods {
     fn clone(&self) -> Self { *self }
 }
@@ -1810,11 +1742,6 @@ pub struct sqlite3_pcache_methods {
                                                                   ::std::os::raw::c_uint)>,
     pub xDestroy: ::std::option::Option<unsafe extern "C" fn(arg1:
                                                                  *mut sqlite3_pcache)>,
-}
-#[test]
-fn bindgen_test_layout_sqlite3_pcache_methods() {
-    assert_eq!(::std::mem::size_of::<sqlite3_pcache_methods>() , 88usize);
-    assert_eq!(::std::mem::align_of::<sqlite3_pcache_methods>() , 8usize);
 }
 impl Clone for sqlite3_pcache_methods {
     fn clone(&self) -> Self { *self }

--- a/libsqlite3-sys/bindgen-bindings/bindgen_3.7.16.rs
+++ b/libsqlite3-sys/bindgen-bindings/bindgen_3.7.16.rs
@@ -455,20 +455,8 @@ pub struct sqlite3_file_sqlite3_io_methods {
                                                                   ::std::os::raw::c_int)
                                              -> ::std::os::raw::c_int>,
 }
-#[test]
-fn bindgen_test_layout_sqlite3_file_sqlite3_io_methods() {
-    assert_eq!(::std::mem::size_of::<sqlite3_file_sqlite3_io_methods>() ,
-               136usize);
-    assert_eq!(::std::mem::align_of::<sqlite3_file_sqlite3_io_methods>() ,
-               8usize);
-}
 impl Clone for sqlite3_file_sqlite3_io_methods {
     fn clone(&self) -> Self { *self }
-}
-#[test]
-fn bindgen_test_layout_sqlite3_file() {
-    assert_eq!(::std::mem::size_of::<sqlite3_file>() , 8usize);
-    assert_eq!(::std::mem::align_of::<sqlite3_file>() , 8usize);
 }
 impl Clone for sqlite3_file {
     fn clone(&self) -> Self { *self }
@@ -596,10 +584,6 @@ pub struct sqlite3_vfs {
                                                        *const ::std::os::raw::c_char>,
 }
 #[test]
-fn bindgen_test_layout_sqlite3_vfs() {
-    assert_eq!(::std::mem::size_of::<sqlite3_vfs>() , 168usize);
-    assert_eq!(::std::mem::align_of::<sqlite3_vfs>() , 8usize);
-}
 impl Clone for sqlite3_vfs {
     fn clone(&self) -> Self { *self }
 }
@@ -652,10 +636,6 @@ pub struct sqlite3_mem_methods {
     pub pAppData: *mut ::std::os::raw::c_void,
 }
 #[test]
-fn bindgen_test_layout_sqlite3_mem_methods() {
-    assert_eq!(::std::mem::size_of::<sqlite3_mem_methods>() , 64usize);
-    assert_eq!(::std::mem::align_of::<sqlite3_mem_methods>() , 8usize);
-}
 impl Clone for sqlite3_mem_methods {
     fn clone(&self) -> Self { *self }
 }
@@ -1604,10 +1584,6 @@ pub struct sqlite3_vtab {
     pub zErrMsg: *mut ::std::os::raw::c_char,
 }
 #[test]
-fn bindgen_test_layout_sqlite3_vtab() {
-    assert_eq!(::std::mem::size_of::<sqlite3_vtab>() , 24usize);
-    assert_eq!(::std::mem::align_of::<sqlite3_vtab>() , 8usize);
-}
 impl Clone for sqlite3_vtab {
     fn clone(&self) -> Self { *self }
 }
@@ -1633,13 +1609,6 @@ pub struct sqlite3_index_info_sqlite3_index_constraint {
     pub usable: ::std::os::raw::c_uchar,
     pub iTermOffset: ::std::os::raw::c_int,
 }
-#[test]
-fn bindgen_test_layout_sqlite3_index_info_sqlite3_index_constraint() {
-    assert_eq!(::std::mem::size_of::<sqlite3_index_info_sqlite3_index_constraint>()
-               , 12usize);
-    assert_eq!(::std::mem::align_of::<sqlite3_index_info_sqlite3_index_constraint>()
-               , 4usize);
-}
 impl Clone for sqlite3_index_info_sqlite3_index_constraint {
     fn clone(&self) -> Self { *self }
 }
@@ -1648,13 +1617,6 @@ impl Clone for sqlite3_index_info_sqlite3_index_constraint {
 pub struct sqlite3_index_info_sqlite3_index_orderby {
     pub iColumn: ::std::os::raw::c_int,
     pub desc: ::std::os::raw::c_uchar,
-}
-#[test]
-fn bindgen_test_layout_sqlite3_index_info_sqlite3_index_orderby() {
-    assert_eq!(::std::mem::size_of::<sqlite3_index_info_sqlite3_index_orderby>()
-               , 8usize);
-    assert_eq!(::std::mem::align_of::<sqlite3_index_info_sqlite3_index_orderby>()
-               , 4usize);
 }
 impl Clone for sqlite3_index_info_sqlite3_index_orderby {
     fn clone(&self) -> Self { *self }
@@ -1665,20 +1627,8 @@ pub struct sqlite3_index_info_sqlite3_index_constraint_usage {
     pub argvIndex: ::std::os::raw::c_int,
     pub omit: ::std::os::raw::c_uchar,
 }
-#[test]
-fn bindgen_test_layout_sqlite3_index_info_sqlite3_index_constraint_usage() {
-    assert_eq!(::std::mem::size_of::<sqlite3_index_info_sqlite3_index_constraint_usage>()
-               , 8usize);
-    assert_eq!(::std::mem::align_of::<sqlite3_index_info_sqlite3_index_constraint_usage>()
-               , 4usize);
-}
 impl Clone for sqlite3_index_info_sqlite3_index_constraint_usage {
     fn clone(&self) -> Self { *self }
-}
-#[test]
-fn bindgen_test_layout_sqlite3_index_info() {
-    assert_eq!(::std::mem::size_of::<sqlite3_index_info>() , 72usize);
-    assert_eq!(::std::mem::align_of::<sqlite3_index_info>() , 8usize);
 }
 impl Clone for sqlite3_index_info {
     fn clone(&self) -> Self { *self }
@@ -1687,11 +1637,6 @@ impl Clone for sqlite3_index_info {
 #[derive(Debug, Copy)]
 pub struct sqlite3_vtab_cursor {
     pub pVtab: *mut sqlite3_vtab,
-}
-#[test]
-fn bindgen_test_layout_sqlite3_vtab_cursor() {
-    assert_eq!(::std::mem::size_of::<sqlite3_vtab_cursor>() , 8usize);
-    assert_eq!(::std::mem::align_of::<sqlite3_vtab_cursor>() , 8usize);
 }
 impl Clone for sqlite3_vtab_cursor {
     fn clone(&self) -> Self { *self }
@@ -1832,11 +1777,6 @@ pub struct sqlite3_module {
                                                                     ::std::os::raw::c_int)
                                                -> ::std::os::raw::c_int>,
 }
-#[test]
-fn bindgen_test_layout_sqlite3_module() {
-    assert_eq!(::std::mem::size_of::<sqlite3_module>() , 184usize);
-    assert_eq!(::std::mem::align_of::<sqlite3_module>() , 8usize);
-}
 impl Clone for sqlite3_module {
     fn clone(&self) -> Self { *self }
 }
@@ -1963,11 +1903,6 @@ pub struct sqlite3_mutex_methods {
                                                                       *mut sqlite3_mutex)
                                                  -> ::std::os::raw::c_int>,
 }
-#[test]
-fn bindgen_test_layout_sqlite3_mutex_methods() {
-    assert_eq!(::std::mem::size_of::<sqlite3_mutex_methods>() , 72usize);
-    assert_eq!(::std::mem::align_of::<sqlite3_mutex_methods>() , 8usize);
-}
 impl Clone for sqlite3_mutex_methods {
     fn clone(&self) -> Self { *self }
 }
@@ -2021,11 +1956,6 @@ pub struct sqlite3_pcache([u8; 0]);
 pub struct sqlite3_pcache_page {
     pub pBuf: *mut ::std::os::raw::c_void,
     pub pExtra: *mut ::std::os::raw::c_void,
-}
-#[test]
-fn bindgen_test_layout_sqlite3_pcache_page() {
-    assert_eq!(::std::mem::size_of::<sqlite3_pcache_page>() , 16usize);
-    assert_eq!(::std::mem::align_of::<sqlite3_pcache_page>() , 8usize);
 }
 impl Clone for sqlite3_pcache_page {
     fn clone(&self) -> Self { *self }
@@ -2084,11 +2014,6 @@ pub struct sqlite3_pcache_methods2 {
     pub xShrink: ::std::option::Option<unsafe extern "C" fn(arg1:
                                                                 *mut sqlite3_pcache)>,
 }
-#[test]
-fn bindgen_test_layout_sqlite3_pcache_methods2() {
-    assert_eq!(::std::mem::size_of::<sqlite3_pcache_methods2>() , 104usize);
-    assert_eq!(::std::mem::align_of::<sqlite3_pcache_methods2>() , 8usize);
-}
 impl Clone for sqlite3_pcache_methods2 {
     fn clone(&self) -> Self { *self }
 }
@@ -2140,11 +2065,6 @@ pub struct sqlite3_pcache_methods {
                                                                   ::std::os::raw::c_uint)>,
     pub xDestroy: ::std::option::Option<unsafe extern "C" fn(arg1:
                                                                  *mut sqlite3_pcache)>,
-}
-#[test]
-fn bindgen_test_layout_sqlite3_pcache_methods() {
-    assert_eq!(::std::mem::size_of::<sqlite3_pcache_methods>() , 88usize);
-    assert_eq!(::std::mem::align_of::<sqlite3_pcache_methods>() , 8usize);
 }
 impl Clone for sqlite3_pcache_methods {
     fn clone(&self) -> Self { *self }
@@ -2253,11 +2173,6 @@ pub struct sqlite3_rtree_geometry {
     pub pUser: *mut ::std::os::raw::c_void,
     pub xDelUser: ::std::option::Option<unsafe extern "C" fn(arg1:
                                                                  *mut ::std::os::raw::c_void)>,
-}
-#[test]
-fn bindgen_test_layout_sqlite3_rtree_geometry() {
-    assert_eq!(::std::mem::size_of::<sqlite3_rtree_geometry>() , 40usize);
-    assert_eq!(::std::mem::align_of::<sqlite3_rtree_geometry>() , 8usize);
 }
 impl Clone for sqlite3_rtree_geometry {
     fn clone(&self) -> Self { *self }

--- a/libsqlite3-sys/bindgen-bindings/bindgen_3.7.7.rs
+++ b/libsqlite3-sys/bindgen-bindings/bindgen_3.7.7.rs
@@ -421,20 +421,8 @@ pub struct sqlite3_file_sqlite3_io_methods {
                                                                   ::std::os::raw::c_int)
                                              -> ::std::os::raw::c_int>,
 }
-#[test]
-fn bindgen_test_layout_sqlite3_file_sqlite3_io_methods() {
-    assert_eq!(::std::mem::size_of::<sqlite3_file_sqlite3_io_methods>() ,
-               136usize);
-    assert_eq!(::std::mem::align_of::<sqlite3_file_sqlite3_io_methods>() ,
-               8usize);
-}
 impl Clone for sqlite3_file_sqlite3_io_methods {
     fn clone(&self) -> Self { *self }
-}
-#[test]
-fn bindgen_test_layout_sqlite3_file() {
-    assert_eq!(::std::mem::size_of::<sqlite3_file>() , 8usize);
-    assert_eq!(::std::mem::align_of::<sqlite3_file>() , 8usize);
 }
 impl Clone for sqlite3_file {
     fn clone(&self) -> Self { *self }
@@ -561,11 +549,6 @@ pub struct sqlite3_vfs {
                                                    ->
                                                        *const ::std::os::raw::c_char>,
 }
-#[test]
-fn bindgen_test_layout_sqlite3_vfs() {
-    assert_eq!(::std::mem::size_of::<sqlite3_vfs>() , 168usize);
-    assert_eq!(::std::mem::align_of::<sqlite3_vfs>() , 8usize);
-}
 impl Clone for sqlite3_vfs {
     fn clone(&self) -> Self { *self }
 }
@@ -616,11 +599,6 @@ pub struct sqlite3_mem_methods {
     pub xShutdown: ::std::option::Option<unsafe extern "C" fn(arg1:
                                                                   *mut ::std::os::raw::c_void)>,
     pub pAppData: *mut ::std::os::raw::c_void,
-}
-#[test]
-fn bindgen_test_layout_sqlite3_mem_methods() {
-    assert_eq!(::std::mem::size_of::<sqlite3_mem_methods>() , 64usize);
-    assert_eq!(::std::mem::align_of::<sqlite3_mem_methods>() , 8usize);
 }
 impl Clone for sqlite3_mem_methods {
     fn clone(&self) -> Self { *self }
@@ -1532,11 +1510,6 @@ pub struct sqlite3_vtab {
     pub nRef: ::std::os::raw::c_int,
     pub zErrMsg: *mut ::std::os::raw::c_char,
 }
-#[test]
-fn bindgen_test_layout_sqlite3_vtab() {
-    assert_eq!(::std::mem::size_of::<sqlite3_vtab>() , 24usize);
-    assert_eq!(::std::mem::align_of::<sqlite3_vtab>() , 8usize);
-}
 impl Clone for sqlite3_vtab {
     fn clone(&self) -> Self { *self }
 }
@@ -1562,13 +1535,6 @@ pub struct sqlite3_index_info_sqlite3_index_constraint {
     pub usable: ::std::os::raw::c_uchar,
     pub iTermOffset: ::std::os::raw::c_int,
 }
-#[test]
-fn bindgen_test_layout_sqlite3_index_info_sqlite3_index_constraint() {
-    assert_eq!(::std::mem::size_of::<sqlite3_index_info_sqlite3_index_constraint>()
-               , 12usize);
-    assert_eq!(::std::mem::align_of::<sqlite3_index_info_sqlite3_index_constraint>()
-               , 4usize);
-}
 impl Clone for sqlite3_index_info_sqlite3_index_constraint {
     fn clone(&self) -> Self { *self }
 }
@@ -1577,13 +1543,6 @@ impl Clone for sqlite3_index_info_sqlite3_index_constraint {
 pub struct sqlite3_index_info_sqlite3_index_orderby {
     pub iColumn: ::std::os::raw::c_int,
     pub desc: ::std::os::raw::c_uchar,
-}
-#[test]
-fn bindgen_test_layout_sqlite3_index_info_sqlite3_index_orderby() {
-    assert_eq!(::std::mem::size_of::<sqlite3_index_info_sqlite3_index_orderby>()
-               , 8usize);
-    assert_eq!(::std::mem::align_of::<sqlite3_index_info_sqlite3_index_orderby>()
-               , 4usize);
 }
 impl Clone for sqlite3_index_info_sqlite3_index_orderby {
     fn clone(&self) -> Self { *self }
@@ -1594,20 +1553,8 @@ pub struct sqlite3_index_info_sqlite3_index_constraint_usage {
     pub argvIndex: ::std::os::raw::c_int,
     pub omit: ::std::os::raw::c_uchar,
 }
-#[test]
-fn bindgen_test_layout_sqlite3_index_info_sqlite3_index_constraint_usage() {
-    assert_eq!(::std::mem::size_of::<sqlite3_index_info_sqlite3_index_constraint_usage>()
-               , 8usize);
-    assert_eq!(::std::mem::align_of::<sqlite3_index_info_sqlite3_index_constraint_usage>()
-               , 4usize);
-}
 impl Clone for sqlite3_index_info_sqlite3_index_constraint_usage {
     fn clone(&self) -> Self { *self }
-}
-#[test]
-fn bindgen_test_layout_sqlite3_index_info() {
-    assert_eq!(::std::mem::size_of::<sqlite3_index_info>() , 72usize);
-    assert_eq!(::std::mem::align_of::<sqlite3_index_info>() , 8usize);
 }
 impl Clone for sqlite3_index_info {
     fn clone(&self) -> Self { *self }
@@ -1616,11 +1563,6 @@ impl Clone for sqlite3_index_info {
 #[derive(Debug, Copy)]
 pub struct sqlite3_vtab_cursor {
     pub pVtab: *mut sqlite3_vtab,
-}
-#[test]
-fn bindgen_test_layout_sqlite3_vtab_cursor() {
-    assert_eq!(::std::mem::size_of::<sqlite3_vtab_cursor>() , 8usize);
-    assert_eq!(::std::mem::align_of::<sqlite3_vtab_cursor>() , 8usize);
 }
 impl Clone for sqlite3_vtab_cursor {
     fn clone(&self) -> Self { *self }
@@ -1761,11 +1703,6 @@ pub struct sqlite3_module {
                                                                     ::std::os::raw::c_int)
                                                -> ::std::os::raw::c_int>,
 }
-#[test]
-fn bindgen_test_layout_sqlite3_module() {
-    assert_eq!(::std::mem::size_of::<sqlite3_module>() , 184usize);
-    assert_eq!(::std::mem::align_of::<sqlite3_module>() , 8usize);
-}
 impl Clone for sqlite3_module {
     fn clone(&self) -> Self { *self }
 }
@@ -1892,11 +1829,6 @@ pub struct sqlite3_mutex_methods {
                                                                       *mut sqlite3_mutex)
                                                  -> ::std::os::raw::c_int>,
 }
-#[test]
-fn bindgen_test_layout_sqlite3_mutex_methods() {
-    assert_eq!(::std::mem::size_of::<sqlite3_mutex_methods>() , 72usize);
-    assert_eq!(::std::mem::align_of::<sqlite3_mutex_methods>() , 8usize);
-}
 impl Clone for sqlite3_mutex_methods {
     fn clone(&self) -> Self { *self }
 }
@@ -1993,11 +1925,6 @@ pub struct sqlite3_pcache_methods {
                                                                   ::std::os::raw::c_uint)>,
     pub xDestroy: ::std::option::Option<unsafe extern "C" fn(arg1:
                                                                  *mut sqlite3_pcache)>,
-}
-#[test]
-fn bindgen_test_layout_sqlite3_pcache_methods() {
-    assert_eq!(::std::mem::size_of::<sqlite3_pcache_methods>() , 88usize);
-    assert_eq!(::std::mem::align_of::<sqlite3_pcache_methods>() , 8usize);
 }
 impl Clone for sqlite3_pcache_methods {
     fn clone(&self) -> Self { *self }
@@ -2101,11 +2028,6 @@ pub struct sqlite3_rtree_geometry {
     pub pUser: *mut ::std::os::raw::c_void,
     pub xDelUser: ::std::option::Option<unsafe extern "C" fn(arg1:
                                                                  *mut ::std::os::raw::c_void)>,
-}
-#[test]
-fn bindgen_test_layout_sqlite3_rtree_geometry() {
-    assert_eq!(::std::mem::size_of::<sqlite3_rtree_geometry>() , 40usize);
-    assert_eq!(::std::mem::align_of::<sqlite3_rtree_geometry>() , 8usize);
 }
 impl Clone for sqlite3_rtree_geometry {
     fn clone(&self) -> Self { *self }


### PR DESCRIPTION
Note that this was done manually by cutting out all #[test] functions
named *_test_layout_*, rather than the automated re-generation step
that produced 53b1b598cb5ca63befa043a05905b681e8890dc7.

Closes: #722