### PR TITLE
add iterator wrapper for named query parameters

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -81,7 +81,9 @@ pub use crate::error::{to_sqlite_error, Error};
 pub use crate::ffi::ErrorCode;
 #[cfg(feature = "load_extension")]
 pub use crate::load_extension_guard::LoadExtensionGuard;
-pub use crate::params::{params_from_iter, Params, ParamsFromIter};
+pub use crate::params::{
+    params_from_iter, params_named_from_iter, Params, ParamsFromIter, ParamsNamedFromIter,
+};
 pub use crate::row::{AndThenRows, Map, MappedRows, Row, RowIndex, Rows};
 pub use crate::statement::{Statement, StatementStatus};
 #[cfg(feature = "modern_sqlite")]


### PR DESCRIPTION
This is like ParamsFromIter but with named parameters.

This is useful for the same reasons as ParamsFromIter. Sometimes you cannot use the macro and the Params implementations for arrays and tuples don't work either.