### PR TITLE
Statement::column_table_name

### DIFF
--- a/src/column.rs
+++ b/src/column.rs
@@ -102,6 +102,30 @@ impl Statement<'_> {
             })
     }
 
+    /// Returns the name of the table assigned to a particular column in the result set
+    /// returned by the prepared statement.
+    ///
+    /// If associated DB schema can be altered concurrently, you should make
+    /// sure that current statement has already been stepped once before
+    /// calling this method.
+    ///
+    /// ## Failure
+    ///
+    /// Returns an `Error::InvalidColumnIndex` if `idx` is outside the valid
+    /// column range for this row.
+    ///
+    /// Panics when table name is not valid UTF-8.
+    #[inline]
+    pub fn column_table_name(&self, col: usize) -> Result<&str> {
+        self.stmt
+            .column_table_name(col)
+            // clippy::or_fun_call (nightly) vs clippy::unnecessary-lazy-evaluations (stable)
+            .ok_or(Error::InvalidColumnIndex(col))
+            .map(|slice| {
+                str::from_utf8(slice.to_bytes()).expect("Invalid UTF-8 sequence in column name")
+            })
+    }
+
     /// Returns the column index in the result set for a given column name.
     ///
     /// If there is no AS clause then the name of the column is unspecified and

--- a/src/raw_statement.rs
+++ b/src/raw_statement.rs
@@ -70,6 +70,24 @@ impl RawStatement {
     }
 
     #[inline]
+    pub fn column_table_name(&self, idx: usize) -> Option<&CStr> {
+        let idx = idx as c_int;
+        if idx < 0 || idx >= self.column_count() as c_int {
+            return None;
+        }
+
+        unsafe {
+            let ptr = ffi::sqlite3_column_table_name(self.ptr, idx);
+
+            assert!(
+                !ptr.is_null(),
+                "Null pointer from sqlite3_column_table_name: Out of memory?"
+            );
+            Some(CStr::from_ptr(ptr))
+        }
+    }
+
+    #[inline]
     #[cfg(feature = "column_decltype")]
     pub fn column_decltype(&self, idx: usize) -> Option<&CStr> {
         unsafe {


### PR DESCRIPTION
Wrapper around `sqlite3_column_table_name` from https://www.sqlite.org/capi3ref.html#sqlite3_column_database_name