### PR TITLE
fix compilation for target wasm32-wasi

### DIFF
--- a/libsqlite3-sys/build.rs
+++ b/libsqlite3-sys/build.rs
@@ -240,7 +240,7 @@ mod build_bundled {
             cfg.flag("-DHAVE_LOCALTIME_R");
         }
         // Target wasm32-wasi can't compile the default VFS
-        if is_compiler("wasm32-wasi") {
+        if env::var("TARGET").map_or(false, |v| v == "wasm32-wasi") {
             cfg.flag("-DSQLITE_OS_OTHER")
                 // https://github.com/rust-lang/rust/issues/74393
                 .flag("-DLONGDOUBLE_TYPE=double");


### PR DESCRIPTION
This PR partially reverts https://github.com/rusqlite/rusqlite/pull/961 that has introduced a bug in detection of `wasm32-wasi` target. That PR replaced the check of `TARGET` with a check of `CARGO_CFG_TARGET_ENV`. That however is incorrect because `wasm32-wasi` is a CPU architecture target (similar to `x86` and `armv8`) and not an operating system.

This PR only affects `wasm32-wasi` compilation and is a no-op for other targets.
