### PR TITLE
Fixed pre-release `wasm32-wasip(\d)` targets not enabling wasi compile flags in `bundled` mode.

### DIFF
--- a/libsqlite3-sys/build.rs
+++ b/libsqlite3-sys/build.rs
@@ -239,7 +239,7 @@ mod build_bundled {
         if !win_target() {
             cfg.flag("-DHAVE_LOCALTIME_R");
         }
-        if env::var("TARGET").map_or(false, |v| v == "wasm32-wasi") {
+        if env::var("TARGET").map_or(false, |v| v.starts_with("wasm32-wasi")) {
             cfg.flag("-USQLITE_THREADSAFE")
                 .flag("-DSQLITE_THREADSAFE=0")
                 // https://github.com/rust-lang/rust/issues/74393


### PR DESCRIPTION
The `wasm32-wasi` target is being deprecated in favor of pre-release targets like `wasm32-wasip(\d)`.

This instead matches the prefix wasi target, so any future pre-releases will probably, maybe, work out of the box.