### PR TITLE
Fix clippy warning: arc_with_non_send_sync - interrupt_lock

### DIFF
--- a/src/functions.rs
+++ b/src/functions.rs
@@ -638,6 +638,7 @@ unsafe extern "C" fn call_boxed_step<A, D, T>(
             args: slice::from_raw_parts(argv, argc as usize),
         };
 
+        #[allow(clippy::unnecessary_cast)]
         if (*pac as *mut A).is_null() {
             *pac = Box::into_raw(Box::new((*boxed_aggr).init(&mut ctx)?));
         }
@@ -708,7 +709,9 @@ where
     // Within the xFinal callback, it is customary to set N=0 in calls to
     // sqlite3_aggregate_context(C,N) so that no pointless memory allocations occur.
     let a: Option<A> = match aggregate_context(ctx, 0) {
-        Some(pac) => {
+        Some(pac) =>
+        {
+            #[allow(clippy::unnecessary_cast)]
             if (*pac as *mut A).is_null() {
                 None
             } else {
@@ -753,7 +756,9 @@ where
     // Within the xValue callback, it is customary to set N=0 in calls to
     // sqlite3_aggregate_context(C,N) so that no pointless memory allocations occur.
     let a: Option<&A> = match aggregate_context(ctx, 0) {
-        Some(pac) => {
+        Some(pac) =>
+        {
+            #[allow(clippy::unnecessary_cast)]
             if (*pac as *mut A).is_null() {
                 None
             } else {

--- a/src/hooks.rs
+++ b/src/hooks.rs
@@ -776,9 +776,10 @@ mod test {
             .unwrap();
 
         let authorizer = move |ctx: AuthContext<'_>| match ctx.action {
-            AuthAction::Read { column_name, .. } if column_name == "private" => {
-                Authorization::Ignore
-            }
+            AuthAction::Read {
+                column_name: "private",
+                ..
+            } => Authorization::Ignore,
             AuthAction::DropTable { .. } => Authorization::Deny,
             AuthAction::Pragma { .. } => panic!("shouldn't be called"),
             _ => Authorization::Allow,

--- a/src/inner_connection.rs
+++ b/src/inner_connection.rs
@@ -40,7 +40,7 @@ pub struct InnerConnection {
 unsafe impl Send for InnerConnection {}
 
 impl InnerConnection {
-    #[allow(clippy::mutex_atomic)]
+    #[allow(clippy::mutex_atomic, clippy::arc_with_non_send_sync)] // See unsafe impl Send / Sync for InterruptHandle
     #[inline]
     pub unsafe fn new(db: *mut ffi::sqlite3, owned: bool) -> InnerConnection {
         InnerConnection {


### PR DESCRIPTION
Fix #1358