### PR TITLE
Replace use of function pointers with `Fn*` traits

### DIFF
--- a/src/busy.rs
+++ b/src/busy.rs
@@ -89,7 +89,11 @@ impl InnerConnection {
     #[inline]
     fn busy_timeout(&mut self, timeout: c_int) -> Result<()> {
         let r = unsafe { ffi::sqlite3_busy_timeout(self.db, timeout) };
-        self.decode_result(r)
+        let res = self.decode_result(r);
+        if res.is_ok() {
+            self.busy_handler = ThinBoxAny::default();
+        }
+        res
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -926,7 +926,7 @@ impl Connection {
         db: *mut ffi::sqlite3,
         pz_err_msg: *mut *mut c_char,
         p_api: *mut ffi::sqlite3_api_routines,
-        init: fn(Self) -> Result<bool>,
+        init: impl FnOnce(Self) -> Result<bool>,
     ) -> c_int {
         if p_api.is_null() {
             return ffi::SQLITE_ERROR;

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -1,8 +1,10 @@
 // Internal utilities
 pub(crate) mod param_cache;
 mod small_cstr;
+mod thin_box_any;
 pub(crate) use param_cache::ParamIndexCache;
 pub(crate) use small_cstr::SmallCString;
+pub(crate) use thin_box_any::ThinBoxAny;
 
 // Doesn't use any modern features or vtab stuff, but is only used by them.
 mod sqlite_string;

--- a/src/util/thin_box_any.rs
+++ b/src/util/thin_box_any.rs
@@ -1,0 +1,103 @@
+use std::mem;
+use std::mem::needs_drop;
+use std::ptr;
+use std::ptr::NonNull;
+
+/// Like `Option<Box<dyn Any>>`, but a single pointer in size.
+#[derive(Default)]
+pub(crate) struct ThinBoxAny(
+    /// A pointer to a function that will be called on drop. The function argument receives a
+    /// pointer to itself.
+    Option<NonNull<unsafe fn(*mut ())>>,
+);
+
+impl ThinBoxAny {
+    /// Heap-allocate some data, returning a pointer and the `ThinBoxAny` controlling its lifetime.
+    pub fn new<T: 'static>(data: T) -> (ThinBoxAny, *mut T) {
+        if size_of::<T>() == 0 {
+            let ptr = ptr::dangling_mut::<T>();
+
+            if needs_drop::<T>() {
+                // Make sure we don't double-drop the type.
+                mem::forget(data);
+
+                // The function that will be called on drop. We just materialize a value of the
+                // type (which is okay since it's zero-sized) and drop it.
+                let drop_function: &'static unsafe fn(*mut ()) =
+                    &const { |_| drop(unsafe { ptr::dangling_mut::<T>().read() }) };
+
+                (Self(Some(NonNull::from(drop_function))), ptr)
+            } else {
+                (Self(None), ptr)
+            }
+        } else {
+            // `repr(C)` ensures that a `*mut Heap<T>` can be converted to a
+            // `*mut unsafe fn(*mut ())`.
+            #[repr(C)]
+            struct Heap<T> {
+                drop: unsafe fn(*mut ()),
+                data: T,
+            }
+            let ptr = NonNull::from(Box::leak(Box::new(Heap {
+                drop: |ptr| drop(unsafe { Box::from_raw(ptr.cast::<Heap<T>>()) }),
+                data,
+            })));
+            let this = Self(Some(ptr.cast::<unsafe fn(*mut ())>()));
+            (this, unsafe { &mut (*ptr.as_ptr()).data })
+        }
+    }
+
+    /// Heap-allocate some data if it is `Some`, and return both a pointer to the data and the
+    /// `ThinBoxAny` that controls its lifetime.
+    pub fn new_option<T: 'static>(data: Option<T>) -> (ThinBoxAny, Option<*mut T>) {
+        match data {
+            Some(data) => {
+                let (boxed, ptr) = Self::new(data);
+                (boxed, Some(ptr))
+            }
+            None => (ThinBoxAny::default(), None),
+        }
+    }
+}
+
+impl Drop for ThinBoxAny {
+    fn drop(&mut self) {
+        if let Some(ptr) = self.0 {
+            unsafe { ptr.read()(ptr.as_ptr().cast()) };
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::ThinBoxAny;
+    use std::cell::Cell;
+
+    thread_local!(static COUNTER: Cell<u32> = const { Cell::new(0) });
+
+    struct Helper<T>(T);
+    impl<T> Drop for Helper<T> {
+        fn drop(&mut self) {
+            COUNTER.set(COUNTER.get() + 1);
+        }
+    }
+
+    #[test]
+    fn zst_with_drop() {
+        COUNTER.set(0);
+        let (boxed, _) = ThinBoxAny::new(Helper(()));
+        assert_eq!(COUNTER.get(), 0);
+        drop(boxed);
+        assert_eq!(COUNTER.get(), 1);
+    }
+
+    #[test]
+    fn non_zst_with_drop() {
+        COUNTER.set(0);
+        let (boxed, data) = ThinBoxAny::new(Helper(5_u32));
+        assert_eq!(unsafe { (*data).0 }, 5);
+        assert_eq!(COUNTER.get(), 0);
+        drop(boxed);
+        assert_eq!(COUNTER.get(), 1);
+    }
+}


### PR DESCRIPTION
This commit replaces all instances of methods accepting `fn(_) -> _` with `F: Fn(_) -> _`, for greater flexibility.

A new internal abstraction is introduced to facilitate this change: `ThinBoxAny`, a type similar to `Option<Box<dyn Any>>` but stored in a single pointer in order to avoid inflating the size of the `Connection` type too much.

There are two exceptions, the deprecated `trace` and `profile` functions. Users who need this flexibility should migrate to `trace_v2` instead.

This change is, unfortunately, breaking. There are two ways in which it breaks code:
+ Code that uses something like `.wal_hook(None)` will now get errors because Rust cannot infer the type parameter of `F`. Users must now write `.wal_hook(None::<fn(&Wal, _) -> _>)`.
+ Code that uses something like `.wal_hook(|hook, _| {})` will now fail, because Rust’s type inference of closures in the presence of HRTBs is limited. Instead, users should write `.wal_hook(|hook: &Wal, _| {})`.

The change is conservative for now, generally requiring `Fn` and `Sync` even when this may not be strictly necessary. It is likely many of these bounds can be relaxed in future.

Fixes: #977