### PR TITLE
Check sqlite3_reset result

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1508,11 +1508,7 @@ mod test {
     fn test_execute_select_with_row() {
         let db = checked_memory_handle();
         let err = db.execute("SELECT 1", []).unwrap_err();
-        assert_eq!(
-            err,
-            Error::ExecuteReturnedResults,
-            "Unexpected error: {err}"
-        );
+        assert_eq!(err, Error::ExecuteReturnedResults);
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1494,9 +1494,20 @@ mod test {
 
     #[test]
     #[cfg(feature = "extra_check")]
-    fn test_execute_select() {
+    fn test_execute_select_with_no_row() {
         let db = checked_memory_handle();
         let err = db.execute("SELECT 1 WHERE 1 < ?1", [1i32]).unwrap_err();
+        assert_eq!(
+            err,
+            Error::ExecuteReturnedResults,
+            "Unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn test_execute_select_with_row() {
+        let db = checked_memory_handle();
+        let err = db.execute("SELECT 1", []).unwrap_err();
         assert_eq!(
             err,
             Error::ExecuteReturnedResults,

--- a/src/row.rs
+++ b/src/row.rs
@@ -14,9 +14,11 @@ pub struct Rows<'stmt> {
 
 impl<'stmt> Rows<'stmt> {
     #[inline]
-    fn reset(&mut self) {
+    fn reset(&mut self) -> Result<()> {
         if let Some(stmt) = self.stmt.take() {
-            stmt.reset();
+            stmt.reset()
+        } else {
+            Ok(())
         }
     }
 
@@ -105,6 +107,7 @@ impl<'stmt> Rows<'stmt> {
 }
 
 impl Drop for Rows<'_> {
+    #[allow(unused_must_use)]
     #[inline]
     fn drop(&mut self) {
         self.reset();
@@ -217,12 +220,12 @@ impl<'stmt> FallibleStreamingIterator for Rows<'stmt> {
                     Ok(())
                 }
                 Ok(false) => {
-                    self.reset();
+                    let r = self.reset();
                     self.row = None;
-                    Ok(())
+                    r
                 }
                 Err(e) => {
-                    self.reset();
+                    let _ = self.reset(); // prevents infinite loop on error
                     self.row = None;
                     Err(e)
                 }

--- a/src/statement.rs
+++ b/src/statement.rs
@@ -650,9 +650,12 @@ impl Statement<'_> {
     fn execute_with_bound_parameters(&mut self) -> Result<usize> {
         self.check_update()?;
         let r = self.stmt.step();
-        self.stmt.reset();
+        let rr = self.stmt.reset();
         match r {
-            ffi::SQLITE_DONE => Ok(self.conn.changes() as usize),
+            ffi::SQLITE_DONE => match rr {
+                ffi::SQLITE_OK => Ok(self.conn.changes() as usize),
+                _ => Err(self.conn.decode_result(rr).unwrap_err()),
+            },
             ffi::SQLITE_ROW => Err(Error::ExecuteReturnedResults),
             _ => Err(self.conn.decode_result(r).unwrap_err()),
         }
@@ -847,8 +850,11 @@ impl Statement<'_> {
     }
 
     #[inline]
-    pub(super) fn reset(&self) -> c_int {
-        self.stmt.reset()
+    pub(super) fn reset(&self) -> Result<()> {
+        match self.stmt.reset() {
+            ffi::SQLITE_OK => Ok(()),
+            code => Err(self.conn.decode_result(code).unwrap_err()),
+        }
     }
 }
 
@@ -1274,7 +1280,7 @@ mod test {
         assert_eq!(0, stmt.column_count());
         stmt.parameter_index("test").unwrap();
         stmt.step().unwrap_err();
-        stmt.reset();
+        stmt.reset().unwrap(); // SQLITE_OMIT_AUTORESET = false
         stmt.execute([]).unwrap_err();
         Ok(())
     }


### PR DESCRIPTION
https://sqlite.org/c3ref/reset.html
> Therefore, it is important that applications check the return code from sqlite3_reset(S) even if no prior call to sqlite3_step(S) indicated a problem.

Fix #1418 