### PR TITLE
Simplify bindgen generation

### DIFF
--- a/libsqlite3-sys/build.rs
+++ b/libsqlite3-sys/build.rs
@@ -487,7 +487,6 @@ mod bindings {
     use super::HeaderLocation;
     use bindgen::callbacks::{IntKind, ParseCallbacks};
 
-    use std::fs;
     use std::path::Path;
 
     use super::win_target;


### PR DESCRIPTION
`rusqlite` users cannot use old versions (< 3.8.3) of SQLite anymore. And `libsqlite3-sys` users should not use SQLITE_DETERMINISTIC when using SQLite < 3.8.3.