### PR TITLE
Fixes generate_series to handle NULL arguments

### DIFF
--- a/src/vtab/series.rs
+++ b/src/vtab/series.rs
@@ -200,19 +200,19 @@ unsafe impl VTabCursor for SeriesTabCursor<'_> {
         let mut idx_num = QueryPlanFlags::from_bits_truncate(idx_num);
         let mut i = 0;
         if idx_num.contains(QueryPlanFlags::START) {
-            self.min_value = args.get(i)?;
+            self.min_value = args.get::<Option<_>>(i)?.unwrap_or_default();
             i += 1;
         } else {
             self.min_value = 0;
         }
         if idx_num.contains(QueryPlanFlags::STOP) {
-            self.max_value = args.get(i)?;
+            self.max_value = args.get::<Option<_>>(i)?.unwrap_or_default();
             i += 1;
         } else {
             self.max_value = 0xffff_ffff;
         }
         if idx_num.contains(QueryPlanFlags::STEP) {
-            self.step = args.get(i)?;
+            self.step = args.get::<Option<_>>(i)?.unwrap_or_default();
             if self.step == 0 {
                 self.step = 1;
             } else if self.step < 0 {

--- a/src/vtab/series.rs
+++ b/src/vtab/series.rs
@@ -8,6 +8,7 @@ use std::marker::PhantomData;
 use std::os::raw::c_int;
 
 use crate::ffi;
+use crate::types::Type;
 use crate::vtab::{
     eponymous_only_module, Context, IndexConstraintOp, IndexInfo, VTab, VTabConfig, VTabConnection,
     VTabCursor, Values,
@@ -197,34 +198,21 @@ impl SeriesTabCursor<'_> {
 unsafe impl VTabCursor for SeriesTabCursor<'_> {
     fn filter(&mut self, idx_num: c_int, _idx_str: Option<&str>, args: &Values<'_>) -> Result<()> {
         let mut idx_num = QueryPlanFlags::from_bits_truncate(idx_num);
-        let mut any_null = false;
         let mut i = 0;
         if idx_num.contains(QueryPlanFlags::START) {
-            if let Some(min_value) = args.get(i)? {
-                self.min_value = min_value;
-            } else {
-                any_null = true;
-            }
+            self.min_value = args.get(i)?;
             i += 1;
         } else {
             self.min_value = 0;
         }
         if idx_num.contains(QueryPlanFlags::STOP) {
-            if let Some(max_value) = args.get(i)? {
-                self.max_value = max_value;
-            } else {
-                any_null = true;
-            }
+            self.max_value = args.get(i)?;
             i += 1;
         } else {
             self.max_value = 0xffff_ffff;
         }
         if idx_num.contains(QueryPlanFlags::STEP) {
-            if let Some(step) = args.get(i)? {
-                self.step = step;
-            } else {
-                any_null = true;
-            }
+            self.step = args.get(i)?;
             if self.step == 0 {
                 self.step = 1;
             } else if self.step < 0 {
@@ -236,11 +224,13 @@ unsafe impl VTabCursor for SeriesTabCursor<'_> {
         } else {
             self.step = 1;
         };
-        if any_null {
-            // If any of the constraints have a NULL value, then
-            // return no rows.
-            self.min_value = 1;
-            self.max_value = 0;
+        for arg in args.iter() {
+            if arg.data_type() == Type::Null {
+                // If any of the constraints have a NULL value, then return no rows.
+                self.min_value = 1;
+                self.max_value = 0;
+                break;
+            }
         }
         self.is_desc = idx_num.contains(QueryPlanFlags::DESC);
         if self.is_desc {

--- a/src/vtab/series.rs
+++ b/src/vtab/series.rs
@@ -316,6 +316,16 @@ mod test {
         let series: Vec<i32> = s.query([])?.map(|r| r.get(0)).collect()?;
         assert_eq!(vec![30, 25, 20, 15, 10, 5, 0], series);
 
+        let mut s = db.prepare("SELECT * FROM generate_series(NULL)")?;
+        let series: Vec<i32> = s.query([])?.map(|r| r.get(0)).collect()?;
+        assert_eq!(Vec::<i32>::new(), series);
+        let mut s = db.prepare("SELECT * FROM generate_series(5,NULL)")?;
+        let series: Vec<i32> = s.query([])?.map(|r| r.get(0)).collect()?;
+        assert_eq!(Vec::<i32>::new(), series);
+        let mut s = db.prepare("SELECT * FROM generate_series(5,10,NULL)")?;
+        let series: Vec<i32> = s.query([])?.map(|r| r.get(0)).collect()?;
+        assert_eq!(Vec::<i32>::new(), series);
+
         Ok(())
     }
 }

--- a/src/vtab/series.rs
+++ b/src/vtab/series.rs
@@ -328,13 +328,23 @@ mod test {
 
         let mut s = db.prepare("SELECT * FROM generate_series(NULL)")?;
         let series: Vec<i32> = s.query([])?.map(|r| r.get(0)).collect()?;
-        assert_eq!(Vec::<i32>::new(), series);
+        let empty = Vec::<i32>::new();
+        assert_eq!(empty, series);
         let mut s = db.prepare("SELECT * FROM generate_series(5,NULL)")?;
         let series: Vec<i32> = s.query([])?.map(|r| r.get(0)).collect()?;
-        assert_eq!(Vec::<i32>::new(), series);
+        assert_eq!(empty, series);
         let mut s = db.prepare("SELECT * FROM generate_series(5,10,NULL)")?;
         let series: Vec<i32> = s.query([])?.map(|r| r.get(0)).collect()?;
-        assert_eq!(Vec::<i32>::new(), series);
+        assert_eq!(empty, series);
+        let mut s = db.prepare("SELECT * FROM generate_series(NULL,10,2)")?;
+        let series: Vec<i32> = s.query([])?.map(|r| r.get(0)).collect()?;
+        assert_eq!(empty, series);
+        let mut s = db.prepare("SELECT * FROM generate_series(5,NULL,2)")?;
+        let series: Vec<i32> = s.query([])?.map(|r| r.get(0)).collect()?;
+        assert_eq!(empty, series);
+        let mut s = db.prepare("SELECT * FROM generate_series(NULL) ORDER BY value DESC")?;
+        let series: Vec<i32> = s.query([])?.map(|r| r.get(0)).collect()?;
+        assert_eq!(empty, series);
 
         Ok(())
     }


### PR DESCRIPTION
SQLite's `generate_series` behavior has it return an empty result set whenever any of the arguments are `NULL`.

```
SQLite version 3.37.2 2022-01-06 13:25:41
Enter ".help" for usage hints.
Connected to a transient in-memory database.
Use ".open FILENAME" to reopen on a persistent database.
sqlite> SELECT value FROM generate_series(0, 3);
┌───────┐
│ value │
├───────┤
│ 0     │
│ 1     │
│ 2     │
│ 3     │
└───────┘
sqlite> SELECT value FROM generate_series(0, NULL);
sqlite> SELECT value FROM generate_series(NULL);
sqlite> SELECT value FROM generate_series(0, 3, NULL);
sqlite> SELECT value FROM generate_series(0, NULL, 2);
sqlite> SELECT value FROM generate_series(NULL, 3, 2);
sqlite> 
```

rusqlite's re-implementation of `generate_series` that's behind the `series` Cargo feature has code suggesting it should have the same behavior of returning no rows, but instead errors out if any of the arguments are `NULL`.

```
SqliteFailure(Error { code: Unknown, extended_code: 1 }, Some("Invalid filter parameter type Null at index 0"))
```

This error was due to the `args.get(i)?` originally being inferred to be `args.get::<i64>(i)?` since they're being assigned to the parameters directly and thus `NULL` causes an error.

This PR fixes the behavior of rusqlite's `generate_series` to match that of SQLite's extension. It does this by interpreting those arguments as `Option<i64> and if they are `None`, then marks that the range should be set to result in no rows.

Adds some tests to the existing series module tests that show that `NULL` arguments result in no rows.