### PR TITLE
Improve loadable extension docs

### DIFF
--- a/examples/loadable_extension.rs
+++ b/examples/loadable_extension.rs
@@ -1,4 +1,18 @@
 //! Adaptation of https://sqlite.org/loadext.html#programming_loadable_extensions
+//!
+//! # build
+//! ```sh
+//! cargo build --example loadable_extension --features "loadable_extension functions trace"
+//! ```
+//!
+//! # test
+//! ```sh
+//! sqlite> .log on
+//! sqlite> .load target/debug/examples/libloadable_extension.so
+//! (28) Rusqlite extension initialized
+//! sqlite> SELECT rusqlite_test_function();
+//! Rusqlite extension loaded correctly!
+//! ```
 use std::os::raw::{c_char, c_int};
 
 use rusqlite::ffi;
@@ -6,18 +20,10 @@ use rusqlite::functions::FunctionFlags;
 use rusqlite::types::{ToSqlOutput, Value};
 use rusqlite::{Connection, Result};
 
-/// # build
-/// ```sh
-/// cargo build --example loadable_extension --features "loadable_extension functions trace"
-/// ```
-/// # test
-/// ```sh
-/// sqlite> .log on
-/// sqlite> .load target/debug/examples/libloadable_extension.so
-/// (28) Rusqlite extension initialized
-/// sqlite> SELECT rusqlite_test_function();
-/// Rusqlite extension loaded correctly!
-/// ```
+/// Entry point for SQLite to load the extension.
+/// See <https://sqlite.org/c3ref/load_extension.html> on this function's name and usage.
+/// # Safety
+/// This function is called by SQLite and must be safe to call.
 #[expect(clippy::not_unsafe_ptr_arg_deref)]
 #[no_mangle]
 pub unsafe extern "C" fn sqlite3_extension_init(


### PR DESCRIPTION
A minor documentation improvement on a loadable extension - moving loadable instructions to the whole example rather than the init function