### PR TITLE
Allow setting default connection transaction behavior

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -377,7 +377,7 @@ impl DatabaseName<'_> {
 pub struct Connection {
     db: RefCell<InnerConnection>,
     cache: StatementCache,
-    transaction_behavior: TransactionBehavior
+    transaction_behavior: TransactionBehavior,
 }
 
 unsafe impl Send for Connection {}
@@ -474,7 +474,7 @@ impl Connection {
         InnerConnection::open_with_flags(&c_path, flags, None).map(|db| Connection {
             db: RefCell::new(db),
             cache: StatementCache::with_capacity(STATEMENT_CACHE_DEFAULT_CAPACITY),
-            transaction_behavior: TransactionBehavior::Deferred
+            transaction_behavior: TransactionBehavior::Deferred,
         })
     }
 
@@ -499,7 +499,7 @@ impl Connection {
         InnerConnection::open_with_flags(&c_path, flags, Some(&c_vfs)).map(|db| Connection {
             db: RefCell::new(db),
             cache: StatementCache::with_capacity(STATEMENT_CACHE_DEFAULT_CAPACITY),
-            transaction_behavior: TransactionBehavior::Deferred
+            transaction_behavior: TransactionBehavior::Deferred,
         })
     }
 
@@ -952,7 +952,7 @@ impl Connection {
         Ok(Connection {
             db: RefCell::new(db),
             cache: StatementCache::with_capacity(STATEMENT_CACHE_DEFAULT_CAPACITY),
-            transaction_behavior: TransactionBehavior::Deferred
+            transaction_behavior: TransactionBehavior::Deferred,
         })
     }
 
@@ -1001,7 +1001,7 @@ impl Connection {
         Ok(Connection {
             db: RefCell::new(db),
             cache: StatementCache::with_capacity(STATEMENT_CACHE_DEFAULT_CAPACITY),
-            transaction_behavior: TransactionBehavior::Deferred
+            transaction_behavior: TransactionBehavior::Deferred,
         })
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -377,6 +377,7 @@ impl DatabaseName<'_> {
 pub struct Connection {
     db: RefCell<InnerConnection>,
     cache: StatementCache,
+    transaction_behavior: TransactionBehavior
 }
 
 unsafe impl Send for Connection {}
@@ -473,6 +474,7 @@ impl Connection {
         InnerConnection::open_with_flags(&c_path, flags, None).map(|db| Connection {
             db: RefCell::new(db),
             cache: StatementCache::with_capacity(STATEMENT_CACHE_DEFAULT_CAPACITY),
+            transaction_behavior: TransactionBehavior::Deferred
         })
     }
 
@@ -497,6 +499,7 @@ impl Connection {
         InnerConnection::open_with_flags(&c_path, flags, Some(&c_vfs)).map(|db| Connection {
             db: RefCell::new(db),
             cache: StatementCache::with_capacity(STATEMENT_CACHE_DEFAULT_CAPACITY),
+            transaction_behavior: TransactionBehavior::Deferred
         })
     }
 
@@ -949,6 +952,7 @@ impl Connection {
         Ok(Connection {
             db: RefCell::new(db),
             cache: StatementCache::with_capacity(STATEMENT_CACHE_DEFAULT_CAPACITY),
+            transaction_behavior: TransactionBehavior::Deferred
         })
     }
 
@@ -997,6 +1001,7 @@ impl Connection {
         Ok(Connection {
             db: RefCell::new(db),
             cache: StatementCache::with_capacity(STATEMENT_CACHE_DEFAULT_CAPACITY),
+            transaction_behavior: TransactionBehavior::Deferred
         })
     }
 

--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -1,10 +1,18 @@
 use crate::{Connection, Result};
 use std::ops::Deref;
 
+impl Connection {
+    /// Set the default transaction behavior for the connection.
+    pub fn set_transaction_behavior(&mut self, behavior: TransactionBehavior) {
+        self.transaction_behavior = behavior;
+    }
+}
+
 /// Options for transaction behavior. See [BEGIN
 /// TRANSACTION](http://www.sqlite.org/lang_transaction.html) for details.
 #[derive(Copy, Clone)]
 #[non_exhaustive]
+
 pub enum TransactionBehavior {
     /// DEFERRED means that the transaction does not actually start until the
     /// database is first accessed.
@@ -414,7 +422,7 @@ impl Connection {
     /// Will return `Err` if the underlying SQLite call fails.
     #[inline]
     pub fn transaction(&mut self) -> Result<Transaction<'_>> {
-        Transaction::new(self, TransactionBehavior::Deferred)
+        Transaction::new(self, self.transaction_behavior)
     }
 
     /// Begin a new transaction with a specified behavior.


### PR DESCRIPTION
Hi,
It would be nice if a per connection default `transaction_behavior` could be set instead of having to use `transaction_with_behavior` everywhere. 

Then, for example:
- a connection of writing could be set `conn.set_transaction_behavior(TransactionBehavior::Immediate)`
- read-connections would be `conn.set_transaction_behavior(TransactionBehavior::Deferred)` 

This PR adds this behavior with the default value remaining unchanged as `TransactionBehavior::Deferred`.
