### PR TITLE
added sqlite3_vtab_nochange() and sqlite3_value_nochange(x)

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -81,3 +81,9 @@ pub(super) unsafe fn set_result(
         }
     }
 }
+
+#[inline]
+#[must_use]
+pub(super) unsafe fn no_change(ctx: *mut sqlite3_context) -> bool {
+    ffi::sqlite3_vtab_nochange(ctx) != 0
+}


### PR DESCRIPTION
I noticed that these methods were stubbed out, so I added them at very low cost. Perhaps I misunderstood why they were stubbed but if not, here they are.