### PR TITLE
columns_with_metadata: access column metadata from prepared statement

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -76,7 +76,7 @@ in_gecko = ["modern_sqlite", "libsqlite3-sys/in_gecko"]
 bundled-windows = ["libsqlite3-sys/bundled-windows"]
 # Build bundled sqlite with -fsanitize=address
 with-asan = ["libsqlite3-sys/with-asan"]
-column_metadata = []
+column_metadata = ["libsqlite3-sys/column_metadata"]
 column_decltype = []
 wasm32-wasi-vfs = ["libsqlite3-sys/wasm32-wasi-vfs"]
 # 3.23.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -76,6 +76,7 @@ in_gecko = ["modern_sqlite", "libsqlite3-sys/in_gecko"]
 bundled-windows = ["libsqlite3-sys/bundled-windows"]
 # Build bundled sqlite with -fsanitize=address
 with-asan = ["libsqlite3-sys/with-asan"]
+column_metadata = []
 column_decltype = []
 wasm32-wasi-vfs = ["libsqlite3-sys/wasm32-wasi-vfs"]
 # 3.23.0
@@ -92,6 +93,7 @@ modern-full = [
     "modern_sqlite",
     "chrono",
     "collation",
+    "column_metadata",
     "column_decltype",
     "csvtab",
     "extra_check",

--- a/bindings.md
+++ b/bindings.md
@@ -120,9 +120,9 @@
 - [X] `sqlite3_column_count`
 - [ ] `sqlite3_data_count`
 - [X] `sqlite3_column_name`
-- [ ] `sqlite3_column_database_name`
-- [ ] `sqlite3_column_table_name`
-- [ ] `sqlite3_column_origin_name`
+- [X] `sqlite3_column_database_name`
+- [X] `sqlite3_column_table_name`
+- [X] `sqlite3_column_origin_name`
 - [X] `sqlite3_column_decltype`
 
 - [X] `sqlite3_step`

--- a/libsqlite3-sys/Cargo.toml
+++ b/libsqlite3-sys/Cargo.toml
@@ -26,6 +26,7 @@ bundled_bindings = []
 loadable_extension = ["prettyplease", "quote", "syn"]
 # sqlite3_unlock_notify >= 3.6.12
 unlock_notify = []
+column_metadata = []
 # 3.13.0
 preupdate_hook = ["buildtime_bindgen"]
 # 3.13.0

--- a/libsqlite3-sys/build.rs
+++ b/libsqlite3-sys/build.rs
@@ -256,6 +256,9 @@ mod build_bundled {
         if cfg!(feature = "unlock_notify") {
             cfg.flag("-DSQLITE_ENABLE_UNLOCK_NOTIFY");
         }
+        if cfg!(feature = "column_metadata") {
+            cfg.flag("-DSQLITE_ENABLE_COLUMN_METADATA");
+        }
         if cfg!(feature = "preupdate_hook") {
             cfg.flag("-DSQLITE_ENABLE_PREUPDATE_HOOK");
         }

--- a/src/column.rs
+++ b/src/column.rs
@@ -3,7 +3,7 @@ use std::str;
 use crate::{Error, Result, Statement};
 
 /// Information about a column of a SQLite query.
-#[cfg(any(feature = "column_decltype", feature = "column_metadata"))]
+#[cfg(feature = "column_decltype")]
 #[cfg_attr(docsrs, doc(cfg(feature = "column_decltype")))]
 #[derive(Debug)]
 pub struct Column<'stmt> {
@@ -11,7 +11,7 @@ pub struct Column<'stmt> {
     decl_type: Option<&'stmt str>,
 }
 
-#[cfg(any(feature = "column_decltype", feature = "column_metadata"))]
+#[cfg(feature = "column_decltype")]
 #[cfg_attr(docsrs, doc(cfg(feature = "column_decltype")))]
 impl Column<'_> {
     /// Returns the name of the column.

--- a/src/column.rs
+++ b/src/column.rs
@@ -195,6 +195,10 @@ impl Statement<'_> {
         cols
     }
 
+    // Returns the names of the database, table, and row from which
+    // each column of this query's results originate.
+    //
+    // Computed or otherwise derived columns will have None values for these fields.
     #[cfg(feature = "column_metadata")]
     pub fn columns_with_metadata(&self) -> Vec<ColumnMetadata> {
         let n = self.column_count();
@@ -259,8 +263,6 @@ mod test {
     #[test]
     #[cfg(feature = "column_metadata")]
     fn test_columns_with_metadata() -> Result<()> {
-        use super::Column;
-
         let db = Connection::open_in_memory()?;
         let query = db.prepare("SELECT * FROM sqlite_master")?;
 

--- a/src/column.rs
+++ b/src/column.rs
@@ -266,23 +266,20 @@ mod test {
 
         let col_mets = query.columns_with_metadata();
         for col in &col_mets {
-            assert_eq!(&col.database_name.map(str::to_lowercase), &Some("main".to_owned()));
-            assert_eq!(&col.table_name.map(str::to_lowercase), &Some("sqlite_master".to_owned()));
+            assert_eq!(&col.database_name, &Some("main"));
+            assert_eq!(&col.table_name, &Some("sqlite_master"));
         }
 
-        let col_origins: Vec<Option<String>> = col_mets
-            .iter()
-            .map(|col| col.origin_name.map(str::to_lowercase))
-            .collect();
+        let col_origins: Vec<Option<&str>> = col_mets.iter().map(|col| col.origin_name).collect();
 
         assert_eq!(
             &col_origins[..5],
             &[
-                Some("type".to_owned()),
-                Some("name".to_owned()),
-                Some("tbl_name".to_owned()),
-                Some("rootpage".to_owned()),
-                Some("sql".to_owned()),
+                Some("type"),
+                Some("name"),
+                Some("tbl_name"),
+                Some("rootpage"),
+                Some("sql"),
             ]
         );
 

--- a/src/column.rs
+++ b/src/column.rs
@@ -279,7 +279,6 @@ mod test {
         assert!(col_mets[5].table_name().is_none());
         assert!(col_mets[5].origin_name().is_none());
 
-
         let col_origins: Vec<Option<&str>> = col_mets.iter().map(|col| col.origin_name()).collect();
 
         assert_eq!(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -75,7 +75,7 @@ use crate::types::ValueRef;
 
 pub use crate::bind::BindIndex;
 pub use crate::cache::CachedStatement;
-#[cfg(feature = "column_decltype")]
+#[cfg(any(feature = "column_metadata", feature = "column_decltype"))]
 pub use crate::column::Column;
 pub use crate::error::{to_sqlite_error, Error};
 pub use crate::ffi::ErrorCode;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -75,7 +75,7 @@ use crate::types::ValueRef;
 
 pub use crate::bind::BindIndex;
 pub use crate::cache::CachedStatement;
-#[cfg(any(feature = "column_metadata", feature = "column_decltype"))]
+#[cfg(feature = "column_decltype")]
 pub use crate::column::Column;
 pub use crate::error::{to_sqlite_error, Error};
 pub use crate::ffi::ErrorCode;

--- a/src/raw_statement.rs
+++ b/src/raw_statement.rs
@@ -69,6 +69,45 @@ impl RawStatement {
     }
 
     #[inline]
+    #[cfg(feature = "column_metadata")]
+    pub fn column_database_name(&self, idx: usize) -> Option<&CStr> {
+        unsafe {
+            let db_name = ffi::sqlite3_column_database_name(self.ptr, idx as c_int);
+            if db_name.is_null() {
+                None
+            } else {
+                Some(CStr::from_ptr(db_name))
+            }
+        }
+    }
+
+    #[inline]
+    #[cfg(feature = "column_metadata")]
+    pub fn column_table_name(&self, idx: usize) -> Option<&CStr> {
+        unsafe {
+            let tbl_name = ffi::sqlite3_column_table_name(self.ptr, idx as c_int);
+            if tbl_name.is_null() {
+                None
+            } else {
+                Some(CStr::from_ptr(tbl_name))
+            }
+        }
+    }
+
+    #[inline]
+    #[cfg(feature = "column_metadata")]
+    pub fn column_origin_name(&self, idx: usize) -> Option<&CStr> {
+        unsafe {
+            let origin_name = ffi::sqlite3_column_origin_name(self.ptr, idx as c_int);
+            if origin_name.is_null() {
+                None
+            } else {
+                Some(CStr::from_ptr(origin_name))
+            }
+        }
+    }
+
+    #[inline]
     #[cfg(feature = "column_decltype")]
     pub fn column_decltype(&self, idx: usize) -> Option<&CStr> {
         unsafe {


### PR DESCRIPTION
A simple binding for the column metadata functions:

sqlite3_column_database_name
sqlite3_column_table_name
sqlite3_column_origin_name

No docs or tests but I am happy to add them if you are interested in the PR.

Cheers,
Jack