### PR TITLE
Correcting inconsistent parameter name (:value/:val) in doctest example

### DIFF
--- a/src/params.rs
+++ b/src/params.rs
@@ -124,7 +124,7 @@ use sealed::Sealed;
 /// ```rust,no_run
 /// # use rusqlite::{Connection, Result, named_params};
 /// fn insert(conn: &Connection) -> Result<()> {
-///     let mut stmt = conn.prepare("INSERT INTO test (key, value) VALUES (:key, :value)")?;
+///     let mut stmt = conn.prepare("INSERT INTO test (key, value) VALUES (:key, :val)")?;
 ///     // Using `rusqlite::params!`:
 ///     stmt.execute(named_params! { ":key": "one", ":val": 2 })?;
 ///     // Alternatively:


### PR DESCRIPTION
Inconsistent parameter name  (:value/:val) in doctest example causes "InvalidParameterName" runtime error:
[Playground demonstration](https://play.rust-lang.org/?version=stable&mode=debug&edition=2021&gist=0b4679d024fd1f26630bfaa48abd9ce4)