### PR TITLE
Use ?NNN format instead of ?

### DIFF
--- a/src/blob/mod.rs
+++ b/src/blob/mod.rs
@@ -134,7 +134,7 @@
 //! // Insert another BLOB, this time using a parameter passed in from
 //! // rust (potentially with a dynamic size).
 //! db.execute(
-//!     "INSERT INTO test_table (content) VALUES (?)",
+//!     "INSERT INTO test_table (content) VALUES (?1)",
 //!     [ZeroBlob(64)],
 //! )?;
 //!
@@ -175,7 +175,7 @@
 //! // Insert another blob, this time using a parameter passed in from
 //! // rust (potentially with a dynamic size).
 //! db.execute(
-//!     "INSERT INTO test_table (content) VALUES (?)",
+//!     "INSERT INTO test_table (content) VALUES (?1)",
 //!     [ZeroBlob(64)],
 //! )?;
 //!

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -17,13 +17,13 @@ impl Connection {
     /// # use rusqlite::{Connection, Result};
     /// fn insert_new_people(conn: &Connection) -> Result<()> {
     ///     {
-    ///         let mut stmt = conn.prepare_cached("INSERT INTO People (name) VALUES (?)")?;
+    ///         let mut stmt = conn.prepare_cached("INSERT INTO People (name) VALUES (?1)")?;
     ///         stmt.execute(["Joe Smith"])?;
     ///     }
     ///     {
     ///         // This will return the same underlying SQLite statement handle without
     ///         // having to prepare it again.
-    ///         let mut stmt = conn.prepare_cached("INSERT INTO People (name) VALUES (?)")?;
+    ///         let mut stmt = conn.prepare_cached("INSERT INTO People (name) VALUES (?1)")?;
     ///         stmt.execute(["Bob Jones"])?;
     ///     }
     ///     Ok(())

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -534,7 +534,7 @@ impl Connection {
     /// ```rust,no_run
     /// # use rusqlite::{Connection};
     /// fn update_rows(conn: &Connection) {
-    ///     match conn.execute("UPDATE foo SET bar = 'baz' WHERE qux = ?", [1i32]) {
+    ///     match conn.execute("UPDATE foo SET bar = 'baz' WHERE qux = ?1", [1i32]) {
     ///         Ok(updated) => println!("{} rows were updated", updated),
     ///         Err(err) => println!("update failed: {}", err),
     ///     }
@@ -739,7 +739,7 @@ impl Connection {
     /// ```rust,no_run
     /// # use rusqlite::{Connection, Result};
     /// fn insert_new_people(conn: &Connection) -> Result<()> {
-    ///     let mut stmt = conn.prepare("INSERT INTO People (name) VALUES (?)")?;
+    ///     let mut stmt = conn.prepare("INSERT INTO People (name) VALUES (?1)")?;
     ///     stmt.execute(["Joe Smith"])?;
     ///     stmt.execute(["Bob Jones"])?;
     ///     Ok(())
@@ -1406,8 +1406,8 @@ mod test {
         let db = Connection::open_in_memory()?;
         db.execute_batch("CREATE TABLE foo(x INTEGER)")?;
 
-        assert_eq!(1, db.execute("INSERT INTO foo(x) VALUES (?)", [1i32])?);
-        assert_eq!(1, db.execute("INSERT INTO foo(x) VALUES (?)", [2i32])?);
+        assert_eq!(1, db.execute("INSERT INTO foo(x) VALUES (?1)", [1i32])?);
+        assert_eq!(1, db.execute("INSERT INTO foo(x) VALUES (?1)", [2i32])?);
 
         assert_eq!(3i32, db.one_column::<i32>("SELECT SUM(x) FROM foo")?);
         Ok(())
@@ -1417,7 +1417,7 @@ mod test {
     #[cfg(feature = "extra_check")]
     fn test_execute_select() {
         let db = checked_memory_handle();
-        let err = db.execute("SELECT 1 WHERE 1 < ?", [1i32]).unwrap_err();
+        let err = db.execute("SELECT 1 WHERE 1 < ?1", [1i32]).unwrap_err();
         assert_eq!(
             err,
             Error::ExecuteReturnedResults,
@@ -1462,7 +1462,7 @@ mod test {
         let db = Connection::open_in_memory()?;
         db.execute_batch("CREATE TABLE foo(x INTEGER);")?;
 
-        let mut insert_stmt = db.prepare("INSERT INTO foo(x) VALUES(?)")?;
+        let mut insert_stmt = db.prepare("INSERT INTO foo(x) VALUES(?1)")?;
         assert_eq!(insert_stmt.execute([1i32])?, 1);
         assert_eq!(insert_stmt.execute([2i32])?, 1);
         assert_eq!(insert_stmt.execute([3i32])?, 1);
@@ -1471,7 +1471,7 @@ mod test {
         assert_eq!(insert_stmt.execute(["goodbye"])?, 1);
         assert_eq!(insert_stmt.execute([types::Null])?, 1);
 
-        let mut update_stmt = db.prepare("UPDATE foo SET x=? WHERE x<?")?;
+        let mut update_stmt = db.prepare("UPDATE foo SET x=?1 WHERE x<?2")?;
         assert_eq!(update_stmt.execute([3i32, 3i32])?, 2);
         assert_eq!(update_stmt.execute([3i32, 3i32])?, 0);
         assert_eq!(update_stmt.execute([8i32, 8i32])?, 3);
@@ -1483,12 +1483,12 @@ mod test {
         let db = Connection::open_in_memory()?;
         db.execute_batch("CREATE TABLE foo(x INTEGER);")?;
 
-        let mut insert_stmt = db.prepare("INSERT INTO foo(x) VALUES(?)")?;
+        let mut insert_stmt = db.prepare("INSERT INTO foo(x) VALUES(?1)")?;
         assert_eq!(insert_stmt.execute([1i32])?, 1);
         assert_eq!(insert_stmt.execute([2i32])?, 1);
         assert_eq!(insert_stmt.execute([3i32])?, 1);
 
-        let mut query = db.prepare("SELECT x FROM foo WHERE x < ? ORDER BY x DESC")?;
+        let mut query = db.prepare("SELECT x FROM foo WHERE x < ?1 ORDER BY x DESC")?;
         {
             let mut rows = query.query([4i32])?;
             let mut v = Vec::<i32>::new();
@@ -1753,7 +1753,7 @@ mod test {
         let db = Connection::open_in_memory()?;
         db.execute_batch("CREATE TABLE foo(i, x);")?;
         let vals = ["foobar", "1234", "qwerty"];
-        let mut insert_stmt = db.prepare("INSERT INTO foo(i, x) VALUES(?, ?)")?;
+        let mut insert_stmt = db.prepare("INSERT INTO foo(i, x) VALUES(?1, ?2)")?;
         for (i, v) in vals.iter().enumerate() {
             let i_to_insert = i as i64;
             assert_eq!(insert_stmt.execute(params![i_to_insert, v])?, 1);
@@ -2019,7 +2019,7 @@ mod test {
         let db = Connection::open_in_memory()?;
         db.execute_batch("CREATE TABLE foo(x INTEGER);")?;
         let b: Box<dyn ToSql> = Box::new(5);
-        db.execute("INSERT INTO foo VALUES(?)", [b])?;
+        db.execute("INSERT INTO foo VALUES(?1)", [b])?;
         db.query_row("SELECT x FROM foo", [], |r| {
             assert_eq!(5, r.get_unwrap::<_, i32>(0));
             Ok(())
@@ -2031,10 +2031,10 @@ mod test {
         let db = Connection::open_in_memory()?;
         db.query_row(
             "SELECT
-            ?, ?, ?, ?, ?, ?, ?, ?, ?, ?,
-            ?, ?, ?, ?, ?, ?, ?, ?, ?, ?,
-            ?, ?, ?, ?, ?, ?, ?, ?, ?, ?,
-            ?, ?, ?, ?;",
+            ?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10,
+            ?11, ?12, ?13, ?14, ?15, ?16, ?17, ?18, ?19, ?20,
+            ?21, ?22, ?23, ?24, ?25, ?26, ?27, ?28, ?29, ?30,
+            ?31, ?32, ?33, ?34;",
             params![
                 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
                 1, 1, 1, 1, 1, 1,

--- a/src/params.rs
+++ b/src/params.rs
@@ -70,7 +70,7 @@ use sealed::Sealed;
 /// ```rust,no_run
 /// # use rusqlite::{Connection, Result, params};
 /// fn update_rows(conn: &Connection) -> Result<()> {
-///     let mut stmt = conn.prepare("INSERT INTO test (a, b) VALUES (?, ?)")?;
+///     let mut stmt = conn.prepare("INSERT INTO test (a, b) VALUES (?1, ?2)")?;
 ///
 ///     // Using a tuple:
 ///     stmt.execute((0, "foobar"))?;
@@ -357,7 +357,7 @@ impl_for_array_ref!(
 /// fn query(conn: &Connection, ids: &BTreeSet<String>) -> Result<()> {
 ///     assert_eq!(ids.len(), 3, "Unrealistic sample code");
 ///
-///     let mut stmt = conn.prepare("SELECT * FROM users WHERE id IN (?, ?, ?)")?;
+///     let mut stmt = conn.prepare("SELECT * FROM users WHERE id IN (?1, ?2, ?3)")?;
 ///     let _rows = stmt.query(params_from_iter(ids.iter()))?;
 ///
 ///     // use _rows...

--- a/src/pragma.rs
+++ b/src/pragma.rs
@@ -211,7 +211,7 @@ impl Connection {
     /// (e.g. `integrity_check`).
     ///
     /// Prefer [PRAGMA function](https://sqlite.org/pragma.html#pragfunc) introduced in SQLite 3.20:
-    /// `SELECT * FROM pragma_table_info(?);`
+    /// `SELECT * FROM pragma_table_info(?1);`
     pub fn pragma<F, V>(
         &self,
         schema_name: Option<DatabaseName<'_>>,
@@ -379,7 +379,7 @@ mod test {
     #[cfg(feature = "modern_sqlite")]
     fn pragma_func() -> Result<()> {
         let db = Connection::open_in_memory()?;
-        let mut table_info = db.prepare("SELECT * FROM pragma_table_info(?)")?;
+        let mut table_info = db.prepare("SELECT * FROM pragma_table_info(?1)")?;
         let mut columns = Vec::new();
         let mut rows = table_info.query(["sqlite_master"])?;
 

--- a/src/session.rs
+++ b/src/session.rs
@@ -779,7 +779,7 @@ mod test {
         assert!(session.is_empty());
 
         session.attach(None)?;
-        db.execute("INSERT INTO foo (t) VALUES (?);", ["bar"])?;
+        db.execute("INSERT INTO foo (t) VALUES (?1);", ["bar"])?;
 
         session.changeset()
     }
@@ -792,7 +792,7 @@ mod test {
         assert!(session.is_empty());
 
         session.attach(None)?;
-        db.execute("INSERT INTO foo (t) VALUES (?);", ["bar"])?;
+        db.execute("INSERT INTO foo (t) VALUES (?1);", ["bar"])?;
 
         let mut output = Vec::new();
         session.changeset_strm(&mut output)?;
@@ -852,7 +852,7 @@ mod test {
         )?;
 
         assert!(!CALLED.load(Ordering::Relaxed));
-        let check = db.query_row("SELECT 1 FROM foo WHERE t = ?", ["bar"], |row| {
+        let check = db.query_row("SELECT 1 FROM foo WHERE t = ?1", ["bar"], |row| {
             row.get::<_, i32>(0)
         })?;
         assert_eq!(1, check);
@@ -887,7 +887,7 @@ mod test {
             |_conflict_type, _item| ConflictAction::SQLITE_CHANGESET_OMIT,
         )?;
 
-        let check = db.query_row("SELECT 1 FROM foo WHERE t = ?", ["bar"], |row| {
+        let check = db.query_row("SELECT 1 FROM foo WHERE t = ?1", ["bar"], |row| {
             row.get::<_, i32>(0)
         })?;
         assert_eq!(1, check);
@@ -903,7 +903,7 @@ mod test {
         assert!(session.is_empty());
 
         session.attach(None)?;
-        db.execute("INSERT INTO foo (t) VALUES (?);", ["bar"])?;
+        db.execute("INSERT INTO foo (t) VALUES (?1);", ["bar"])?;
 
         assert!(!session.is_empty());
         Ok(())

--- a/src/trace.rs
+++ b/src/trace.rs
@@ -144,13 +144,13 @@ mod test {
         let mut db = Connection::open_in_memory()?;
         db.trace(Some(tracer));
         {
-            let _ = db.query_row("SELECT ?", [1i32], |_| Ok(()));
-            let _ = db.query_row("SELECT ?", ["hello"], |_| Ok(()));
+            let _ = db.query_row("SELECT ?1", [1i32], |_| Ok(()));
+            let _ = db.query_row("SELECT ?1", ["hello"], |_| Ok(()));
         }
         db.trace(None);
         {
-            let _ = db.query_row("SELECT ?", [2i32], |_| Ok(()));
-            let _ = db.query_row("SELECT ?", ["goodbye"], |_| Ok(()));
+            let _ = db.query_row("SELECT ?1", [2i32], |_| Ok(()));
+            let _ = db.query_row("SELECT ?1", ["goodbye"], |_| Ok(()));
         }
 
         let traced_stmts = TRACED_STMTS.lock().unwrap();

--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -718,7 +718,7 @@ mod test {
     }
 
     fn insert(x: i32, conn: &Connection) -> Result<usize> {
-        conn.execute("INSERT INTO foo VALUES(?)", [x])
+        conn.execute("INSERT INTO foo VALUES(?1)", [x])
     }
 
     fn assert_current_sum(x: i32, conn: &Connection) -> Result<()> {

--- a/src/types/chrono.rs
+++ b/src/types/chrono.rs
@@ -176,7 +176,7 @@ mod test {
     fn test_naive_date() -> Result<()> {
         let db = checked_memory_handle()?;
         let date = NaiveDate::from_ymd_opt(2016, 2, 23).unwrap();
-        db.execute("INSERT INTO foo (t) VALUES (?)", [date])?;
+        db.execute("INSERT INTO foo (t) VALUES (?1)", [date])?;
 
         let s: String = db.one_column("SELECT t FROM foo")?;
         assert_eq!("2016-02-23", s);
@@ -189,7 +189,7 @@ mod test {
     fn test_naive_time() -> Result<()> {
         let db = checked_memory_handle()?;
         let time = NaiveTime::from_hms_opt(23, 56, 4).unwrap();
-        db.execute("INSERT INTO foo (t) VALUES (?)", [time])?;
+        db.execute("INSERT INTO foo (t) VALUES (?1)", [time])?;
 
         let s: String = db.one_column("SELECT t FROM foo")?;
         assert_eq!("23:56:04", s);
@@ -205,7 +205,7 @@ mod test {
         let time = NaiveTime::from_hms_opt(23, 56, 4).unwrap();
         let dt = NaiveDateTime::new(date, time);
 
-        db.execute("INSERT INTO foo (t) VALUES (?)", [dt])?;
+        db.execute("INSERT INTO foo (t) VALUES (?1)", [dt])?;
 
         let s: String = db.one_column("SELECT t FROM foo")?;
         assert_eq!("2016-02-23 23:56:04", s);
@@ -226,7 +226,7 @@ mod test {
         let dt = NaiveDateTime::new(date, time);
         let utc = Utc.from_utc_datetime(&dt);
 
-        db.execute("INSERT INTO foo (t) VALUES (?)", [utc])?;
+        db.execute("INSERT INTO foo (t) VALUES (?1)", [utc])?;
 
         let s: String = db.one_column("SELECT t FROM foo")?;
         assert_eq!("2016-02-23 23:56:04.789+00:00", s);
@@ -253,7 +253,7 @@ mod test {
         let dt = NaiveDateTime::new(date, time);
         let local = Local.from_local_datetime(&dt).single().unwrap();
 
-        db.execute("INSERT INTO foo (t) VALUES (?)", [local])?;
+        db.execute("INSERT INTO foo (t) VALUES (?1)", [local])?;
 
         // Stored string should be in UTC
         let s: String = db.one_column("SELECT t FROM foo")?;
@@ -269,7 +269,7 @@ mod test {
         let db = checked_memory_handle()?;
         let time = DateTime::parse_from_rfc3339("2020-04-07T11:23:45+04:00").unwrap();
 
-        db.execute("INSERT INTO foo (t) VALUES (?)", [time])?;
+        db.execute("INSERT INTO foo (t) VALUES (?1)", [time])?;
 
         // Stored string should preserve timezone offset
         let s: String = db.one_column("SELECT t FROM foo")?;
@@ -298,7 +298,7 @@ mod test {
     #[test]
     fn test_naive_date_time_param() -> Result<()> {
         let db = checked_memory_handle()?;
-        let result: Result<bool> = db.query_row("SELECT 1 WHERE ? BETWEEN datetime('now', '-1 minute') AND datetime('now', '+1 minute')", [Utc::now().naive_utc()], |r| r.get(0));
+        let result: Result<bool> = db.query_row("SELECT 1 WHERE ?1 BETWEEN datetime('now', '-1 minute') AND datetime('now', '+1 minute')", [Utc::now().naive_utc()], |r| r.get(0));
         result.unwrap();
         Ok(())
     }
@@ -306,7 +306,7 @@ mod test {
     #[test]
     fn test_date_time_param() -> Result<()> {
         let db = checked_memory_handle()?;
-        let result: Result<bool> = db.query_row("SELECT 1 WHERE ? BETWEEN datetime('now', '-1 minute') AND datetime('now', '+1 minute')", [Utc::now()], |r| r.get(0));
+        let result: Result<bool> = db.query_row("SELECT 1 WHERE ?1 BETWEEN datetime('now', '-1 minute') AND datetime('now', '+1 minute')", [Utc::now()], |r| r.get(0));
         result.unwrap();
         Ok(())
     }

--- a/src/types/from_sql.rs
+++ b/src/types/from_sql.rs
@@ -244,7 +244,7 @@ mod test {
         {
             for n in out_of_range {
                 let err = db
-                    .query_row("SELECT ?", [n], |r| r.get::<_, T>(0))
+                    .query_row("SELECT ?1", [n], |r| r.get::<_, T>(0))
                     .unwrap_err();
                 match err {
                     Error::IntegralValueOutOfRange(_, value) => assert_eq!(*n, value),
@@ -254,7 +254,7 @@ mod test {
             for n in in_range {
                 assert_eq!(
                     *n,
-                    db.query_row("SELECT ?", [n], |r| r.get::<_, T>(0))
+                    db.query_row("SELECT ?1", [n], |r| r.get::<_, T>(0))
                         .unwrap()
                         .into()
                 );

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -102,7 +102,7 @@ mod value_ref;
 /// # use rusqlite::types::{Null};
 ///
 /// fn insert_null(conn: &Connection) -> Result<usize> {
-///     conn.execute("INSERT INTO people (name) VALUES (?)", [Null])
+///     conn.execute("INSERT INTO people (name) VALUES (?1)", [Null])
 /// }
 /// ```
 #[derive(Copy, Clone)]
@@ -153,7 +153,7 @@ mod test {
         let db = checked_memory_handle()?;
 
         let v1234 = vec![1u8, 2, 3, 4];
-        db.execute("INSERT INTO foo(b) VALUES (?)", [&v1234])?;
+        db.execute("INSERT INTO foo(b) VALUES (?1)", [&v1234])?;
 
         let v: Vec<u8> = db.one_column("SELECT b FROM foo")?;
         assert_eq!(v, v1234);
@@ -165,7 +165,7 @@ mod test {
         let db = checked_memory_handle()?;
 
         let empty = vec![];
-        db.execute("INSERT INTO foo(b) VALUES (?)", [&empty])?;
+        db.execute("INSERT INTO foo(b) VALUES (?1)", [&empty])?;
 
         let v: Vec<u8> = db.one_column("SELECT b FROM foo")?;
         assert_eq!(v, empty);
@@ -177,7 +177,7 @@ mod test {
         let db = checked_memory_handle()?;
 
         let s = "hello, world!";
-        db.execute("INSERT INTO foo(t) VALUES (?)", [&s])?;
+        db.execute("INSERT INTO foo(t) VALUES (?1)", [&s])?;
 
         let from: String = db.one_column("SELECT t FROM foo")?;
         assert_eq!(from, s);
@@ -189,7 +189,7 @@ mod test {
         let db = checked_memory_handle()?;
 
         let s = "hello, world!";
-        db.execute("INSERT INTO foo(t) VALUES (?)", [s.to_owned()])?;
+        db.execute("INSERT INTO foo(t) VALUES (?1)", [s.to_owned()])?;
 
         let from: String = db.one_column("SELECT t FROM foo")?;
         assert_eq!(from, s);
@@ -200,7 +200,7 @@ mod test {
     fn test_value() -> Result<()> {
         let db = checked_memory_handle()?;
 
-        db.execute("INSERT INTO foo(i) VALUES (?)", [Value::Integer(10)])?;
+        db.execute("INSERT INTO foo(i) VALUES (?1)", [Value::Integer(10)])?;
 
         assert_eq!(10i64, db.one_column::<i64>("SELECT i FROM foo")?);
         Ok(())
@@ -213,8 +213,8 @@ mod test {
         let s = Some("hello, world!");
         let b = Some(vec![1u8, 2, 3, 4]);
 
-        db.execute("INSERT INTO foo(t) VALUES (?)", [&s])?;
-        db.execute("INSERT INTO foo(b) VALUES (?)", [&b])?;
+        db.execute("INSERT INTO foo(t) VALUES (?1)", [&s])?;
+        db.execute("INSERT INTO foo(b) VALUES (?1)", [&b])?;
 
         let mut stmt = db.prepare("SELECT t, b FROM foo ORDER BY ROWID ASC")?;
         let mut rows = stmt.query([])?;

--- a/src/types/serde_json.rs
+++ b/src/types/serde_json.rs
@@ -41,7 +41,7 @@ mod test {
         let json = r#"{"foo": 13, "bar": "baz"}"#;
         let data: Value = serde_json::from_str(json).unwrap();
         db.execute(
-            "INSERT INTO foo (t, b) VALUES (?, ?)",
+            "INSERT INTO foo (t, b) VALUES (?1, ?2)",
             [&data as &dyn ToSql, &json.as_bytes()],
         )?;
 

--- a/src/types/time.rs
+++ b/src/types/time.rs
@@ -91,7 +91,7 @@ mod test {
         ts_vec.push(make_datetime(10_000_000_000, 0)); //November 20, 2286
 
         for ts in ts_vec {
-            db.execute("INSERT INTO foo(t) VALUES (?)", [ts])?;
+            db.execute("INSERT INTO foo(t) VALUES (?1)", [ts])?;
 
             let from: OffsetDateTime = db.one_column("SELECT t FROM foo")?;
 
@@ -143,7 +143,7 @@ mod test {
                 Ok(OffsetDateTime::parse("2013-10-07T04:23:19.120-04:00", &Rfc3339).unwrap()),
             ),
         ] {
-            let result: Result<OffsetDateTime> = db.query_row("SELECT ?", [s], |r| r.get(0));
+            let result: Result<OffsetDateTime> = db.query_row("SELECT ?1", [s], |r| r.get(0));
             assert_eq!(result, t);
         }
         Ok(())
@@ -160,7 +160,7 @@ mod test {
     #[test]
     fn test_param() -> Result<()> {
         let db = Connection::open_in_memory()?;
-        let result: Result<bool> = db.query_row("SELECT 1 WHERE ? BETWEEN datetime('now', '-1 minute') AND datetime('now', '+1 minute')", [OffsetDateTime::now_utc()], |r| r.get(0));
+        let result: Result<bool> = db.query_row("SELECT 1 WHERE ?1 BETWEEN datetime('now', '-1 minute') AND datetime('now', '+1 minute')", [OffsetDateTime::now_utc()], |r| r.get(0));
         result.unwrap();
         Ok(())
     }

--- a/src/types/to_sql.rs
+++ b/src/types/to_sql.rs
@@ -368,10 +368,10 @@ mod test {
         db.execute(
             "
             INSERT INTO foo(i128, desc) VALUES
-                (?, 'zero'),
-                (?, 'neg one'), (?, 'neg two'),
-                (?, 'pos one'), (?, 'pos two'),
-                (?, 'min'), (?, 'max')",
+                (?1, 'zero'),
+                (?2, 'neg one'), (?3, 'neg two'),
+                (?4, 'pos one'), (?5, 'pos two'),
+                (?6, 'min'), (?7, 'max')",
             [0i128, -1i128, -2i128, 1i128, 2i128, i128::MIN, i128::MAX],
         )?;
 
@@ -410,11 +410,11 @@ mod test {
         let id = Uuid::new_v4();
 
         db.execute(
-            "INSERT INTO foo (id, label) VALUES (?, ?)",
+            "INSERT INTO foo (id, label) VALUES (?1, ?2)",
             params![id, "target"],
         )?;
 
-        let mut stmt = db.prepare("SELECT id, label FROM foo WHERE id = ?")?;
+        let mut stmt = db.prepare("SELECT id, label FROM foo WHERE id = ?1")?;
 
         let mut rows = stmt.query(params![id])?;
         let row = rows.next()?.unwrap();

--- a/src/types/url.rs
+++ b/src/types/url.rs
@@ -49,7 +49,7 @@ mod test {
         let url2 = "http://www.example2.com/👌";
 
         db.execute(
-            "INSERT INTO urls (i, v) VALUES (0, ?), (1, ?), (2, ?), (3, ?)",
+            "INSERT INTO urls (i, v) VALUES (0, ?1), (1, ?2), (2, ?3), (3, ?4)",
             // also insert a non-hex encoded url (which might be present if it was
             // inserted separately)
             params![url0, url1, url2, "illegal"],

--- a/src/vtab/array.rs
+++ b/src/vtab/array.rs
@@ -17,7 +17,7 @@
 //!     let v = [1i64, 2, 3, 4];
 //!     // Note: A `Rc<Vec<Value>>` must be used as the parameter.
 //!     let values = Rc::new(v.iter().copied().map(Value::from).collect::<Vec<Value>>());
-//!     let mut stmt = db.prepare("SELECT value from rarray(?);")?;
+//!     let mut stmt = db.prepare("SELECT value from rarray(?1);")?;
 //!     let rows = stmt.query_map([values], |row| row.get::<_, i64>(0))?;
 //!     for value in rows {
 //!         println!("{}", value?);
@@ -206,7 +206,7 @@ mod test {
         let values: Vec<Value> = v.into_iter().map(Value::from).collect();
         let ptr = Rc::new(values);
         {
-            let mut stmt = db.prepare("SELECT value from rarray(?);")?;
+            let mut stmt = db.prepare("SELECT value from rarray(?1);")?;
 
             let rows = stmt.query_map([&ptr], |row| row.get::<_, i64>(0))?;
             assert_eq!(2, Rc::strong_count(&ptr));

--- a/src/vtab/vtablog.rs
+++ b/src/vtab/vtablog.rs
@@ -286,13 +286,13 @@ mod test {
         let mut stmt = db.prepare("SELECT * FROM log;")?;
         let mut rows = stmt.query([])?;
         while rows.next()?.is_some() {}
-        db.execute("DELETE FROM log WHERE a = ?", ["a1"])?;
+        db.execute("DELETE FROM log WHERE a = ?1", ["a1"])?;
         db.execute(
-            "INSERT INTO log (a, b, c) VALUES (?, ?, ?)",
+            "INSERT INTO log (a, b, c) VALUES (?1, ?2, ?3)",
             ["a", "b", "c"],
         )?;
         db.execute(
-            "UPDATE log SET b = ?, c = ? WHERE a = ?",
+            "UPDATE log SET b = ?1, c = ?2 WHERE a = ?3",
             ["bn", "cn", "a1"],
         )?;
         Ok(())


### PR DESCRIPTION
https://sqlite.org/lang_expr.html#parameters
> But because it is easy to miscount the question marks, the use of this parameter format is discouraged. Programmers are encouraged to use one of the symbolic formats below or the ?NNN format above instead.