### PR TITLE
Remove fallible-iterator dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -121,7 +121,6 @@ chrono = { version = "0.4", optional = true, default-features = false, features 
 serde_json = { version = "1.0", optional = true }
 csv = { version = "1.1", optional = true }
 url = { version = "2.1", optional = true }
-fallible-iterator = "0.3"
 fallible-streaming-iterator = "0.1"
 uuid = { version = "1.0", optional = true }
 smallvec = "1.6.1"
@@ -130,6 +129,7 @@ rusqlite-macros = { path = "rusqlite-macros", version = "0.1.0", optional = true
 [dev-dependencies]
 doc-comment = "0.3"
 tempfile = "3.1.0"
+fallible-iterator = "0.3"
 lazy_static = "1.4"
 regex = "1.5.5"
 uuid = { version = "1.0", features = ["v4"] }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -81,7 +81,7 @@ pub use crate::ffi::ErrorCode;
 #[cfg(feature = "load_extension")]
 pub use crate::load_extension_guard::LoadExtensionGuard;
 pub use crate::params::{params_from_iter, Params, ParamsFromIter};
-pub use crate::row::{AndThenRows, Map, MappedRows, Row, RowIndex, Rows};
+pub use crate::row::{AndThenRows, MappedRows, Row, RowIndex, Rows};
 pub use crate::statement::{Statement, StatementStatus};
 #[cfg(feature = "modern_sqlite")]
 pub use crate::transaction::TransactionState;

--- a/src/row.rs
+++ b/src/row.rs
@@ -1,3 +1,4 @@
+#[cfg(test)]
 use fallible_iterator::FallibleIterator;
 use fallible_streaming_iterator::FallibleStreamingIterator;
 use std::convert;
@@ -50,6 +51,7 @@ impl<'stmt> Rows<'stmt> {
     /// }
     /// ```
     // FIXME Hide FallibleStreamingIterator::map
+    #[cfg(test)]
     #[inline]
     pub fn map<F, B>(self, f: F) -> Map<'stmt, F>
     where
@@ -113,12 +115,14 @@ impl Drop for Rows<'_> {
 
 /// `F` is used to transform the _streaming_ iterator into a _fallible_
 /// iterator.
+#[cfg(test)]
 #[must_use = "iterators are lazy and do nothing unless consumed"]
 pub struct Map<'stmt, F> {
     rows: Rows<'stmt>,
     f: F,
 }
 
+#[cfg(test)]
 impl<F, B> FallibleIterator for Map<'_, F>
 where
     F: FnMut(&Row<'_>) -> Result<B>,


### PR DESCRIPTION
Keep it as a dev dependency
Caveat: existing `Rows::map` function may be replaced silently (if FallibleStreamingIterator is in scope) by `FallibleStreamingIterator::map`.
Fix #833

- [ ] check https://github.com/search?q=repo%3Aholochain%2Fholochain+rusqlite+fallible&type=code
- [ ] check https://github.com/search?q=lang%3Arust+%22use+rusqlite%22+%22use+fallible_iterator%22+%22.map%28%22+NOT+is%3Afork+NOT+is%3Aarchived+NOT+path%3Avendored+NOT+user%3Arusqlite&type=code