### PR TITLE
Introduce Name trait to support both &str and &CStr as name

### DIFF
--- a/examples/loadable_extension.rs
+++ b/examples/loadable_extension.rs
@@ -36,7 +36,7 @@ pub unsafe extern "C" fn sqlite3_extension_init(
 
 fn extension_init(db: Connection) -> Result<bool> {
     db.create_scalar_function(
-        "rusqlite_test_function",
+        c"rusqlite_test_function",
         0,
         FunctionFlags::SQLITE_DETERMINISTIC,
         |_ctx| {

--- a/src/blob/mod.rs
+++ b/src/blob/mod.rs
@@ -192,7 +192,7 @@ use std::ptr;
 
 use super::ffi;
 use super::types::{ToSql, ToSqlOutput};
-use crate::{Connection, DatabaseName, Result};
+use crate::{Connection, Name, Result};
 
 mod pos_io;
 
@@ -215,19 +215,19 @@ impl Connection {
     /// C-compatible string or if the underlying SQLite BLOB open call
     /// fails.
     #[inline]
-    pub fn blob_open<'a>(
+    pub fn blob_open<'a, D: Name, N: Name>(
         &'a self,
-        db: DatabaseName<'_>,
-        table: &str,
-        column: &str,
+        db: D,
+        table: N,
+        column: N,
         row_id: i64,
         read_only: bool,
     ) -> Result<Blob<'a>> {
         let c = self.db.borrow_mut();
         let mut blob = ptr::null_mut();
         let db = db.as_cstr()?;
-        let table = super::str_to_cstring(table)?;
-        let column = super::str_to_cstring(column)?;
+        let table = table.as_cstr()?;
+        let column = column.as_cstr()?;
         let rc = unsafe {
             ffi::sqlite3_blob_open(
                 c.db(),
@@ -438,7 +438,7 @@ mod test {
     fn test_blob() -> Result<()> {
         let (db, rowid) = db_with_test_blob()?;
 
-        let mut blob = db.blob_open(DatabaseName::Main, "test", "content", rowid, false)?;
+        let mut blob = db.blob_open(DatabaseName::Main, c"test", c"content", rowid, false)?;
         assert!(!blob.is_empty());
         assert_eq!(10, blob.len());
         assert_eq!(4, blob.write(b"Clob").unwrap());
@@ -449,7 +449,7 @@ mod test {
         blob.reopen(rowid)?;
         blob.close()?;
 
-        blob = db.blob_open(DatabaseName::Main, "test", "content", rowid, true)?;
+        blob = db.blob_open(DatabaseName::Main, c"test", c"content", rowid, true)?;
         let mut bytes = [0u8; 5];
         assert_eq!(5, blob.read(&mut bytes[..]).unwrap());
         assert_eq!(&bytes, b"Clob5");
@@ -490,7 +490,7 @@ mod test {
     fn test_blob_in_bufreader() -> Result<()> {
         let (db, rowid) = db_with_test_blob()?;
 
-        let mut blob = db.blob_open(DatabaseName::Main, "test", "content", rowid, false)?;
+        let mut blob = db.blob_open(c"main", c"test", c"content", rowid, false)?;
         assert_eq!(8, blob.write(b"one\ntwo\n").unwrap());
 
         blob.reopen(rowid)?;
@@ -515,7 +515,7 @@ mod test {
         let (db, rowid) = db_with_test_blob()?;
 
         {
-            let blob = db.blob_open(DatabaseName::Main, "test", "content", rowid, false)?;
+            let blob = db.blob_open(DatabaseName::Main, c"test", c"content", rowid, false)?;
             let mut writer = BufWriter::new(blob);
 
             // trying to write too much and then flush should fail
@@ -526,14 +526,14 @@ mod test {
 
         {
             // ... but it should've written the first 10 bytes
-            let mut blob = db.blob_open(DatabaseName::Main, "test", "content", rowid, false)?;
+            let mut blob = db.blob_open(DatabaseName::Main, c"test", c"content", rowid, false)?;
             let mut bytes = [0u8; 10];
             assert_eq!(10, blob.read(&mut bytes[..]).unwrap());
             assert_eq!(b"0123456701", &bytes);
         }
 
         {
-            let blob = db.blob_open(DatabaseName::Main, "test", "content", rowid, false)?;
+            let blob = db.blob_open(DatabaseName::Main, c"test", c"content", rowid, false)?;
             let mut writer = BufWriter::new(blob);
 
             // trying to write_all too much should fail
@@ -543,7 +543,7 @@ mod test {
 
         {
             // ... but it should've written the first 10 bytes
-            let mut blob = db.blob_open(DatabaseName::Main, "test", "content", rowid, false)?;
+            let mut blob = db.blob_open(DatabaseName::Main, c"test", c"content", rowid, false)?;
             let mut bytes = [0u8; 10];
             assert_eq!(10, blob.read(&mut bytes[..]).unwrap());
             assert_eq!(b"aaaaaaaaaa", &bytes);

--- a/src/blob/pos_io.rs
+++ b/src/blob/pos_io.rs
@@ -203,7 +203,7 @@ mod test {
         db.execute("INSERT INTO test_table(content) VALUES (ZEROBLOB(10))", [])?;
 
         let rowid = db.last_insert_rowid();
-        let mut blob = db.blob_open(DatabaseName::Main, "test_table", "content", rowid, false)?;
+        let mut blob = db.blob_open(DatabaseName::Main, c"test_table", c"content", rowid, false)?;
         // modify the seek pos to ensure we aren't using it or modifying it.
         blob.seek(std::io::SeekFrom::Start(1)).unwrap();
 

--- a/src/collation.rs
+++ b/src/collation.rs
@@ -7,12 +7,12 @@ use std::slice;
 
 use crate::ffi;
 use crate::util::free_boxed_value;
-use crate::{str_to_cstring, Connection, InnerConnection, Result};
+use crate::{Connection, InnerConnection, Name, Result};
 
 impl Connection {
     /// Add or modify a collation.
     #[inline]
-    pub fn create_collation<C>(&self, collation_name: &str, x_compare: C) -> Result<()>
+    pub fn create_collation<C, N: Name>(&self, collation_name: N, x_compare: C) -> Result<()>
     where
         C: Fn(&str, &str) -> Ordering + Send + 'static,
     {
@@ -29,7 +29,7 @@ impl Connection {
 
     /// Remove collation.
     #[inline]
-    pub fn remove_collation(&self, collation_name: &str) -> Result<()> {
+    pub fn remove_collation<N: Name>(&self, collation_name: N) -> Result<()> {
         self.db.borrow_mut().remove_collation(collation_name)
     }
 }
@@ -57,7 +57,7 @@ impl InnerConnection {
     ///     Ok(())
     /// }
     /// ```
-    fn create_collation<C>(&mut self, collation_name: &str, x_compare: C) -> Result<()>
+    fn create_collation<C, N: Name>(&mut self, collation_name: N, x_compare: C) -> Result<()>
     where
         C: Fn(&str, &str) -> Ordering + Send + 'static,
     {
@@ -99,7 +99,7 @@ impl InnerConnection {
         }
 
         let boxed_f: *mut C = Box::into_raw(Box::new(x_compare));
-        let c_name = str_to_cstring(collation_name)?;
+        let c_name = collation_name.as_cstr()?;
         let flags = ffi::SQLITE_UTF8;
         let r = unsafe {
             ffi::sqlite3_create_collation_v2(
@@ -163,8 +163,8 @@ impl InnerConnection {
     }
 
     #[inline]
-    fn remove_collation(&mut self, collation_name: &str) -> Result<()> {
-        let c_name = str_to_cstring(collation_name)?;
+    fn remove_collation<N: Name>(&mut self, collation_name: N) -> Result<()> {
+        let c_name = collation_name.as_cstr()?;
         let r = unsafe {
             ffi::sqlite3_create_collation_v2(
                 self.db(),
@@ -193,7 +193,7 @@ mod test {
     #[test]
     fn test_unicase() -> Result<()> {
         let db = Connection::open_in_memory()?;
-        db.create_collation("unicase", unicase_compare)?;
+        db.create_collation(c"unicase", unicase_compare)?;
         collate(db)
     }
 
@@ -227,7 +227,7 @@ mod test {
     #[test]
     fn remove_collation() -> Result<()> {
         let db = Connection::open_in_memory()?;
-        db.create_collation("unicase", unicase_compare)?;
-        db.remove_collation("unicase")
+        db.create_collation(c"unicase", unicase_compare)?;
+        db.remove_collation(c"unicase")
     }
 }

--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -1,4 +1,4 @@
-use crate::{Connection, Result};
+use crate::{Connection, Name, Result};
 use std::ops::Deref;
 
 /// Options for transaction behavior. See [BEGIN
@@ -512,10 +512,7 @@ impl Connection {
     /// Determine the transaction state of a database
     #[cfg(feature = "modern_sqlite")] // 3.37.0
     #[cfg_attr(docsrs, doc(cfg(feature = "modern_sqlite")))]
-    pub fn transaction_state(
-        &self,
-        db_name: Option<crate::DatabaseName<'_>>,
-    ) -> Result<TransactionState> {
+    pub fn transaction_state<N: Name>(&self, db_name: Option<N>) -> Result<TransactionState> {
         self.db.borrow().txn_state(db_name)
     }
 
@@ -793,13 +790,13 @@ mod test {
             TransactionState::None,
             db.transaction_state(Some(DatabaseName::Main))?
         );
-        assert_eq!(TransactionState::None, db.transaction_state(None)?);
+        assert_eq!(TransactionState::None, db.transaction_state::<&str>(None)?);
         db.execute_batch("BEGIN")?;
-        assert_eq!(TransactionState::None, db.transaction_state(None)?);
+        assert_eq!(TransactionState::None, db.transaction_state::<&str>(None)?);
         let _: i32 = db.pragma_query_value(None, "user_version", |row| row.get(0))?;
-        assert_eq!(TransactionState::Read, db.transaction_state(None)?);
+        assert_eq!(TransactionState::Read, db.transaction_state::<&str>(None)?);
         db.pragma_update(None, "user_version", 1)?;
-        assert_eq!(TransactionState::Write, db.transaction_state(None)?);
+        assert_eq!(TransactionState::Write, db.transaction_state::<&str>(None)?);
         db.execute_batch("ROLLBACK")?;
         Ok(())
     }
@@ -812,17 +809,17 @@ mod test {
         db.execute_batch("CREATE TABLE t(i UNIQUE);")?;
         assert!(db.is_autocommit());
         let mut stmt = db.prepare("SELECT name FROM sqlite_master")?;
-        assert_eq!(TransactionState::None, db.transaction_state(None)?);
+        assert_eq!(TransactionState::None, db.transaction_state::<&str>(None)?);
         {
             let mut rows = stmt.query([])?;
             assert!(rows.next()?.is_some()); // start reading
-            assert_eq!(TransactionState::Read, db.transaction_state(None)?);
+            assert_eq!(TransactionState::Read, db.transaction_state::<&str>(None)?);
             db.execute("INSERT INTO t VALUES (1)", [])?; // auto-commit
-            assert_eq!(TransactionState::Read, db.transaction_state(None)?);
+            assert_eq!(TransactionState::Read, db.transaction_state::<&str>(None)?);
             assert!(rows.next()?.is_some()); // still reading
-            assert_eq!(TransactionState::Read, db.transaction_state(None)?);
+            assert_eq!(TransactionState::Read, db.transaction_state::<&str>(None)?);
             assert!(rows.next()?.is_none()); // end
-            assert_eq!(TransactionState::None, db.transaction_state(None)?);
+            assert_eq!(TransactionState::None, db.transaction_state::<&str>(None)?);
         }
         Ok(())
     }

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -12,3 +12,51 @@ pub(crate) use sqlite_string::{alloc, SqliteMallocString};
 pub(crate) unsafe extern "C" fn free_boxed_value<T>(p: *mut std::ffi::c_void) {
     drop(Box::from_raw(p.cast::<T>()));
 }
+
+use crate::{DatabaseName, Result};
+use std::ffi::CStr;
+
+pub enum Named<'a> {
+    Small(SmallCString),
+    C(&'a CStr),
+}
+impl std::ops::Deref for Named<'_> {
+    type Target = CStr;
+    #[inline]
+    fn deref(&self) -> &CStr {
+        match self {
+            Named::Small(s) => s.as_cstr(),
+            Named::C(s) => s,
+        }
+    }
+}
+
+/// Database, table, column, collation, function, module, vfs name
+pub trait Name: std::fmt::Debug {
+    /// FIXME
+    fn as_cstr(&self) -> Result<Named>;
+}
+impl Name for &str {
+    fn as_cstr(&self) -> Result<Named> {
+        let ss = SmallCString::new(self)?;
+        Ok(Named::Small(ss))
+    }
+}
+impl Name for &CStr {
+    #[inline]
+    fn as_cstr(&self) -> Result<Named> {
+        Ok(Named::C(self))
+    }
+}
+
+impl Name for DatabaseName<'_> {
+    #[inline]
+    fn as_cstr(&self) -> Result<Named> {
+        Ok(match self {
+            DatabaseName::Main => Named::C(c"main"),
+            DatabaseName::Temp => Named::C(c"temp"),
+            DatabaseName::Attached(s) => s.as_cstr()?,
+            DatabaseName::C(s) => Named::C(s),
+        })
+    }
+}

--- a/src/util/small_cstr.rs
+++ b/src/util/small_cstr.rs
@@ -5,7 +5,7 @@ use std::ffi::{CStr, CString, NulError};
 /// small enough. Also guarantees it's input is UTF-8 -- used for cases where we
 /// need to pass a NUL-terminated string to SQLite, and we have a `&str`.
 #[derive(Clone, PartialEq, Eq, PartialOrd, Ord)]
-pub(crate) struct SmallCString(SmallVec<[u8; 16]>);
+pub struct SmallCString(SmallVec<[u8; 16]>);
 
 impl SmallCString {
     #[inline]

--- a/src/vtab/array.rs
+++ b/src/vtab/array.rs
@@ -59,7 +59,7 @@ impl ToSql for Array {
 /// Register the "rarray" module.
 pub fn load_module(conn: &Connection) -> Result<()> {
     let aux: Option<()> = None;
-    conn.create_module("rarray", eponymous_only_module::<ArrayTab>(), aux)
+    conn.create_module(c"rarray", eponymous_only_module::<ArrayTab>(), aux)
 }
 
 // Column numbers

--- a/src/vtab/csvtab.rs
+++ b/src/vtab/csvtab.rs
@@ -48,7 +48,7 @@ use crate::{Connection, Error, Result};
 /// ```
 pub fn load_module(conn: &Connection) -> Result<()> {
     let aux: Option<()> = None;
-    conn.create_module("csv", read_only_module::<CsvTab>(), aux)
+    conn.create_module(c"csv", read_only_module::<CsvTab>(), aux)
 }
 
 /// An instance of the CSV virtual table

--- a/src/vtab/series.rs
+++ b/src/vtab/series.rs
@@ -17,7 +17,11 @@ use crate::{error::error_from_sqlite_code, Connection, Result};
 /// Register the `generate_series` module.
 pub fn load_module(conn: &Connection) -> Result<()> {
     let aux: Option<()> = None;
-    conn.create_module("generate_series", eponymous_only_module::<SeriesTab>(), aux)
+    conn.create_module(
+        c"generate_series",
+        eponymous_only_module::<SeriesTab>(),
+        aux,
+    )
 }
 
 // Column numbers

--- a/src/vtab/vtablog.rs
+++ b/src/vtab/vtablog.rs
@@ -14,7 +14,7 @@ use crate::{Connection, Error, Result};
 /// Register the "vtablog" module.
 pub fn load_module(conn: &Connection) -> Result<()> {
     let aux: Option<()> = None;
-    conn.create_module("vtablog", update_module::<VTabLog>(), aux)
+    conn.create_module(c"vtablog", update_module::<VTabLog>(), aux)
 }
 
 /// An instance of the vtablog virtual table

--- a/tests/vtab.rs
+++ b/tests/vtab.rs
@@ -85,7 +85,7 @@ fn test_dummy_module() -> rusqlite::Result<()> {
 
     let db = Connection::open_in_memory()?;
 
-    db.create_module::<DummyTab>("dummy", module, None)?;
+    db.create_module::<DummyTab, _>(c"dummy", module, None)?;
 
     let version = version_number();
     if version < 3_009_000 {


### PR DESCRIPTION
- [ ] remove `DatabaseName` ?
- [ ] fix `db_filename` (unsound ?)
- [ ] how to fix `Option<Name>` impact ?