### PR TITLE
Add Statement.readonly() accessor

### DIFF
--- a/src/raw_statement.rs
+++ b/src/raw_statement.rs
@@ -197,7 +197,6 @@ impl RawStatement {
     }
 
     // does not work for PRAGMA
-    #[cfg(feature = "extra_check")]
     #[inline]
     pub fn readonly(&self) -> bool {
         unsafe { ffi::sqlite3_stmt_readonly(self.ptr) != 0 }

--- a/src/statement.rs
+++ b/src/statement.rs
@@ -709,6 +709,12 @@ impl Statement<'_> {
         self.stmt.is_explain()
     }
 
+    /// Returns true if the statement is read only.
+    #[inline]
+    pub fn readonly(&self) -> bool {
+        self.stmt.readonly()
+    }
+
     #[cfg(feature = "extra_check")]
     #[inline]
     pub(crate) fn check_no_tail(&self) -> Result<()> {
@@ -1321,6 +1327,14 @@ mod test {
         let db = Connection::open_in_memory()?;
         let stmt = db.prepare("SELECT 1;")?;
         assert_eq!(0, stmt.is_explain());
+        Ok(())
+    }
+
+    #[test]
+    fn readonly() -> Result<()> {
+        let db = Connection::open_in_memory()?;
+        let stmt = db.prepare("SELECT 1;")?;
+        assert!(stmt.readonly());
         Ok(())
     }
 


### PR DESCRIPTION
Condition on the `extra_check` feature, which matches the implementation within RawStatement.

Thanks