### PR TITLE
Repairing description comment of params! macro

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -151,7 +151,7 @@ pub(crate) use util::SmallCString;
 // Number of cached prepared statements we'll hold on to.
 const STATEMENT_CACHE_DEFAULT_CAPACITY: usize = 16;
 
-/// A macro making it more convenient to longer lists of
+/// A macro making it more convenient to pass longer lists of
 /// parameters as a `&[&dyn ToSql]`.
 ///
 /// # Example


### PR DESCRIPTION
The verb "pass" of this sentence got deleted in PR https://github.com/rusqlite/rusqlite/blob/2ec0b2e8fe01aec768396fb0b4e8fd21a77fe95a/src/lib.rs#L148 (by accident, I presume).

Resolves #1320 .