### PR TITLE
expose total_changes()

### DIFF
--- a/src/inner_connection.rs
+++ b/src/inner_connection.rs
@@ -289,6 +289,18 @@ impl InnerConnection {
     }
 
     #[inline]
+    pub fn total_changes(&self) -> u64 {
+        #[cfg(not(feature = "modern_sqlite"))]
+        unsafe {
+            ffi::sqlite3_total_changes(self.db()) as u64
+        }
+        #[cfg(feature = "modern_sqlite")] // 3.37.0
+        unsafe {
+            ffi::sqlite3_total_changes64(self.db()) as u64
+        }
+    }
+
+    #[inline]
     pub fn is_autocommit(&self) -> bool {
         unsafe { ffi::sqlite3_get_autocommit(self.db()) != 0 }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1005,6 +1005,16 @@ impl Connection {
         self.db.borrow().changes()
     }
 
+    /// Return the total number of rows modified, inserted or deleted by all
+    /// completed INSERT, UPDATE or DELETE statements since the database
+    /// connection was opened, including those executed as part of trigger programs.
+    ///
+    /// See <https://www.sqlite.org/c3ref/total_changes.html>
+    #[inline]
+    pub fn total_changes(&self) -> u64 {
+        self.db.borrow().total_changes()
+    }
+
     /// Test for auto-commit mode.
     /// Autocommit mode is on by default.
     #[inline]


### PR DESCRIPTION
the total_changes() function allows to count all modified rows including those executed as part of triggers (changes() return 0 for triggers).
simply compare total_changes() before and after the query.
This is the easiest way to check whether "instead of triggers" have actually modified rows.