### PR TITLE
Use C string literal for database name

### DIFF
--- a/src/backup.rs
+++ b/src/backup.rs
@@ -207,8 +207,8 @@ impl Backup<'_, '_> {
         to: &'b mut Connection,
         to_name: DatabaseName<'_>,
     ) -> Result<Backup<'a, 'b>> {
-        let to_name = to_name.as_cstring()?;
-        let from_name = from_name.as_cstring()?;
+        let to_name = to_name.as_cstr()?;
+        let from_name = from_name.as_cstr()?;
 
         let to_db = to.db.borrow_mut().db;
 

--- a/src/blob/mod.rs
+++ b/src/blob/mod.rs
@@ -225,7 +225,7 @@ impl Connection {
     ) -> Result<Blob<'a>> {
         let c = self.db.borrow_mut();
         let mut blob = ptr::null_mut();
-        let db = db.as_cstring()?;
+        let db = db.as_cstr()?;
         let table = super::str_to_cstring(table)?;
         let column = super::str_to_cstring(column)?;
         let rc = unsafe {

--- a/src/inner_connection.rs
+++ b/src/inner_connection.rs
@@ -346,7 +346,7 @@ impl InnerConnection {
     fn remove_preupdate_hook(&mut self) {}
 
     pub fn db_readonly(&self, db_name: super::DatabaseName<'_>) -> Result<bool> {
-        let name = db_name.as_cstring()?;
+        let name = db_name.as_cstr()?;
         let r = unsafe { ffi::sqlite3_db_readonly(self.db, name.as_ptr()) };
         match r {
             0 => Ok(false),
@@ -368,7 +368,7 @@ impl InnerConnection {
         db_name: Option<super::DatabaseName<'_>>,
     ) -> Result<super::transaction::TransactionState> {
         let r = if let Some(ref name) = db_name {
-            let name = name.as_cstring()?;
+            let name = name.as_cstr()?;
             unsafe { ffi::sqlite3_txn_state(self.db, name.as_ptr()) }
         } else {
             unsafe { ffi::sqlite3_txn_state(self.db, ptr::null()) }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -381,15 +381,6 @@ impl DatabaseName<'_> {
             DatabaseName::C(cs)
         }
     }
-    #[cfg(feature = "hooks")]
-    pub(crate) fn from_cstr(db_name: &std::ffi::CStr) -> DatabaseName<'_> {
-        let s = db_name.to_str().expect("illegal database name");
-        match s {
-            "main" => DatabaseName::Main,
-            "temp" => DatabaseName::Temp,
-            _ => DatabaseName::Attached(s),
-        }
-    }
 }
 
 /// A connection to a SQLite database.

--- a/src/pragma.rs
+++ b/src/pragma.rs
@@ -47,6 +47,7 @@ impl Sql {
             DatabaseName::Main => self.buf.push_str("main"),
             DatabaseName::Temp => self.buf.push_str("temp"),
             DatabaseName::Attached(s) => self.push_identifier(s),
+            DatabaseName::C(s) => self.push_identifier(s.to_str().expect("invalid database name")),
         };
     }
 

--- a/src/serialize.rs
+++ b/src/serialize.rs
@@ -66,7 +66,7 @@ impl Deref for Data<'_> {
 impl Connection {
     /// Serialize a database.
     pub fn serialize(&self, schema: DatabaseName) -> Result<Data> {
-        let schema = schema.as_cstring()?;
+        let schema = schema.as_cstr()?;
         let mut sz = 0;
         let mut ptr: *mut u8 = unsafe {
             ffi::sqlite3_serialize(
@@ -102,7 +102,7 @@ impl Connection {
         data: OwnedData,
         read_only: bool,
     ) -> Result<()> {
-        let schema = schema.as_cstring()?;
+        let schema = schema.as_cstr()?;
         let (data, sz) = data.into_raw();
         let sz = sz.try_into().unwrap();
         let flags = if read_only {

--- a/src/session.rs
+++ b/src/session.rs
@@ -42,7 +42,7 @@ impl Session<'_> {
         db: &'conn Connection,
         name: DatabaseName<'_>,
     ) -> Result<Session<'conn>> {
-        let name = name.as_cstring()?;
+        let name = name.as_cstr()?;
 
         let db = db.db.borrow_mut().db;
 
@@ -154,7 +154,7 @@ impl Session<'_> {
 
     /// Load the difference between tables.
     pub fn diff(&mut self, from: DatabaseName<'_>, table: &str) -> Result<()> {
-        let from = from.as_cstring()?;
+        let from = from.as_cstr()?;
         let table = str_to_cstring(table)?;
         let table = table.as_ptr();
         unsafe {


### PR DESCRIPTION
No alloc for "main" and "temp".
No alloc possible when the attached database name is known at compile time / a C string literal can be usd.
No alloc when the database name is given by SQLite (`sqlite3_wal_hook`).