### PR TITLE
Fix Batch impl

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1141,7 +1141,6 @@ impl<'conn> fallible_iterator::FallibleIterator for Batch<'conn, '_> {
     /// Iterates on each batch statements.
     ///
     /// Returns `Ok(None)` when batch is completed.
-    #[expect(clippy::should_implement_trait)] // fallible iterator
     fn next(&mut self) -> Result<Option<Statement<'conn>>> {
         while self.tail < self.sql.len() {
             let sql = &self.sql[self.tail..];

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1105,6 +1105,7 @@ impl fmt::Debug for Connection {
 /// So you should break the loop when an error is raised by the `next` method.
 ///
 /// ```rust
+/// use fallible_iterator::FallibleIterator;
 /// use rusqlite::{Batch, Connection, Result};
 ///
 /// fn main() -> Result<()> {

--- a/src/row.rs
+++ b/src/row.rs
@@ -5,7 +5,7 @@ use std::convert;
 use super::{Error, Result, Statement};
 use crate::types::{FromSql, FromSqlError, ValueRef};
 
-/// A handle for the resulting rows of a query.
+/// A handle (lazy fallible streaming iterator) for the resulting rows of a query.
 #[must_use = "Rows is lazy and will do nothing unless consumed"]
 pub struct Rows<'stmt> {
     pub(crate) stmt: Option<&'stmt Statement<'stmt>>,


### PR DESCRIPTION
- document that there is no parsing error recovery
- and remove `Iterator` impl to prevent users from looping indefinitely on Some(Err(..))

Fix #1581