### PR TITLE
No longer panic if we fail to close the connection when dropping it.

### DIFF
--- a/src/inner_connection.rs
+++ b/src/inner_connection.rs
@@ -371,15 +371,7 @@ impl Drop for InnerConnection {
     #[allow(unused_must_use)]
     #[inline]
     fn drop(&mut self) {
-        use std::thread::panicking;
-
-        if let Err(e) = self.close() {
-            if panicking() {
-                eprintln!("Error while closing SQLite connection: {e:?}");
-            } else {
-                panic!("Error while closing SQLite connection: {:?}", e);
-            }
-        }
+        self.close();
     }
 }
 


### PR DESCRIPTION
I couldn't find any docstrings that need to be changed nor anywhere I should add to a changelog, but let me know if I missed something. The function already has `#[allow(unused_must_use)]` so this really is trivial.

Fixes #1292