### PR TITLE
require `cc` 1.0.100 or later

### DIFF
--- a/libsqlite3-sys/Cargo.toml
+++ b/libsqlite3-sys/Cargo.toml
@@ -40,7 +40,7 @@ openssl-sys = { version = "0.9", optional = true }
 [build-dependencies]
 bindgen = { version = "0.69", optional = true, default-features = false, features = ["runtime"] }
 pkg-config = { version = "0.3.19", optional = true }
-cc = { version = "1.0", optional = true }
+cc = { version = "1.0.100", optional = true }
 vcpkg = { version = "0.2", optional = true }
 # for loadable_extension:
 prettyplease = {version = "0.2", optional = true }


### PR DESCRIPTION
Closes #1545
xref #1543

Signature of cfg.flag changed in `cc` 1.0.100

I would recommend point releases of both `libsqlite3-sys` and `rusqlite`, and possibly yanking the existing versions.