### PR TITLE
Omit API

### DIFF
--- a/libsqlite3-sys/bindgen-bindings/bindgen_3.14.0.rs
+++ b/libsqlite3-sys/bindgen-bindings/bindgen_3.14.0.rs
@@ -430,9 +430,6 @@ pub type sqlite3_uint64 = sqlite_uint64;
 extern "C" {
     pub fn sqlite3_close(arg1: *mut sqlite3) -> ::std::os::raw::c_int;
 }
-extern "C" {
-    pub fn sqlite3_close_v2(arg1: *mut sqlite3) -> ::std::os::raw::c_int;
-}
 pub type sqlite3_callback = ::std::option::Option<
     unsafe extern "C" fn(
         arg1: *mut ::std::os::raw::c_void,
@@ -970,15 +967,6 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    pub fn sqlite3_prepare(
-        db: *mut sqlite3,
-        zSql: *const ::std::os::raw::c_char,
-        nByte: ::std::os::raw::c_int,
-        ppStmt: *mut *mut sqlite3_stmt,
-        pzTail: *mut *const ::std::os::raw::c_char,
-    ) -> ::std::os::raw::c_int;
-}
-extern "C" {
     pub fn sqlite3_prepare_v2(
         db: *mut sqlite3,
         zSql: *const ::std::os::raw::c_char,
@@ -1204,30 +1192,6 @@ extern "C" {
     pub fn sqlite3_reset(pStmt: *mut sqlite3_stmt) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    pub fn sqlite3_create_function(
-        db: *mut sqlite3,
-        zFunctionName: *const ::std::os::raw::c_char,
-        nArg: ::std::os::raw::c_int,
-        eTextRep: ::std::os::raw::c_int,
-        pApp: *mut ::std::os::raw::c_void,
-        xFunc: ::std::option::Option<
-            unsafe extern "C" fn(
-                arg1: *mut sqlite3_context,
-                arg2: ::std::os::raw::c_int,
-                arg3: *mut *mut sqlite3_value,
-            ),
-        >,
-        xStep: ::std::option::Option<
-            unsafe extern "C" fn(
-                arg1: *mut sqlite3_context,
-                arg2: ::std::os::raw::c_int,
-                arg3: *mut *mut sqlite3_value,
-            ),
-        >,
-        xFinal: ::std::option::Option<unsafe extern "C" fn(arg1: *mut sqlite3_context)>,
-    ) -> ::std::os::raw::c_int;
-}
-extern "C" {
     pub fn sqlite3_create_function_v2(
         db: *mut sqlite3,
         zFunctionName: *const ::std::os::raw::c_char,
@@ -1419,23 +1383,6 @@ extern "C" {
 }
 extern "C" {
     pub fn sqlite3_result_subtype(arg1: *mut sqlite3_context, arg2: ::std::os::raw::c_uint);
-}
-extern "C" {
-    pub fn sqlite3_create_collation(
-        arg1: *mut sqlite3,
-        zName: *const ::std::os::raw::c_char,
-        eTextRep: ::std::os::raw::c_int,
-        pArg: *mut ::std::os::raw::c_void,
-        xCompare: ::std::option::Option<
-            unsafe extern "C" fn(
-                arg1: *mut ::std::os::raw::c_void,
-                arg2: ::std::os::raw::c_int,
-                arg3: *const ::std::os::raw::c_void,
-                arg4: ::std::os::raw::c_int,
-                arg5: *const ::std::os::raw::c_void,
-            ) -> ::std::os::raw::c_int,
-        >,
-    ) -> ::std::os::raw::c_int;
 }
 extern "C" {
     pub fn sqlite3_create_collation_v2(
@@ -1744,14 +1691,6 @@ pub struct sqlite3_index_orderby {
 pub struct sqlite3_index_constraint_usage {
     pub argvIndex: ::std::os::raw::c_int,
     pub omit: ::std::os::raw::c_uchar,
-}
-extern "C" {
-    pub fn sqlite3_create_module(
-        db: *mut sqlite3,
-        zName: *const ::std::os::raw::c_char,
-        p: *const sqlite3_module,
-        pClientData: *mut ::std::os::raw::c_void,
-    ) -> ::std::os::raw::c_int;
 }
 extern "C" {
     pub fn sqlite3_create_module_v2(

--- a/libsqlite3-sys/bindgen-bindings/bindgen_3.14.0_ext.rs
+++ b/libsqlite3-sys/bindgen-bindings/bindgen_3.14.0_ext.rs
@@ -3050,116 +3050,6 @@ pub unsafe fn sqlite3_complete(
     (fun)(sql)
 }
 
-static __SQLITE3_CREATE_COLLATION: ::std::sync::atomic::AtomicPtr<()> = ::std::sync::atomic::AtomicPtr::new(
-    ::std::ptr::null_mut(),
-);
-pub unsafe fn sqlite3_create_collation(
-    arg1: *mut sqlite3,
-    arg2: *const ::std::os::raw::c_char,
-    arg3: ::std::os::raw::c_int,
-    arg4: *mut ::std::os::raw::c_void,
-    arg5: ::std::option::Option<
-        unsafe extern "C" fn(
-            arg1: *mut ::std::os::raw::c_void,
-            arg2: ::std::os::raw::c_int,
-            arg3: *const ::std::os::raw::c_void,
-            arg4: ::std::os::raw::c_int,
-            arg5: *const ::std::os::raw::c_void,
-        ) -> ::std::os::raw::c_int,
-    >,
-) -> ::std::os::raw::c_int {
-    let ptr = __SQLITE3_CREATE_COLLATION.load(::std::sync::atomic::Ordering::Acquire);
-    assert!(! ptr.is_null(), "SQLite API not initialized or SQLite feature omitted");
-    let fun: unsafe extern "C" fn(
-        arg1: *mut sqlite3,
-        arg2: *const ::std::os::raw::c_char,
-        arg3: ::std::os::raw::c_int,
-        arg4: *mut ::std::os::raw::c_void,
-        arg5: ::std::option::Option<
-            unsafe extern "C" fn(
-                arg1: *mut ::std::os::raw::c_void,
-                arg2: ::std::os::raw::c_int,
-                arg3: *const ::std::os::raw::c_void,
-                arg4: ::std::os::raw::c_int,
-                arg5: *const ::std::os::raw::c_void,
-            ) -> ::std::os::raw::c_int,
-        >,
-    ) -> ::std::os::raw::c_int = ::std::mem::transmute(ptr);
-    (fun)(arg1, arg2, arg3, arg4, arg5)
-}
-
-static __SQLITE3_CREATE_FUNCTION: ::std::sync::atomic::AtomicPtr<()> = ::std::sync::atomic::AtomicPtr::new(
-    ::std::ptr::null_mut(),
-);
-pub unsafe fn sqlite3_create_function(
-    arg1: *mut sqlite3,
-    arg2: *const ::std::os::raw::c_char,
-    arg3: ::std::os::raw::c_int,
-    arg4: ::std::os::raw::c_int,
-    arg5: *mut ::std::os::raw::c_void,
-    xFunc: ::std::option::Option<
-        unsafe extern "C" fn(
-            arg1: *mut sqlite3_context,
-            arg2: ::std::os::raw::c_int,
-            arg3: *mut *mut sqlite3_value,
-        ),
-    >,
-    xStep: ::std::option::Option<
-        unsafe extern "C" fn(
-            arg1: *mut sqlite3_context,
-            arg2: ::std::os::raw::c_int,
-            arg3: *mut *mut sqlite3_value,
-        ),
-    >,
-    xFinal: ::std::option::Option<unsafe extern "C" fn(arg1: *mut sqlite3_context)>,
-) -> ::std::os::raw::c_int {
-    let ptr = __SQLITE3_CREATE_FUNCTION.load(::std::sync::atomic::Ordering::Acquire);
-    assert!(! ptr.is_null(), "SQLite API not initialized or SQLite feature omitted");
-    let fun: unsafe extern "C" fn(
-        arg1: *mut sqlite3,
-        arg2: *const ::std::os::raw::c_char,
-        arg3: ::std::os::raw::c_int,
-        arg4: ::std::os::raw::c_int,
-        arg5: *mut ::std::os::raw::c_void,
-        xFunc: ::std::option::Option<
-            unsafe extern "C" fn(
-                arg1: *mut sqlite3_context,
-                arg2: ::std::os::raw::c_int,
-                arg3: *mut *mut sqlite3_value,
-            ),
-        >,
-        xStep: ::std::option::Option<
-            unsafe extern "C" fn(
-                arg1: *mut sqlite3_context,
-                arg2: ::std::os::raw::c_int,
-                arg3: *mut *mut sqlite3_value,
-            ),
-        >,
-        xFinal: ::std::option::Option<unsafe extern "C" fn(arg1: *mut sqlite3_context)>,
-    ) -> ::std::os::raw::c_int = ::std::mem::transmute(ptr);
-    (fun)(arg1, arg2, arg3, arg4, arg5, xFunc, xStep, xFinal)
-}
-
-static __SQLITE3_CREATE_MODULE: ::std::sync::atomic::AtomicPtr<()> = ::std::sync::atomic::AtomicPtr::new(
-    ::std::ptr::null_mut(),
-);
-pub unsafe fn sqlite3_create_module(
-    arg1: *mut sqlite3,
-    arg2: *const ::std::os::raw::c_char,
-    arg3: *const sqlite3_module,
-    arg4: *mut ::std::os::raw::c_void,
-) -> ::std::os::raw::c_int {
-    let ptr = __SQLITE3_CREATE_MODULE.load(::std::sync::atomic::Ordering::Acquire);
-    assert!(! ptr.is_null(), "SQLite API not initialized or SQLite feature omitted");
-    let fun: unsafe extern "C" fn(
-        arg1: *mut sqlite3,
-        arg2: *const ::std::os::raw::c_char,
-        arg3: *const sqlite3_module,
-        arg4: *mut ::std::os::raw::c_void,
-    ) -> ::std::os::raw::c_int = ::std::mem::transmute(ptr);
-    (fun)(arg1, arg2, arg3, arg4)
-}
-
 static __SQLITE3_DATA_COUNT: ::std::sync::atomic::AtomicPtr<()> = ::std::sync::atomic::AtomicPtr::new(
     ::std::ptr::null_mut(),
 );
@@ -3422,28 +3312,6 @@ pub unsafe fn sqlite3_open(
         arg2: *mut *mut sqlite3,
     ) -> ::std::os::raw::c_int = ::std::mem::transmute(ptr);
     (fun)(arg1, arg2)
-}
-
-static __SQLITE3_PREPARE: ::std::sync::atomic::AtomicPtr<()> = ::std::sync::atomic::AtomicPtr::new(
-    ::std::ptr::null_mut(),
-);
-pub unsafe fn sqlite3_prepare(
-    arg1: *mut sqlite3,
-    arg2: *const ::std::os::raw::c_char,
-    arg3: ::std::os::raw::c_int,
-    arg4: *mut *mut sqlite3_stmt,
-    arg5: *mut *const ::std::os::raw::c_char,
-) -> ::std::os::raw::c_int {
-    let ptr = __SQLITE3_PREPARE.load(::std::sync::atomic::Ordering::Acquire);
-    assert!(! ptr.is_null(), "SQLite API not initialized or SQLite feature omitted");
-    let fun: unsafe extern "C" fn(
-        arg1: *mut sqlite3,
-        arg2: *const ::std::os::raw::c_char,
-        arg3: ::std::os::raw::c_int,
-        arg4: *mut *mut sqlite3_stmt,
-        arg5: *mut *const ::std::os::raw::c_char,
-    ) -> ::std::os::raw::c_int = ::std::mem::transmute(ptr);
-    (fun)(arg1, arg2, arg3, arg4, arg5)
 }
 
 static __SQLITE3_PROFILE: ::std::sync::atomic::AtomicPtr<()> = ::std::sync::atomic::AtomicPtr::new(
@@ -5014,18 +4882,6 @@ pub unsafe fn sqlite3_vtab_on_conflict(arg1: *mut sqlite3) -> ::std::os::raw::c_
     (fun)(arg1)
 }
 
-static __SQLITE3_CLOSE_V2: ::std::sync::atomic::AtomicPtr<()> = ::std::sync::atomic::AtomicPtr::new(
-    ::std::ptr::null_mut(),
-);
-pub unsafe fn sqlite3_close_v2(arg1: *mut sqlite3) -> ::std::os::raw::c_int {
-    let ptr = __SQLITE3_CLOSE_V2.load(::std::sync::atomic::Ordering::Acquire);
-    assert!(! ptr.is_null(), "SQLite API not initialized or SQLite feature omitted");
-    let fun: unsafe extern "C" fn(arg1: *mut sqlite3) -> ::std::os::raw::c_int = ::std::mem::transmute(
-        ptr,
-    );
-    (fun)(arg1)
-}
-
 static __SQLITE3_DB_FILENAME: ::std::sync::atomic::AtomicPtr<()> = ::std::sync::atomic::AtomicPtr::new(
     ::std::ptr::null_mut(),
 );
@@ -5771,18 +5627,6 @@ pub unsafe fn rusqlite_extension_init2(
         __SQLITE3_COMPLETE
             .store(fun as usize as *mut (), ::std::sync::atomic::Ordering::Release);
     }
-    if let Some(fun) = (*p_api).create_collation {
-        __SQLITE3_CREATE_COLLATION
-            .store(fun as usize as *mut (), ::std::sync::atomic::Ordering::Release);
-    }
-    if let Some(fun) = (*p_api).create_function {
-        __SQLITE3_CREATE_FUNCTION
-            .store(fun as usize as *mut (), ::std::sync::atomic::Ordering::Release);
-    }
-    if let Some(fun) = (*p_api).create_module {
-        __SQLITE3_CREATE_MODULE
-            .store(fun as usize as *mut (), ::std::sync::atomic::Ordering::Release);
-    }
     if let Some(fun) = (*p_api).data_count {
         __SQLITE3_DATA_COUNT
             .store(fun as usize as *mut (), ::std::sync::atomic::Ordering::Release);
@@ -5853,10 +5697,6 @@ pub unsafe fn rusqlite_extension_init2(
     }
     if let Some(fun) = (*p_api).open {
         __SQLITE3_OPEN
-            .store(fun as usize as *mut (), ::std::sync::atomic::Ordering::Release);
-    }
-    if let Some(fun) = (*p_api).prepare {
-        __SQLITE3_PREPARE
             .store(fun as usize as *mut (), ::std::sync::atomic::Ordering::Release);
     }
     if let Some(fun) = (*p_api).profile {
@@ -6221,10 +6061,6 @@ pub unsafe fn rusqlite_extension_init2(
     }
     if let Some(fun) = (*p_api).vtab_on_conflict {
         __SQLITE3_VTAB_ON_CONFLICT
-            .store(fun as usize as *mut (), ::std::sync::atomic::Ordering::Release);
-    }
-    if let Some(fun) = (*p_api).close_v2 {
-        __SQLITE3_CLOSE_V2
             .store(fun as usize as *mut (), ::std::sync::atomic::Ordering::Release);
     }
     if let Some(fun) = (*p_api).db_filename {

--- a/libsqlite3-sys/build.rs
+++ b/libsqlite3-sys/build.rs
@@ -575,7 +575,12 @@ mod bindings {
     ) -> ::std::os::raw::c_int;
 }"#,
                 )
-                .blocklist_function(".*16.*");
+                .blocklist_function(".*16.*")
+                .blocklist_function("sqlite3_close_v2")
+                .blocklist_function("sqlite3_create_collation")
+                .blocklist_function("sqlite3_create_function")
+                .blocklist_function("sqlite3_create_module")
+                .blocklist_function("sqlite3_prepare");
         }
 
         if cfg!(any(feature = "sqlcipher", feature = "bundled-sqlcipher")) {
@@ -681,6 +686,11 @@ mod loadable_extension {
                 || name == "global_recover"
                 || name == "thread_cleanup"
                 || name == "transfer_bindings"
+                || name == "create_collation"
+                || name == "create_function"
+                || name == "create_module"
+                || name == "prepare"
+                || name == "close_v2"
             {
                 continue; // omit deprecated
             }

--- a/libsqlite3-sys/sqlcipher/bindgen_bundled_version.rs
+++ b/libsqlite3-sys/sqlcipher/bindgen_bundled_version.rs
@@ -545,9 +545,6 @@ pub type sqlite3_uint64 = sqlite_uint64;
 extern "C" {
     pub fn sqlite3_close(arg1: *mut sqlite3) -> ::std::os::raw::c_int;
 }
-extern "C" {
-    pub fn sqlite3_close_v2(arg1: *mut sqlite3) -> ::std::os::raw::c_int;
-}
 pub type sqlite3_callback = ::std::option::Option<
     unsafe extern "C" fn(
         arg1: *mut ::std::os::raw::c_void,
@@ -1131,15 +1128,6 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    pub fn sqlite3_prepare(
-        db: *mut sqlite3,
-        zSql: *const ::std::os::raw::c_char,
-        nByte: ::std::os::raw::c_int,
-        ppStmt: *mut *mut sqlite3_stmt,
-        pzTail: *mut *const ::std::os::raw::c_char,
-    ) -> ::std::os::raw::c_int;
-}
-extern "C" {
     pub fn sqlite3_prepare_v2(
         db: *mut sqlite3,
         zSql: *const ::std::os::raw::c_char,
@@ -1390,30 +1378,6 @@ extern "C" {
 }
 extern "C" {
     pub fn sqlite3_reset(pStmt: *mut sqlite3_stmt) -> ::std::os::raw::c_int;
-}
-extern "C" {
-    pub fn sqlite3_create_function(
-        db: *mut sqlite3,
-        zFunctionName: *const ::std::os::raw::c_char,
-        nArg: ::std::os::raw::c_int,
-        eTextRep: ::std::os::raw::c_int,
-        pApp: *mut ::std::os::raw::c_void,
-        xFunc: ::std::option::Option<
-            unsafe extern "C" fn(
-                arg1: *mut sqlite3_context,
-                arg2: ::std::os::raw::c_int,
-                arg3: *mut *mut sqlite3_value,
-            ),
-        >,
-        xStep: ::std::option::Option<
-            unsafe extern "C" fn(
-                arg1: *mut sqlite3_context,
-                arg2: ::std::os::raw::c_int,
-                arg3: *mut *mut sqlite3_value,
-            ),
-        >,
-        xFinal: ::std::option::Option<unsafe extern "C" fn(arg1: *mut sqlite3_context)>,
-    ) -> ::std::os::raw::c_int;
 }
 extern "C" {
     pub fn sqlite3_create_function_v2(
@@ -1670,23 +1634,6 @@ extern "C" {
 }
 extern "C" {
     pub fn sqlite3_result_subtype(arg1: *mut sqlite3_context, arg2: ::std::os::raw::c_uint);
-}
-extern "C" {
-    pub fn sqlite3_create_collation(
-        arg1: *mut sqlite3,
-        zName: *const ::std::os::raw::c_char,
-        eTextRep: ::std::os::raw::c_int,
-        pArg: *mut ::std::os::raw::c_void,
-        xCompare: ::std::option::Option<
-            unsafe extern "C" fn(
-                arg1: *mut ::std::os::raw::c_void,
-                arg2: ::std::os::raw::c_int,
-                arg3: *const ::std::os::raw::c_void,
-                arg4: ::std::os::raw::c_int,
-                arg5: *const ::std::os::raw::c_void,
-            ) -> ::std::os::raw::c_int,
-        >,
-    ) -> ::std::os::raw::c_int;
 }
 extern "C" {
     pub fn sqlite3_create_collation_v2(
@@ -2083,14 +2030,6 @@ pub struct sqlite3_index_orderby {
 pub struct sqlite3_index_constraint_usage {
     pub argvIndex: ::std::os::raw::c_int,
     pub omit: ::std::os::raw::c_uchar,
-}
-extern "C" {
-    pub fn sqlite3_create_module(
-        db: *mut sqlite3,
-        zName: *const ::std::os::raw::c_char,
-        p: *const sqlite3_module,
-        pClientData: *mut ::std::os::raw::c_void,
-    ) -> ::std::os::raw::c_int;
 }
 extern "C" {
     pub fn sqlite3_create_module_v2(

--- a/libsqlite3-sys/sqlite3/bindgen_bundled_version.rs
+++ b/libsqlite3-sys/sqlite3/bindgen_bundled_version.rs
@@ -546,9 +546,6 @@ pub type sqlite3_uint64 = sqlite_uint64;
 extern "C" {
     pub fn sqlite3_close(arg1: *mut sqlite3) -> ::std::os::raw::c_int;
 }
-extern "C" {
-    pub fn sqlite3_close_v2(arg1: *mut sqlite3) -> ::std::os::raw::c_int;
-}
 pub type sqlite3_callback = ::std::option::Option<
     unsafe extern "C" fn(
         arg1: *mut ::std::os::raw::c_void,
@@ -1132,15 +1129,6 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    pub fn sqlite3_prepare(
-        db: *mut sqlite3,
-        zSql: *const ::std::os::raw::c_char,
-        nByte: ::std::os::raw::c_int,
-        ppStmt: *mut *mut sqlite3_stmt,
-        pzTail: *mut *const ::std::os::raw::c_char,
-    ) -> ::std::os::raw::c_int;
-}
-extern "C" {
     pub fn sqlite3_prepare_v2(
         db: *mut sqlite3,
         zSql: *const ::std::os::raw::c_char,
@@ -1391,30 +1379,6 @@ extern "C" {
 }
 extern "C" {
     pub fn sqlite3_reset(pStmt: *mut sqlite3_stmt) -> ::std::os::raw::c_int;
-}
-extern "C" {
-    pub fn sqlite3_create_function(
-        db: *mut sqlite3,
-        zFunctionName: *const ::std::os::raw::c_char,
-        nArg: ::std::os::raw::c_int,
-        eTextRep: ::std::os::raw::c_int,
-        pApp: *mut ::std::os::raw::c_void,
-        xFunc: ::std::option::Option<
-            unsafe extern "C" fn(
-                arg1: *mut sqlite3_context,
-                arg2: ::std::os::raw::c_int,
-                arg3: *mut *mut sqlite3_value,
-            ),
-        >,
-        xStep: ::std::option::Option<
-            unsafe extern "C" fn(
-                arg1: *mut sqlite3_context,
-                arg2: ::std::os::raw::c_int,
-                arg3: *mut *mut sqlite3_value,
-            ),
-        >,
-        xFinal: ::std::option::Option<unsafe extern "C" fn(arg1: *mut sqlite3_context)>,
-    ) -> ::std::os::raw::c_int;
 }
 extern "C" {
     pub fn sqlite3_create_function_v2(
@@ -1671,23 +1635,6 @@ extern "C" {
 }
 extern "C" {
     pub fn sqlite3_result_subtype(arg1: *mut sqlite3_context, arg2: ::std::os::raw::c_uint);
-}
-extern "C" {
-    pub fn sqlite3_create_collation(
-        arg1: *mut sqlite3,
-        zName: *const ::std::os::raw::c_char,
-        eTextRep: ::std::os::raw::c_int,
-        pArg: *mut ::std::os::raw::c_void,
-        xCompare: ::std::option::Option<
-            unsafe extern "C" fn(
-                arg1: *mut ::std::os::raw::c_void,
-                arg2: ::std::os::raw::c_int,
-                arg3: *const ::std::os::raw::c_void,
-                arg4: ::std::os::raw::c_int,
-                arg5: *const ::std::os::raw::c_void,
-            ) -> ::std::os::raw::c_int,
-        >,
-    ) -> ::std::os::raw::c_int;
 }
 extern "C" {
     pub fn sqlite3_create_collation_v2(
@@ -2051,14 +1998,6 @@ pub struct sqlite3_index_orderby {
 pub struct sqlite3_index_constraint_usage {
     pub argvIndex: ::std::os::raw::c_int,
     pub omit: ::std::os::raw::c_uchar,
-}
-extern "C" {
-    pub fn sqlite3_create_module(
-        db: *mut sqlite3,
-        zName: *const ::std::os::raw::c_char,
-        p: *const sqlite3_module,
-        pClientData: *mut ::std::os::raw::c_void,
-    ) -> ::std::os::raw::c_int;
 }
 extern "C" {
     pub fn sqlite3_create_module_v2(

--- a/libsqlite3-sys/sqlite3/bindgen_bundled_version_ext.rs
+++ b/libsqlite3-sys/sqlite3/bindgen_bundled_version_ext.rs
@@ -3483,116 +3483,6 @@ pub unsafe fn sqlite3_complete(
     (fun)(sql)
 }
 
-static __SQLITE3_CREATE_COLLATION: ::std::sync::atomic::AtomicPtr<()> = ::std::sync::atomic::AtomicPtr::new(
-    ::std::ptr::null_mut(),
-);
-pub unsafe fn sqlite3_create_collation(
-    arg1: *mut sqlite3,
-    arg2: *const ::std::os::raw::c_char,
-    arg3: ::std::os::raw::c_int,
-    arg4: *mut ::std::os::raw::c_void,
-    arg5: ::std::option::Option<
-        unsafe extern "C" fn(
-            arg1: *mut ::std::os::raw::c_void,
-            arg2: ::std::os::raw::c_int,
-            arg3: *const ::std::os::raw::c_void,
-            arg4: ::std::os::raw::c_int,
-            arg5: *const ::std::os::raw::c_void,
-        ) -> ::std::os::raw::c_int,
-    >,
-) -> ::std::os::raw::c_int {
-    let ptr = __SQLITE3_CREATE_COLLATION.load(::std::sync::atomic::Ordering::Acquire);
-    assert!(! ptr.is_null(), "SQLite API not initialized or SQLite feature omitted");
-    let fun: unsafe extern "C" fn(
-        arg1: *mut sqlite3,
-        arg2: *const ::std::os::raw::c_char,
-        arg3: ::std::os::raw::c_int,
-        arg4: *mut ::std::os::raw::c_void,
-        arg5: ::std::option::Option<
-            unsafe extern "C" fn(
-                arg1: *mut ::std::os::raw::c_void,
-                arg2: ::std::os::raw::c_int,
-                arg3: *const ::std::os::raw::c_void,
-                arg4: ::std::os::raw::c_int,
-                arg5: *const ::std::os::raw::c_void,
-            ) -> ::std::os::raw::c_int,
-        >,
-    ) -> ::std::os::raw::c_int = ::std::mem::transmute(ptr);
-    (fun)(arg1, arg2, arg3, arg4, arg5)
-}
-
-static __SQLITE3_CREATE_FUNCTION: ::std::sync::atomic::AtomicPtr<()> = ::std::sync::atomic::AtomicPtr::new(
-    ::std::ptr::null_mut(),
-);
-pub unsafe fn sqlite3_create_function(
-    arg1: *mut sqlite3,
-    arg2: *const ::std::os::raw::c_char,
-    arg3: ::std::os::raw::c_int,
-    arg4: ::std::os::raw::c_int,
-    arg5: *mut ::std::os::raw::c_void,
-    xFunc: ::std::option::Option<
-        unsafe extern "C" fn(
-            arg1: *mut sqlite3_context,
-            arg2: ::std::os::raw::c_int,
-            arg3: *mut *mut sqlite3_value,
-        ),
-    >,
-    xStep: ::std::option::Option<
-        unsafe extern "C" fn(
-            arg1: *mut sqlite3_context,
-            arg2: ::std::os::raw::c_int,
-            arg3: *mut *mut sqlite3_value,
-        ),
-    >,
-    xFinal: ::std::option::Option<unsafe extern "C" fn(arg1: *mut sqlite3_context)>,
-) -> ::std::os::raw::c_int {
-    let ptr = __SQLITE3_CREATE_FUNCTION.load(::std::sync::atomic::Ordering::Acquire);
-    assert!(! ptr.is_null(), "SQLite API not initialized or SQLite feature omitted");
-    let fun: unsafe extern "C" fn(
-        arg1: *mut sqlite3,
-        arg2: *const ::std::os::raw::c_char,
-        arg3: ::std::os::raw::c_int,
-        arg4: ::std::os::raw::c_int,
-        arg5: *mut ::std::os::raw::c_void,
-        xFunc: ::std::option::Option<
-            unsafe extern "C" fn(
-                arg1: *mut sqlite3_context,
-                arg2: ::std::os::raw::c_int,
-                arg3: *mut *mut sqlite3_value,
-            ),
-        >,
-        xStep: ::std::option::Option<
-            unsafe extern "C" fn(
-                arg1: *mut sqlite3_context,
-                arg2: ::std::os::raw::c_int,
-                arg3: *mut *mut sqlite3_value,
-            ),
-        >,
-        xFinal: ::std::option::Option<unsafe extern "C" fn(arg1: *mut sqlite3_context)>,
-    ) -> ::std::os::raw::c_int = ::std::mem::transmute(ptr);
-    (fun)(arg1, arg2, arg3, arg4, arg5, xFunc, xStep, xFinal)
-}
-
-static __SQLITE3_CREATE_MODULE: ::std::sync::atomic::AtomicPtr<()> = ::std::sync::atomic::AtomicPtr::new(
-    ::std::ptr::null_mut(),
-);
-pub unsafe fn sqlite3_create_module(
-    arg1: *mut sqlite3,
-    arg2: *const ::std::os::raw::c_char,
-    arg3: *const sqlite3_module,
-    arg4: *mut ::std::os::raw::c_void,
-) -> ::std::os::raw::c_int {
-    let ptr = __SQLITE3_CREATE_MODULE.load(::std::sync::atomic::Ordering::Acquire);
-    assert!(! ptr.is_null(), "SQLite API not initialized or SQLite feature omitted");
-    let fun: unsafe extern "C" fn(
-        arg1: *mut sqlite3,
-        arg2: *const ::std::os::raw::c_char,
-        arg3: *const sqlite3_module,
-        arg4: *mut ::std::os::raw::c_void,
-    ) -> ::std::os::raw::c_int = ::std::mem::transmute(ptr);
-    (fun)(arg1, arg2, arg3, arg4)
-}
-
 static __SQLITE3_DATA_COUNT: ::std::sync::atomic::AtomicPtr<()> = ::std::sync::atomic::AtomicPtr::new(
     ::std::ptr::null_mut(),
 );
@@ -3855,28 +3745,6 @@ pub unsafe fn sqlite3_open(
         arg2: *mut *mut sqlite3,
     ) -> ::std::os::raw::c_int = ::std::mem::transmute(ptr);
     (fun)(arg1, arg2)
-}
-
-static __SQLITE3_PREPARE: ::std::sync::atomic::AtomicPtr<()> = ::std::sync::atomic::AtomicPtr::new(
-    ::std::ptr::null_mut(),
-);
-pub unsafe fn sqlite3_prepare(
-    arg1: *mut sqlite3,
-    arg2: *const ::std::os::raw::c_char,
-    arg3: ::std::os::raw::c_int,
-    arg4: *mut *mut sqlite3_stmt,
-    arg5: *mut *const ::std::os::raw::c_char,
-) -> ::std::os::raw::c_int {
-    let ptr = __SQLITE3_PREPARE.load(::std::sync::atomic::Ordering::Acquire);
-    assert!(! ptr.is_null(), "SQLite API not initialized or SQLite feature omitted");
-    let fun: unsafe extern "C" fn(
-        arg1: *mut sqlite3,
-        arg2: *const ::std::os::raw::c_char,
-        arg3: ::std::os::raw::c_int,
-        arg4: *mut *mut sqlite3_stmt,
-        arg5: *mut *const ::std::os::raw::c_char,
-    ) -> ::std::os::raw::c_int = ::std::mem::transmute(ptr);
-    (fun)(arg1, arg2, arg3, arg4, arg5)
 }
 
 static __SQLITE3_PROFILE: ::std::sync::atomic::AtomicPtr<()> = ::std::sync::atomic::AtomicPtr::new(
@@ -5440,18 +5308,6 @@ static __SQLITE3_VTAB_ON_CONFLICT: ::std::sync::atomic::AtomicPtr<()> = ::std::s
 );
 pub unsafe fn sqlite3_vtab_on_conflict(arg1: *mut sqlite3) -> ::std::os::raw::c_int {
     let ptr = __SQLITE3_VTAB_ON_CONFLICT.load(::std::sync::atomic::Ordering::Acquire);
-    assert!(! ptr.is_null(), "SQLite API not initialized or SQLite feature omitted");
-    let fun: unsafe extern "C" fn(arg1: *mut sqlite3) -> ::std::os::raw::c_int = ::std::mem::transmute(
-        ptr,
-    );
-    (fun)(arg1)
-}
-
-static __SQLITE3_CLOSE_V2: ::std::sync::atomic::AtomicPtr<()> = ::std::sync::atomic::AtomicPtr::new(
-    ::std::ptr::null_mut(),
-);
-pub unsafe fn sqlite3_close_v2(arg1: *mut sqlite3) -> ::std::os::raw::c_int {
-    let ptr = __SQLITE3_CLOSE_V2.load(::std::sync::atomic::Ordering::Acquire);
     assert!(! ptr.is_null(), "SQLite API not initialized or SQLite feature omitted");
     let fun: unsafe extern "C" fn(arg1: *mut sqlite3) -> ::std::os::raw::c_int = ::std::mem::transmute(
         ptr,
@@ -7037,18 +6893,6 @@ pub unsafe fn rusqlite_extension_init2(
         __SQLITE3_COMPLETE
             .store(fun as usize as *mut (), ::std::sync::atomic::Ordering::Release);
     }
-    if let Some(fun) = (*p_api).create_collation {
-        __SQLITE3_CREATE_COLLATION
-            .store(fun as usize as *mut (), ::std::sync::atomic::Ordering::Release);
-    }
-    if let Some(fun) = (*p_api).create_function {
-        __SQLITE3_CREATE_FUNCTION
-            .store(fun as usize as *mut (), ::std::sync::atomic::Ordering::Release);
-    }
-    if let Some(fun) = (*p_api).create_module {
-        __SQLITE3_CREATE_MODULE
-            .store(fun as usize as *mut (), ::std::sync::atomic::Ordering::Release);
-    }
     if let Some(fun) = (*p_api).data_count {
         __SQLITE3_DATA_COUNT
             .store(fun as usize as *mut (), ::std::sync::atomic::Ordering::Release);
@@ -7119,10 +6963,6 @@ pub unsafe fn rusqlite_extension_init2(
     }
     if let Some(fun) = (*p_api).open {
         __SQLITE3_OPEN
-            .store(fun as usize as *mut (), ::std::sync::atomic::Ordering::Release);
-    }
-    if let Some(fun) = (*p_api).prepare {
-        __SQLITE3_PREPARE
             .store(fun as usize as *mut (), ::std::sync::atomic::Ordering::Release);
     }
     if let Some(fun) = (*p_api).profile {
@@ -7487,10 +7327,6 @@ pub unsafe fn rusqlite_extension_init2(
     }
     if let Some(fun) = (*p_api).vtab_on_conflict {
         __SQLITE3_VTAB_ON_CONFLICT
-            .store(fun as usize as *mut (), ::std::sync::atomic::Ordering::Release);
-    }
-    if let Some(fun) = (*p_api).close_v2 {
-        __SQLITE3_CLOSE_V2
             .store(fun as usize as *mut (), ::std::sync::atomic::Ordering::Release);
     }
     if let Some(fun) = (*p_api).db_filename {


### PR DESCRIPTION
sqlite3_close_v2 (for gced languages)
sqlite3_create_collation (vs sqlite3_create_collation_v2) sqlite3_create_function (vs sqlite3_create_function_v2) sqlite3_create_module (vs sqlite3_create_module_v2) sqlite3_prepare (vs sqlite3_prepare_v2/v3)