### PR TITLE
Add `pub use` to macros to make them usable to other crates

### DIFF
--- a/src/types/from_sql.rs
+++ b/src/types/from_sql.rs
@@ -107,6 +107,8 @@ macro_rules! from_sql_integral(
     )
 );
 
+pub use from_sql_integral;
+
 from_sql_integral!(i8);
 from_sql_integral!(i16);
 from_sql_integral!(i32);

--- a/src/types/to_sql.rs
+++ b/src/types/to_sql.rs
@@ -64,7 +64,7 @@ macro_rules! from_value(
     )
 );
 
-pub(crate) use from_value;
+pub use from_value;
 
 from_value!(String);
 from_value!(Null);
@@ -180,7 +180,7 @@ macro_rules! to_sql_self(
     )
 );
 
-pub(crate) use to_sql_self;
+pub use to_sql_self;
 
 to_sql_self!(Null);
 to_sql_self!(bool);
@@ -244,6 +244,8 @@ macro_rules! to_sql_self_fallible(
         }
     )
 );
+
+pub use to_sql_self_fallible;
 
 // Special implementations for usize and u64 because these conversions can fail.
 to_sql_self_fallible!(u64);

--- a/src/types/to_sql.rs
+++ b/src/types/to_sql.rs
@@ -63,6 +63,9 @@ macro_rules! from_value(
         }
     )
 );
+
+pub(crate) use from_value;
+
 from_value!(String);
 from_value!(Null);
 from_value!(bool);
@@ -176,6 +179,8 @@ macro_rules! to_sql_self(
         }
     )
 );
+
+pub(crate) use to_sql_self;
 
 to_sql_self!(Null);
 to_sql_self!(bool);


### PR DESCRIPTION
I intend to make the macros `to_sql_self`, `to_sql_self_fallible`, `from_value` and `from_sql_output` usable for other crates who intend their code to be interoperable with `rusqlite`. This means they can use the crate to make new implementations to be able to execute their values.
For example:
```rust
struct SQLType {
   value: i32,
   strings: String
}
to_sql_self!(SQLType)
```
This is needed due to the <a href="https://github.com/rust-lang/rust/issues/30191">Rust issue linked here.</a>
This will also help crate maintainers more easily implement the `ToSql` and `FromSql` traits.