### PR TITLE
Implement ergonomic loadable extension macro

### DIFF
--- a/examples/loadable_extension.rs
+++ b/examples/loadable_extension.rs
@@ -1,40 +1,28 @@
 //! Adaptation of https://sqlite.org/loadext.html#programming_loadable_extensions
-use std::os::raw::{c_char, c_int};
+//!
+//! # build
+//! ```sh
+//! cargo build --example loadable_extension --features "loadable_extension modern_sqlite functions vtab trace"
+//! ```
+//!
+//! # test
+//! ```sh
+//! sqlite> .log on
+//! sqlite> .load target/debug/examples/libloadable_extension.so
+//! (28) Rusqlite extension initialized
+//! sqlite> SELECT rusqlite_test_function();
+//! Rusqlite extension loaded correctly!
+//! ```
 
-use rusqlite::ffi;
 use rusqlite::functions::FunctionFlags;
+use rusqlite::trace::log;
 use rusqlite::types::{ToSqlOutput, Value};
-use rusqlite::{to_sqlite_error, Connection, Result};
+use rusqlite::{ffi, sqlite3_extension_init};
+use rusqlite::{Connection, Result};
 
-/// # build
-/// ```sh
-/// cargo build --example loadable_extension --features "loadable_extension modern_sqlite functions vtab trace"
-/// ```
-/// # test
-/// ```sh
-/// sqlite> .log on
-/// sqlite> .load target/debug/examples/libloadable_extension.so
-/// (28) Rusqlite extension initialized
-/// sqlite> SELECT rusqlite_test_function();
-/// Rusqlite extension loaded correctly!
-/// ```
-#[allow(clippy::not_unsafe_ptr_arg_deref)]
-#[no_mangle]
-pub extern "C" fn sqlite3_extension_init(
-    db: *mut ffi::sqlite3,
-    pz_err_msg: *mut *mut c_char,
-    p_api: *mut ffi::sqlite3_api_routines,
-) -> c_int {
-    if p_api.is_null() {
-        return ffi::SQLITE_ERROR;
-    } else if let Err(err) = extension_init(db, p_api) {
-        return unsafe { to_sqlite_error(&err, pz_err_msg) };
-    }
-    ffi::SQLITE_OK
-}
+sqlite3_extension_init!(extension_init);
 
-fn extension_init(db: *mut ffi::sqlite3, p_api: *mut ffi::sqlite3_api_routines) -> Result<()> {
-    let db = unsafe { Connection::extension_init2(db, p_api)? };
+fn extension_init(db: Connection) -> Result<()> {
     db.create_scalar_function(
         "rusqlite_test_function",
         0,
@@ -45,6 +33,6 @@ fn extension_init(db: *mut ffi::sqlite3, p_api: *mut ffi::sqlite3_api_routines) 
             )))
         },
     )?;
-    rusqlite::trace::log(ffi::SQLITE_WARNING, "Rusqlite extension initialized");
+    log(ffi::SQLITE_WARNING, "Rusqlite extension initialized");
     Ok(())
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1278,7 +1278,7 @@ macro_rules! sqlite3_extension_init {
     ($func: ident, $entry_point: ident) => {
         #[allow(clippy::not_unsafe_ptr_arg_deref)]
         #[no_mangle]
-        pub extern "C" fn sqlite3_extension_init(
+        pub extern "C" fn $entry_point(
             db: *mut ::rusqlite::ffi::sqlite3,
             pz_err_msg: *mut *mut std::os::raw::c_char,
             p_api: *mut ::rusqlite::ffi::sqlite3_api_routines,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1241,6 +1241,9 @@ impl InterruptHandle {
 /// Adds an entrypoint implementation for a SQLite extension.
 /// This macro must be used once in the root of a crate that implements a SQLite extension.
 ///
+/// See [Loading extension](https://sqlite.org/loadext.html#loading_an_extension) for more details
+/// on the recommended entry point names to support autodiscovery.
+///
 /// # Example
 /// ```
 /// use rusqlite::Connection;
@@ -1270,6 +1273,9 @@ impl InterruptHandle {
 #[macro_export]
 macro_rules! sqlite3_extension_init {
     ($func: ident) => {
+        sqlite3_extension_init!($func, sqlite3_extension_init);
+    };
+    ($func: ident, $entry_point: ident) => {
         #[allow(clippy::not_unsafe_ptr_arg_deref)]
         #[no_mangle]
         pub extern "C" fn sqlite3_extension_init(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1241,6 +1241,7 @@ impl InterruptHandle {
 /// Adds an entrypoint implementation for a SQLite extension.
 /// This macro must be used once in the root of a crate that implements a SQLite extension.
 ///
+/// Optionally, the second parameter can be used to specify the name of the public entry point function.
 /// See [Loading extension](https://sqlite.org/loadext.html#loading_an_extension) for more details
 /// on the recommended entry point names to support autodiscovery.
 ///


### PR DESCRIPTION
This simplifies loadable extension code and removes the need for unsafe code.

Add a new (feature gated) macro called `sqlite3_extension_init!(my_init_fn)` that creates the needed unsafe SQLite3 extension entry point. The macro calls user's function, passing ownership of a safe database `Connection` struct.

Some of the macro content could, in theory, be moved to some function, or could be left as is.

Closes #1424