### PR TITLE
impl ToSql and FromSql for SmallString from smallstr crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -122,6 +122,7 @@ fallible-iterator = "0.2"
 fallible-streaming-iterator = "0.1"
 uuid = { version = "1.0", optional = true }
 smallvec = "1.6.1"
+smallstr = { version = "0.3", optional = true }
 
 [dev-dependencies]
 doc-comment = "0.3"

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -83,6 +83,9 @@ mod from_sql;
 #[cfg(feature = "serde_json")]
 #[cfg_attr(docsrs, doc(cfg(feature = "serde_json")))]
 mod serde_json;
+#[cfg(feature = "smallstr")]
+#[cfg_attr(docsrs, doc(cfg(feature = "smallstr")))]
+mod smallstr;
 #[cfg(feature = "time")]
 #[cfg_attr(docsrs, doc(cfg(feature = "time")))]
 mod time;

--- a/src/types/smallstr.rs
+++ b/src/types/smallstr.rs
@@ -1,0 +1,58 @@
+#![warn(clippy::pedantic)]
+//! Implementation of [`FromSql`] and [`ToSql`] for [`SmallString`]
+
+use smallstr::SmallString;
+use smallvec::Array;
+
+use crate::types::{FromSql, FromSqlResult, ToSql, ToSqlOutput, ValueRef};
+use crate::Result;
+
+/// Deserialize a TEXT SQL value to a `SmallString`.
+///
+/// The behaviour of conversion should be identical to that of `String`, `Box<str>`, etc
+impl<A: Array<Item = u8>> FromSql for SmallString<A> {
+    fn column_result(value: ValueRef<'_>) -> FromSqlResult<Self> {
+        value.as_str().map(From::from)
+    }
+}
+
+/// Serialize a TEXT SQL value from a `SmallString`.
+///
+/// The behaviour of conversion should be identical to that of `String`, `Box<str>`, `&str`, etc
+impl<A: Array<Item = u8>> ToSql for SmallString<A> {
+    fn to_sql(&self) -> Result<ToSqlOutput<'_>> {
+        self.as_str().to_sql()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+
+    use smallstr::SmallString;
+
+    use crate::{Connection, Result};
+
+    #[test]
+    fn round_trip() -> Result<()> {
+        let db = Connection::open_in_memory()?;
+
+        let slug = SmallString::<[u8; 16]>::from("apple");
+
+        db.execute_batch(
+            "CREATE TABLE strings (id INTEGER PRIMARY KEY AUTOINCREMENT, data TEXT) STRICT",
+        )?;
+
+        let id = db
+            .prepare("INSERT INTO strings (data) VALUES (?1)")?
+            .insert([slug])?;
+
+        let stored: SmallString<[u8; 16]> =
+            db.query_row("SELECT * FROM strings WHERE id=?1", [id], |row| {
+                row.get("data")
+            })?;
+
+        assert_eq!(stored, "apple");
+
+        Ok(())
+    }
+}


### PR DESCRIPTION
This implements the feature proposed in github issue #1323. 

This code passes clippy pedantic, fmt, and a new test written for it. 

One consideration is that `smallstr 0.3` relies on `smallvec 1.8`, wheras this crate holds a dependency on `smallvec 1.6`. I'm not too deep in dependency resolution knowledge but as I understand this wont pose a real problem