### PR TITLE
Activate SQLITE_OPEN_EXRESCODE by default

### DIFF
--- a/src/inner_connection.rs
+++ b/src/inner_connection.rs
@@ -73,9 +73,7 @@ impl InnerConnection {
 
         // turn on extended results code before opening database to have a better diagnostic if a failure happens
         let exrescode = if version_number() >= 3_037_000 {
-            if !flags.contains(OpenFlags::SQLITE_OPEN_EXRESCODE) {
-                flags |= OpenFlags::SQLITE_OPEN_EXRESCODE;
-            }
+            flags |= OpenFlags::SQLITE_OPEN_EXRESCODE;
             true
         } else {
             false // flag SQLITE_OPEN_EXRESCODE is ignored by SQLite version < 3.37.0

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1214,7 +1214,6 @@ impl Default for OpenFlags {
             | OpenFlags::SQLITE_OPEN_CREATE
             | OpenFlags::SQLITE_OPEN_NO_MUTEX
             | OpenFlags::SQLITE_OPEN_URI
-            | OpenFlags::SQLITE_OPEN_EXRESCODE
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1214,6 +1214,7 @@ impl Default for OpenFlags {
             | OpenFlags::SQLITE_OPEN_CREATE
             | OpenFlags::SQLITE_OPEN_NO_MUTEX
             | OpenFlags::SQLITE_OPEN_URI
+            | OpenFlags::SQLITE_OPEN_EXRESCODE
     }
 }
 


### PR DESCRIPTION
I am not completly sure that it is fine to activate this flag with an old SQLite version.
See http://sqlite.org/c3ref/open.html
> If the 3rd parameter to sqlite3_open_v2() is not one of the required combinations shown above optionally combined with other SQLITE_OPEN_* bits then the behavior is undefined.