### PR TITLE
Upgrade to hashlink 0.9

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -116,7 +116,7 @@ bundled-full = ["modern-full", "bundled"]
 [dependencies]
 time = { version = "0.3.0", features = ["formatting", "macros", "parsing"], optional = true }
 bitflags = "2.0"
-hashlink = "0.8"
+hashlink = "0.9"
 chrono = { version = "0.4", optional = true, default-features = false, features = ["clock"] }
 serde_json = { version = "1.0", optional = true }
 csv = { version = "1.1", optional = true }

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -57,7 +57,7 @@ impl Connection {
 }
 
 /// Prepared statements LRU cache.
-// #[derive(Debug)] // FIXME: https://github.com/kyren/hashlink/pull/4
+#[derive(Debug)]
 pub struct StatementCache(RefCell<LruCache<Arc<str>, RawStatement>>);
 
 #[allow(clippy::non_send_fields_in_send_ty)]


### PR DESCRIPTION
This upgrade to hashlink 0.9, with no actual code changes required.

As a drive-by, this also resolves the FIXME to derive Debug for StatementCache, which would have been fine ever since the noted PR was published in hashlink 0.6.
