### PR TITLE
Enable built-in SQL math functions when building bundled SQLite

### DIFF
--- a/libsqlite3-sys/build.rs
+++ b/libsqlite3-sys/build.rs
@@ -128,6 +128,7 @@ mod build_bundled {
             .flag("-DSQLITE_ENABLE_FTS5")
             .flag("-DSQLITE_ENABLE_JSON1")
             .flag("-DSQLITE_ENABLE_LOAD_EXTENSION=1")
+            .flag("-DSQLITE_ENABLE_MATH_FUNCTIONS")
             .flag("-DSQLITE_ENABLE_MEMORY_MANAGEMENT")
             .flag("-DSQLITE_ENABLE_RTREE")
             .flag("-DSQLITE_ENABLE_STAT2")


### PR DESCRIPTION
I noticed that I lost the built-in modulo function as I switched to the bundled SQLite and I tracked it down to `SQLITE_ENABLE_MATH_FUNCTIONS` not being set when building it.

The built-in math functions (i.e. being able to do `SELECT mod(5, 3)`) are described here: https://www.sqlite.org/lang_mathfunc.html, and the compile-time option here: https://www.sqlite.org/compile.html#enable_math_functions.

I don't think there are any compability concerns with enabling these because:
a) per https://www.sqlite.org/compile.html#enable_math_functions it's enabled automatically by the configure script for Unix and windows (so it's probably more common for it to be enabled than disabled)
b) it's not an error to use `Connection::create_scalar_function` to overwrite these built-in functions (I tested this, but not very extensively).

As far as I can tell this would only be an issue for someone if they somehow relied on those functions *not* being defined, which seems unlikely.