### PR TITLE
Add SQLITE_MAX_COLUMN compile-time option

### DIFF
--- a/libsqlite3-sys/build.rs
+++ b/libsqlite3-sys/build.rs
@@ -268,6 +268,11 @@ mod build_bundled {
         }
         println!("cargo:rerun-if-env-changed=SQLITE_MAX_EXPR_DEPTH");
 
+        if let Ok(limit) = env::var("SQLITE_MAX_COLUMN") {
+            cfg.flag(&format!("-DSQLITE_MAX_COLUMN={limit}"));
+        }
+        println!("cargo:rerun-if-env-changed=SQLITE_MAX_COLUMN");
+
         if let Ok(extras) = env::var("LIBSQLITE3_FLAGS") {
             for extra in extras.split_whitespace() {
                 if extra.starts_with("-D") || extra.starts_with("-U") {


### PR DESCRIPTION
In `bundled` mode, add support in build script for SQLITE_MAX_COLUMN compile-time option.

See links:
https://www.sqlite.org/compile.html
https://www.sqlite.org/limits.html