### PR TITLE
Switch deprecated target wasm32-wasi to wasm32-wasip1

### DIFF
--- a/examples/persons/README.md
+++ b/examples/persons/README.md
@@ -6,7 +6,7 @@
 $ cargo run --example persons
 ```
 
-## Run (wasm32-wasi)
+## Run (wasm32-wasip1)
 
 ### Requisites
 
@@ -18,9 +18,9 @@ $ cargo run --example persons
 $ export WASI_SDK_PATH=`<wasi-sdk-path>`
 $ export CC_wasm32_wasi="${WASI_SDK_PATH}/bin/clang --sysroot=${WASI_SDK_PATH}/share/wasi-sysroot"
 # Build
-$ cargo build --example persons --target wasm32-wasi --release --features bundled
+$ cargo build --example persons --target wasm32-wasip1 --release --features bundled
 # Run
-$ wasmtime target/wasm32-wasi/release/examples/persons.wasm
+$ wasmtime target/wasm32-wasip1/release/examples/persons.wasm
 Found persons:
 ID: 1, Name: Steven
 ID: 2, Name: John

--- a/libsqlite3-sys/build.rs
+++ b/libsqlite3-sys/build.rs
@@ -239,7 +239,9 @@ mod build_bundled {
         if !win_target() {
             cfg.flag("-DHAVE_LOCALTIME_R");
         }
-        if env::var("TARGET").map_or(false, |v| v.starts_with("wasm32-wasi")) {
+        if env::var("TARGET").map_or(false, |v| {
+            v.starts_with("wasm32-wasi") || v.starts_with("wasm32-wasip1")
+        }) {
             cfg.flag("-USQLITE_THREADSAFE")
                 .flag("-DSQLITE_THREADSAFE=0")
                 // https://github.com/rust-lang/rust/issues/74393


### PR DESCRIPTION
The rust target `wasm-wasi` is being replaced with more specific `wasm32-wasip1` target and `wams32-wasi` will be deprecated starting 2025 ([https://blog.rust-lang.org/2024/04/09/updates-to-rusts-wasi-targets.html](https://blog.rust-lang.org/2024/04/09/updates-to-rusts-wasi-targets.html)).

This change adds `wasm32-wasip1` to the build rules.