### PR TITLE
Force linking against system sqlite libs

### DIFF
--- a/libsqlite3-sys/build.rs
+++ b/libsqlite3-sys/build.rs
@@ -36,7 +36,11 @@ fn main() {
             .expect("Could not copy bindings to output directory");
         return;
     }
-    if cfg!(all(
+
+    println!("cargo:rerun-if-env-changed=LIBSQLITE3_SYS_USE_PKG_CONFIG");
+    if env::var_os("LIBSQLITE3_SYS_USE_PKG_CONFIG").map_or(false, |s| s != "0") {
+        build_linked::main(&out_dir, &out_path);
+    } else if cfg!(all(
         feature = "sqlcipher",
         not(feature = "bundled-sqlcipher")
     )) {


### PR DESCRIPTION
This commit introduces new env var, LIBSQLITE3_SYS_USE_PKG_CONFIG, which can be set to non-zero values to force building against sqlite libraries from the system overriding bundled features.

Prior art in other -sys crates:

- [ssh2-rs](https://github.com/alexcrichton/ssh2-rs/commit/a35a60aafedf101dc67ff24bab2cc5817f292fb7)
- [zstd-rs](https://github.com/gyscos/zstd-rs/commit/22e359a53f4b577a45ae28bed6a1717c1b0fb6a9)
- [rust-openssl](https://github.com/sfackler/rust-openssl/commit/830658ec0bdae8ba1f6310f2e8116750d01c1b82)