### PR TITLE
Add 'serialize' feature to 'modern-full'

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -104,6 +104,7 @@ modern-full = [
     "limits",
     "load_extension",
     "serde_json",
+    "serialize",
     "series",
     "time",
     "trace",


### PR DESCRIPTION
The primary goal is to get the serialize apis included in docs.rs, but it seems logical to include with all the other modern features.