### PR TITLE
Implement FromSql & ToSql for std::num::NonZero types

### DIFF
--- a/src/types/from_sql.rs
+++ b/src/types/from_sql.rs
@@ -308,7 +308,9 @@ mod test {
                 for &n in $out_of_range {
                     assert_eq!(
                         db.query_row("SELECT ?1", [n], |r| r.get::<_, $nz>(0)),
-                        Err(Error::IntegralValueOutOfRange(0, n))
+                        Err(Error::IntegralValueOutOfRange(0, n)),
+                        "{}",
+                        std::any::type_name::<$nz>()
                     );
                 }
                 for &n in $in_range {
@@ -332,11 +334,31 @@ mod test {
             &[0, -2_147_483_649, 2_147_483_648],
             &[-2_147_483_648, -1, 1, 2_147_483_647]
         );
+        check_ranges!(
+            std::num::NonZeroI64,
+            &[0],
+            &[-2_147_483_648, -1, 1, 2_147_483_647, i64::MAX, i64::MIN]
+        );
+        check_ranges!(
+            std::num::NonZeroIsize,
+            &[0],
+            &[-2_147_483_648, -1, 1, 2_147_483_647]
+        );
         check_ranges!(std::num::NonZeroU8, &[0, -2, -1, 256], &[1, 255]);
         check_ranges!(std::num::NonZeroU16, &[0, -2, -1, 65536], &[1, 65535]);
         check_ranges!(
             std::num::NonZeroU32,
             &[0, -2, -1, 4_294_967_296],
+            &[1, 4_294_967_295]
+        );
+        check_ranges!(
+            std::num::NonZeroU64,
+            &[0, -2, -1, -4_294_967_296],
+            &[1, 4_294_967_295, i64::MAX as u64]
+        );
+        check_ranges!(
+            std::num::NonZeroUsize,
+            &[0, -2, -1, -4_294_967_296],
             &[1, 4_294_967_295]
         );
 

--- a/src/types/from_sql.rs
+++ b/src/types/from_sql.rs
@@ -96,6 +96,15 @@ macro_rules! from_sql_integral(
                 i.try_into().map_err(|_| FromSqlError::OutOfRange(i))
             }
         }
+    );
+    (non_zero $nz:ty, $z:ty) => (
+        impl FromSql for $nz {
+            #[inline]
+            fn column_result(value: ValueRef<'_>) -> FromSqlResult<Self> {
+                let i = <$z>::column_result(value)?;
+                <$nz>::new(i).ok_or(FromSqlError::OutOfRange(0))
+            }
+        }
     )
 );
 
@@ -109,6 +118,22 @@ from_sql_integral!(u16);
 from_sql_integral!(u32);
 from_sql_integral!(u64);
 from_sql_integral!(usize);
+
+from_sql_integral!(non_zero std::num::NonZeroIsize, isize);
+from_sql_integral!(non_zero std::num::NonZeroI8, i8);
+from_sql_integral!(non_zero std::num::NonZeroI16, i16);
+from_sql_integral!(non_zero std::num::NonZeroI32, i32);
+from_sql_integral!(non_zero std::num::NonZeroI64, i64);
+#[cfg(feature = "i128_blob")]
+#[cfg_attr(docsrs, doc(cfg(feature = "i128_blob")))]
+from_sql_integral!(non_zero std::num::NonZeroI128, i128);
+
+from_sql_integral!(non_zero std::num::NonZeroUsize, usize);
+from_sql_integral!(non_zero std::num::NonZeroU8, u8);
+from_sql_integral!(non_zero std::num::NonZeroU16, u16);
+from_sql_integral!(non_zero std::num::NonZeroU32, u32);
+from_sql_integral!(non_zero std::num::NonZeroU64, u64);
+// std::num::NonZeroU128 is not supported since u128 isn't either
 
 impl FromSql for i64 {
     #[inline]

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -26,7 +26,8 @@
 //! [`ToSql`] always succeeds except when storing a `u64` or `usize` value that
 //! cannot fit in an `INTEGER` (`i64`). Also note that SQLite ignores column
 //! types, so if you store an `i64` in a column with type `REAL` it will be
-//! stored as an `INTEGER`, not a `REAL`.
+//! stored as an `INTEGER`, not a `REAL` (unless the column is part of a
+//! [STRICT table](https://www.sqlite.org/stricttables.html)).
 //!
 //! If the `time` feature is enabled, implementations are
 //! provided for `time::OffsetDateTime` that use the RFC 3339 date/time format,

--- a/src/types/to_sql.rs
+++ b/src/types/to_sql.rs
@@ -267,9 +267,12 @@ mod test {
         is_to_sql::<i16>();
         is_to_sql::<i32>();
         is_to_sql::<i64>();
+        is_to_sql::<isize>();
         is_to_sql::<u8>();
         is_to_sql::<u16>();
         is_to_sql::<u32>();
+        is_to_sql::<u64>();
+        is_to_sql::<usize>();
     }
 
     #[test]


### PR DESCRIPTION
Pros:
- pretty straightforward implementation
- support for more standard library types
- won't (shouldn't) break anything because of orphan rules

Cons:
- clutters up docs (and code) a little
- probably not very extensively used

I also added a little note about STRICT tables to the docs.