### PR TITLE
Linkage issue in windows

### DIFF
--- a/libsqlite3-sys/build.rs
+++ b/libsqlite3-sys/build.rs
@@ -181,15 +181,10 @@ mod build_bundled {
                 cfg.include(env::var("DEP_OPENSSL_INCLUDE").unwrap());
                 // cargo will resolve downstream to the static lib in
                 // openssl-sys
-            } else if is_windows {
-                // Windows without `-vendored-openssl` takes this to link against a prebuilt
-                // OpenSSL lib
-                cfg.include(inc_dir.to_string_lossy().as_ref());
-                println!("cargo:rustc-link-lib=dylib=libcrypto");
             } else if use_openssl {
                 cfg.include(inc_dir.to_string_lossy().as_ref());
-                // branch not taken on Windows, just `crypto` is fine.
-                println!("cargo:rustc-link-lib=dylib=crypto");
+                let lib_name = if is_windows { "libcrypto" } else { "crypto" };
+                println!("cargo:rustc-link-lib=dylib={}", lib_name);
                 println!("cargo:rustc-link-search={}", lib_dir.to_string_lossy());
             } else if is_apple {
                 cfg.flag("-DSQLCIPHER_CRYPTO_CC");

--- a/libsqlite3-sys/build.rs
+++ b/libsqlite3-sys/build.rs
@@ -185,8 +185,7 @@ mod build_bundled {
                 // Windows without `-vendored-openssl` takes this to link against a prebuilt
                 // OpenSSL lib
                 cfg.include(inc_dir.to_string_lossy().as_ref());
-                let lib = lib_dir.join("libcrypto.lib");
-                cfg.flag(lib.to_string_lossy().as_ref());
+                println!("cargo:rustc-link-lib=dylib=libcrypto");
             } else if use_openssl {
                 cfg.include(inc_dir.to_string_lossy().as_ref());
                 // branch not taken on Windows, just `crypto` is fine.


### PR DESCRIPTION
It always tell me that
```
c:\sql>cargo build
   Compiling libsqlite3-sys v0.25.2 (c:\sql\libsqlite3-sys)
warning: cl : Command line warning D9027 : source file 'C:\Program Files\OpenSSL-Win64\lib\libcrypto.lib' ignored
   Compiling rusqlite v0.28.0 (c:\sql)
    Finished dev [unoptimized + debuginfo] target(s) in 5.11s
```
so I change the script.

I think it can fix issue #966 also