### PR TITLE
Fix ergonomics of Statements

### DIFF
--- a/src/collation.rs
+++ b/src/collation.rs
@@ -192,7 +192,7 @@ mod test {
              INSERT INTO foo (bar) VALUES ('Maße');
              INSERT INTO foo (bar) VALUES ('MASSE');",
         )?;
-        let mut stmt = db.prepare("SELECT DISTINCT bar COLLATE unicase FROM foo ORDER BY 1")?;
+        let stmt = db.prepare("SELECT DISTINCT bar COLLATE unicase FROM foo ORDER BY 1")?;
         let rows = stmt.query([])?;
         assert_eq!(rows.count()?, 1);
         Ok(())

--- a/src/column.rs
+++ b/src/column.rs
@@ -193,7 +193,7 @@ mod test {
              INSERT INTO foo VALUES(4, NULL);
              END;",
         )?;
-        let mut stmt = db.prepare("SELECT x as renamed, y FROM foo")?;
+        let stmt = db.prepare("SELECT x as renamed, y FROM foo")?;
         let mut rows = stmt.query([])?;
         let row = rows.next()?.unwrap();
         match row.get::<_, String>(0).unwrap_err() {

--- a/src/functions.rs
+++ b/src/functions.rs
@@ -1051,7 +1051,7 @@ mod test {
                      ('e', 1);",
         )?;
 
-        let mut stmt = db.prepare(
+        let stmt = db.prepare(
             "SELECT x, sumint(y) OVER (
                    ORDER BY x ROWS BETWEEN 1 PRECEDING AND 1 FOLLOWING
                  ) AS sum_y

--- a/src/pragma.rs
+++ b/src/pragma.rs
@@ -194,7 +194,7 @@ impl Connection {
     {
         let mut query = Sql::new();
         query.push_pragma(schema_name, pragma_name)?;
-        let mut stmt = self.prepare(&query)?;
+        let stmt = self.prepare(&query)?;
         let mut rows = stmt.query([])?;
         while let Some(result_row) = rows.next()? {
             let row = result_row;
@@ -231,7 +231,7 @@ impl Connection {
         sql.open_brace();
         sql.push_value(&pragma_value)?;
         sql.close_brace();
-        let mut stmt = self.prepare(&sql)?;
+        let stmt = self.prepare(&sql)?;
         let mut rows = stmt.query([])?;
         while let Some(result_row) = rows.next()? {
             let row = result_row;
@@ -379,7 +379,7 @@ mod test {
     #[cfg(feature = "modern_sqlite")]
     fn pragma_func() -> Result<()> {
         let db = Connection::open_in_memory()?;
-        let mut table_info = db.prepare("SELECT * FROM pragma_table_info(?1)")?;
+        let table_info = db.prepare("SELECT * FROM pragma_table_info(?1)")?;
         let mut columns = Vec::new();
         let mut rows = table_info.query(["sqlite_master"])?;
 

--- a/src/raw_statement.rs
+++ b/src/raw_statement.rs
@@ -44,6 +44,16 @@ impl RawStatement {
     }
 
     #[inline]
+    pub(crate) fn is_cached(&self) -> bool {
+        self.statement_cache_key.is_some()
+    }
+
+    #[inline]
+    pub(crate) fn clear_statement_cache_key(&mut self) {
+        self.statement_cache_key = None;
+    }
+
+    #[inline]
     pub(crate) fn set_statement_cache_key(&mut self, p: impl Into<Arc<str>>) {
         self.statement_cache_key = Some(p.into());
     }

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -217,7 +217,7 @@ mod test {
         db.execute("INSERT INTO foo(t) VALUES (?1)", [Some(s)])?;
         db.execute("INSERT INTO foo(b) VALUES (?1)", [&b])?;
 
-        let mut stmt = db.prepare("SELECT t, b FROM foo ORDER BY ROWID ASC")?;
+        let stmt = db.prepare("SELECT t, b FROM foo ORDER BY ROWID ASC")?;
         let mut rows = stmt.query([])?;
 
         {
@@ -252,7 +252,7 @@ mod test {
             [],
         )?;
 
-        let mut stmt = db.prepare("SELECT b, t, i, f, n FROM foo")?;
+        let stmt = db.prepare("SELECT b, t, i, f, n FROM foo")?;
         let mut rows = stmt.query([])?;
 
         let row = rows.next()?.unwrap();
@@ -344,7 +344,7 @@ mod test {
             [],
         )?;
 
-        let mut stmt = db.prepare("SELECT b, t, i, f, n FROM foo")?;
+        let stmt = db.prepare("SELECT b, t, i, f, n FROM foo")?;
         let mut rows = stmt.query([])?;
 
         let row = rows.next()?.unwrap();
@@ -361,23 +361,23 @@ mod test {
 
     macro_rules! test_conversion {
         ($db_etc:ident, $insert_value:expr, $get_type:ty,expect $expected_value:expr) => {
-            $db_etc.insert_statement.execute(params![$insert_value])?;
-            let res = $db_etc
+            $db_etc().insert_statement.execute(params![$insert_value])?;
+            let res = $db_etc()
                 .query_statement
                 .query_row([], |row| row.get::<_, $get_type>(0));
             assert_eq!(res?, $expected_value);
-            $db_etc.delete_statement.execute([])?;
+            $db_etc().delete_statement.execute([])?;
         };
         ($db_etc:ident, $insert_value:expr, $get_type:ty,expect_from_sql_error) => {
-            $db_etc.insert_statement.execute(params![$insert_value])?;
-            let res = $db_etc
+            $db_etc().insert_statement.execute(params![$insert_value])?;
+            let res = $db_etc()
                 .query_statement
                 .query_row([], |row| row.get::<_, $get_type>(0));
             res.unwrap_err();
-            $db_etc.delete_statement.execute([])?;
+            $db_etc().delete_statement.execute([])?;
         };
         ($db_etc:ident, $insert_value:expr, $get_type:ty,expect_to_sql_error) => {
-            $db_etc
+            $db_etc()
                 .insert_statement
                 .execute(params![$insert_value])
                 .unwrap_err();
@@ -401,10 +401,10 @@ mod test {
             delete_statement: Statement<'conn>,
         }
 
-        let mut db_etc = DbEtc {
-            insert_statement: db.prepare("INSERT INTO foo VALUES (?1)")?,
-            query_statement: db.prepare("SELECT x FROM foo")?,
-            delete_statement: db.prepare("DELETE FROM foo")?,
+        let db_etc = || DbEtc {
+            insert_statement: db.prepare("INSERT INTO foo VALUES (?1)").unwrap(),
+            query_statement: db.prepare("SELECT x FROM foo").unwrap(),
+            delete_statement: db.prepare("DELETE FROM foo").unwrap(),
         };
 
         // Basic non-converting test.

--- a/src/types/to_sql.rs
+++ b/src/types/to_sql.rs
@@ -439,7 +439,7 @@ mod test {
             [0i128, -1i128, -2i128, 1i128, 2i128, i128::MIN, i128::MAX],
         )?;
 
-        let mut stmt = db.prepare("SELECT i128, desc FROM foo ORDER BY i128 ASC")?;
+        let stmt = db.prepare("SELECT i128, desc FROM foo ORDER BY i128 ASC")?;
 
         let res = stmt
             .query_map([], |row| {
@@ -488,7 +488,7 @@ mod test {
                 nz!(i128::MAX),
             ],
         )?;
-        let mut stmt = db.prepare("SELECT i128, desc FROM foo ORDER BY i128 ASC")?;
+        let stmt = db.prepare("SELECT i128, desc FROM foo ORDER BY i128 ASC")?;
 
         let res = stmt
             .query_map([], |row| Ok((row.get(0)?, row.get(1)?)))?
@@ -526,7 +526,7 @@ mod test {
             params![id, "target"],
         )?;
 
-        let mut stmt = db.prepare("SELECT id, label FROM foo WHERE id = ?1")?;
+        let stmt = db.prepare("SELECT id, label FROM foo WHERE id = ?1")?;
 
         let mut rows = stmt.query(params![id])?;
         let row = rows.next()?.unwrap();

--- a/src/vtab/array.rs
+++ b/src/vtab/array.rs
@@ -206,7 +206,7 @@ mod test {
         let values: Vec<Value> = v.into_iter().map(Value::from).collect();
         let ptr = Rc::new(values);
         {
-            let mut stmt = db.prepare("SELECT value from rarray(?1);")?;
+            let stmt = db.prepare("SELECT value from rarray(?1);")?;
 
             let rows = stmt.query_map([&ptr], |row| row.get::<_, i64>(0))?;
             assert_eq!(2, Rc::strong_count(&ptr));

--- a/src/vtab/csvtab.rs
+++ b/src/vtab/csvtab.rs
@@ -353,7 +353,7 @@ mod test {
         db.execute_batch("CREATE VIRTUAL TABLE vtab USING csv(filename='test.csv', header=yes)")?;
 
         {
-            let mut s = db.prepare("SELECT rowid, * FROM vtab")?;
+            let s = db.prepare("SELECT rowid, * FROM vtab")?;
             {
                 let headers = s.column_names();
                 assert_eq!(vec!["rowid", "colA", "colB", "colC"], headers);
@@ -373,7 +373,7 @@ mod test {
         db.execute_batch("CREATE VIRTUAL TABLE vtab USING csv(filename='test.csv', header=yes)")?;
 
         {
-            let mut s = db.prepare(
+            let s = db.prepare(
                 "SELECT v1.rowid, v1.* FROM vtab v1 NATURAL JOIN vtab v2 WHERE \
                      v1.rowid < v2.rowid",
             )?;

--- a/src/vtab/series.rs
+++ b/src/vtab/series.rs
@@ -295,7 +295,7 @@ mod test {
         let db = Connection::open_in_memory()?;
         series::load_module(&db)?;
 
-        let mut s = db.prepare("SELECT * FROM generate_series(0,20,5)")?;
+        let s = db.prepare("SELECT * FROM generate_series(0,20,5)")?;
 
         let series = s.query_map([], |row| row.get::<_, i32>(0))?;
 
@@ -305,34 +305,33 @@ mod test {
             expected += 5;
         }
 
-        let mut s =
-            db.prepare("SELECT * FROM generate_series WHERE start=1 AND stop=9 AND step=2")?;
+        let s = db.prepare("SELECT * FROM generate_series WHERE start=1 AND stop=9 AND step=2")?;
         let series: Vec<i32> = s.query([])?.map(|r| r.get(0)).collect()?;
         assert_eq!(vec![1, 3, 5, 7, 9], series);
-        let mut s = db.prepare("SELECT * FROM generate_series LIMIT 5")?;
+        let s = db.prepare("SELECT * FROM generate_series LIMIT 5")?;
         let series: Vec<i32> = s.query([])?.map(|r| r.get(0)).collect()?;
         assert_eq!(vec![0, 1, 2, 3, 4], series);
-        let mut s = db.prepare("SELECT * FROM generate_series(0,32,5) ORDER BY value DESC")?;
+        let s = db.prepare("SELECT * FROM generate_series(0,32,5) ORDER BY value DESC")?;
         let series: Vec<i32> = s.query([])?.map(|r| r.get(0)).collect()?;
         assert_eq!(vec![30, 25, 20, 15, 10, 5, 0], series);
 
-        let mut s = db.prepare("SELECT * FROM generate_series(NULL)")?;
+        let s = db.prepare("SELECT * FROM generate_series(NULL)")?;
         let series: Vec<i32> = s.query([])?.map(|r| r.get(0)).collect()?;
         let empty = Vec::<i32>::new();
         assert_eq!(empty, series);
-        let mut s = db.prepare("SELECT * FROM generate_series(5,NULL)")?;
+        let s = db.prepare("SELECT * FROM generate_series(5,NULL)")?;
         let series: Vec<i32> = s.query([])?.map(|r| r.get(0)).collect()?;
         assert_eq!(empty, series);
-        let mut s = db.prepare("SELECT * FROM generate_series(5,10,NULL)")?;
+        let s = db.prepare("SELECT * FROM generate_series(5,10,NULL)")?;
         let series: Vec<i32> = s.query([])?.map(|r| r.get(0)).collect()?;
         assert_eq!(empty, series);
-        let mut s = db.prepare("SELECT * FROM generate_series(NULL,10,2)")?;
+        let s = db.prepare("SELECT * FROM generate_series(NULL,10,2)")?;
         let series: Vec<i32> = s.query([])?.map(|r| r.get(0)).collect()?;
         assert_eq!(empty, series);
-        let mut s = db.prepare("SELECT * FROM generate_series(5,NULL,2)")?;
+        let s = db.prepare("SELECT * FROM generate_series(5,NULL,2)")?;
         let series: Vec<i32> = s.query([])?.map(|r| r.get(0)).collect()?;
         assert_eq!(empty, series);
-        let mut s = db.prepare("SELECT * FROM generate_series(NULL) ORDER BY value DESC")?;
+        let s = db.prepare("SELECT * FROM generate_series(NULL) ORDER BY value DESC")?;
         let series: Vec<i32> = s.query([])?.map(|r| r.get(0)).collect()?;
         assert_eq!(empty, series);
 

--- a/src/vtab/vtablog.rs
+++ b/src/vtab/vtablog.rs
@@ -280,7 +280,7 @@ mod test {
                     rows=25
                 );",
         )?;
-        let mut stmt = db.prepare("SELECT * FROM log;")?;
+        let stmt = db.prepare("SELECT * FROM log;")?;
         let mut rows = stmt.query([])?;
         while rows.next()?.is_some() {}
         db.execute("DELETE FROM log WHERE a = ?1", ["a1"])?;

--- a/tests/vtab.rs
+++ b/tests/vtab.rs
@@ -92,7 +92,7 @@ fn test_dummy_module() -> rusqlite::Result<()> {
         return Ok(());
     }
 
-    let mut s = db.prepare("SELECT * FROM dummy()")?;
+    let s = db.prepare("SELECT * FROM dummy()")?;
 
     let dummy = s.query_row([], |row| row.get::<_, i32>(0))?;
     assert_eq!(1, dummy);


### PR DESCRIPTION
Fixes #1337.

This patch does the following:

- All querying functions now consume the `Statement`
- Merges `CachedStatement` into `Statement`
- Makes `RawStatement` responsible for knowing whether the statement is cached or not
- Updates the `Statement` drop implementation to handle the caching
- Updates the lifetime name on `Rows` from `'stmt` to `'conn` to make it clear the lifetime is for the connection

The majority of the lines changed are changes to the tests to make the queries no longer need to be `mut`. All tests passed with `--features bundled-full,modern-full`.