### PR TITLE
Remove release_memory feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,8 +43,6 @@ collation = []
 functions = []
 # sqlite3_log: 3.6.23 (2010-03-09)
 trace = []
-# sqlite3_db_release_memory: 3.7.10 (2012-01-16)
-release_memory = []
 bundled = ["libsqlite3-sys/bundled", "modern_sqlite"]
 bundled-sqlcipher = ["libsqlite3-sys/bundled-sqlcipher", "bundled"]
 bundled-sqlcipher-vendored-openssl = [

--- a/src/inner_connection.rs
+++ b/src/inner_connection.rs
@@ -382,7 +382,6 @@ impl InnerConnection {
     }
 
     #[inline]
-    #[cfg(feature = "release_memory")]
     pub fn release_memory(&self) -> Result<()> {
         self.decode_result(unsafe { ffi::sqlite3_db_release_memory(self.db) })
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -652,7 +652,6 @@ impl Connection {
     ///
     /// This calls [`sqlite3_db_release_memory`](https://www.sqlite.org/c3ref/db_release_memory.html).
     #[inline]
-    #[cfg(feature = "release_memory")]
     pub fn release_memory(&self) -> Result<()> {
         self.db.borrow_mut().release_memory()
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2287,4 +2287,10 @@ mod test {
         assert!(db.is_interrupted());
         Ok(())
     }
+
+    #[test]
+    fn release_memory() -> Result<()> {
+        let db = Connection::open_in_memory()?;
+        db.release_memory()
+    }
 }


### PR DESCRIPTION
Because `sqlite3_db_release_memory` is available in 3.14.0 (min version supported by rusqlite)
And:
<http://sqlite.org/c3ref/db_release_memory.html>
> Unlike the sqlite3_release_memory() interface, this interface is in effect even when the SQLITE_ENABLE_MEMORY_MANAGEMENT compile-time option is omitted.