### PR TITLE
Fix csvtab doc example

### DIFF
--- a/src/vtab/csvtab.rs
+++ b/src/vtab/csvtab.rs
@@ -14,7 +14,7 @@
 //!     // Assume my_csv.csv
 //!     let schema = "
 //!         CREATE VIRTUAL TABLE my_csv_data
-//!         USING csv(filename = 'my_csv.csv')
+//!         USING csv(filename='my_csv.csv')
 //!     ";
 //!     db.execute_batch(schema)?;
 //!     // Now the `my_csv_data` (virtual) table can be queried as normal...


### PR DESCRIPTION
Fixes ```SqliteFailure(Error { code: Unknown, extended_code: 1 }, Some("file ' 'my_csv.csv'' does not exist"))``` when running the example code. 
(It looks for a file name with a leading space currently)