### PR TITLE
Expose the include directory of the bundled sqlite version

### DIFF
--- a/libsqlite3-sys/build.rs
+++ b/libsqlite3-sys/build.rs
@@ -114,6 +114,7 @@ mod build_bundled {
         {
             super::copy_bindings(lib_name, "bindgen_bundled_version", out_path);
         }
+        println!("cargo:include={}/{lib_name}", env!("CARGO_MANIFEST_DIR"));
         println!("cargo:rerun-if-changed={lib_name}/sqlite3.c");
         println!("cargo:rerun-if-changed=sqlite3/wasm32-wasi-vfs.c");
         let mut cfg = cc::Build::new();


### PR DESCRIPTION
This commit exposes the include directory of the bundled sqlite version via by instructing cargo to set the `DEP_SQLITE3_INCLUDE` enviroment variable as documented in the cargo book:
https://doc.rust-lang.org/cargo/reference/build-script-examples.html#using-another-sys-crate

This enables other sys crates to rely on the bundled sqlite version and use it as base for their compilation if they have a (sub-)dependency on libsqlite3.