### PR TITLE
Make it build for wasm32-wasi

### DIFF
--- a/libsqlite3-sys/build.rs
+++ b/libsqlite3-sys/build.rs
@@ -19,11 +19,11 @@ fn android_target() -> bool {
 }
 
 /// Tells whether a given compiler will be used `compiler_name` is compared to
-/// the content of `CARGO_CFG_TARGET_ENV` (and is always lowercase)
+/// the content of `TARGET` (and is always lowercase)
 ///
 /// See [`win_target`]
 fn is_compiler(compiler_name: &str) -> bool {
-    env::var("CARGO_CFG_TARGET_ENV").map_or(false, |v| v == compiler_name)
+    env::var("TARGET").map_or(false, |v| v == compiler_name)
 }
 
 fn main() {
@@ -244,6 +244,7 @@ mod build_bundled {
         // Target wasm32-wasi can't compile the default VFS
         if is_compiler("wasm32-wasi") {
             cfg.flag("-DSQLITE_OS_OTHER")
+                .flag("-DSQLITE_THREADSAFE=0")
                 // https://github.com/rust-lang/rust/issues/74393
                 .flag("-DLONGDOUBLE_TYPE=double");
             if cfg!(feature = "wasm32-wasi-vfs") {


### PR DESCRIPTION
`CARGO_CFG_TARGET_ENV` is not being set when compiling to `wasm32-wasi` and if it isn't then the flags used for compiling sqlite correctly for it do not get applied. We can use `TARGET` instead, which seems to be always set. 

Also, `-DSQLITE_THREADSAFE=0` is needed as a flag, as without it, sqlite will use `pthread.h` which is not defined for wasi targets. 