### PR TITLE
Fix CI clippy - use `Rc<Mutex<...>>` instead of `Arc`

### DIFF
--- a/src/functions.rs
+++ b/src/functions.rs
@@ -638,6 +638,7 @@ unsafe extern "C" fn call_boxed_step<A, D, T>(
             args: slice::from_raw_parts(argv, argc as usize),
         };
 
+        #[allow(clippy::unnecessary_cast)]
         if (*pac as *mut A).is_null() {
             *pac = Box::into_raw(Box::new((*boxed_aggr).init(&mut ctx)?));
         }
@@ -708,7 +709,9 @@ where
     // Within the xFinal callback, it is customary to set N=0 in calls to
     // sqlite3_aggregate_context(C,N) so that no pointless memory allocations occur.
     let a: Option<A> = match aggregate_context(ctx, 0) {
-        Some(pac) => {
+        Some(pac) =>
+        {
+            #[allow(clippy::unnecessary_cast)]
             if (*pac as *mut A).is_null() {
                 None
             } else {
@@ -753,7 +756,9 @@ where
     // Within the xValue callback, it is customary to set N=0 in calls to
     // sqlite3_aggregate_context(C,N) so that no pointless memory allocations occur.
     let a: Option<&A> = match aggregate_context(ctx, 0) {
-        Some(pac) => {
+        Some(pac) =>
+        {
+            #[allow(clippy::unnecessary_cast)]
             if (*pac as *mut A).is_null() {
                 None
             } else {

--- a/src/hooks.rs
+++ b/src/hooks.rs
@@ -776,9 +776,10 @@ mod test {
             .unwrap();
 
         let authorizer = move |ctx: AuthContext<'_>| match ctx.action {
-            AuthAction::Read { column_name, .. } if column_name == "private" => {
-                Authorization::Ignore
-            }
+            AuthAction::Read {
+                column_name: "private",
+                ..
+            } => Authorization::Ignore,
             AuthAction::DropTable { .. } => Authorization::Deny,
             AuthAction::Pragma { .. } => panic!("shouldn't be called"),
             _ => Authorization::Allow,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -63,10 +63,11 @@ use std::fmt;
 use std::os::raw::{c_char, c_int};
 
 use std::path::Path;
+use std::rc::Rc;
 use std::result;
 use std::str;
 use std::sync::atomic::Ordering;
-use std::sync::{Arc, Mutex};
+use std::sync::Mutex;
 
 use crate::cache::StatementCache;
 use crate::inner_connection::{InnerConnection, BYPASS_SQLITE_INIT};
@@ -1162,7 +1163,7 @@ pub unsafe fn bypass_sqlite_initialization() {
 
 /// Allows interrupting a long-running computation.
 pub struct InterruptHandle {
-    db_lock: Arc<Mutex<*mut ffi::sqlite3>>,
+    db_lock: Rc<Mutex<*mut ffi::sqlite3>>,
 }
 
 unsafe impl Send for InterruptHandle {}


### PR DESCRIPTION
This might be totally incorrect!  I got it to compile by switching `Arc` to `Rc`, but I am not certain if this is safe or not!  Please review.  I also had to add a few `#[allow(clippy::unnecessary_cast)]` -- seems like there is a bug in 1.73 clippy - filed https://github.com/rust-lang/rust-clippy/issues/11634