### PR TITLE
Support virtual table IN interface

### DIFF
--- a/src/vtab/mod.rs
+++ b/src/vtab/mod.rs
@@ -516,14 +516,23 @@ impl IndexInfo {
     pub fn set_rhs_value(&mut self, constraint_idx: c_int, value: ValueRef) -> Result<()> {
         // TODO ValueRef to sqlite3_value
         crate::error::check(unsafe { ffi::sqlite3_vtab_rhs_value(self.O, constraint_idx, value) })
+    }*/
+
+    /// Returns whether this constraint was used in an IN query
+    #[cfg(feature = "modern_sqlite")] // SQLite >= 3.38.0
+    #[cfg_attr(docsrs, doc(cfg(feature = "modern_sqlite")))]
+    pub fn has_in_constraint(&self, constraint_idx: usize) -> bool {
+        unsafe { ffi::sqlite3_vtab_in(self.0, constraint_idx as _, -1) != 0 }
     }
 
-    /// Identify and handle IN constraints
+    /// Returns whether this constraint should be handled as an IN, meaning you can extract the IN values from inside the `filter()` vtable method.
     #[cfg(feature = "modern_sqlite")] // SQLite >= 3.38.0
-    pub fn set_in_constraint(&mut self, constraint_idx: c_int, b_handle: c_int) -> bool {
-        unsafe { ffi::sqlite3_vtab_in(self.0, constraint_idx, b_handle) != 0 }
-    } // TODO sqlite3_vtab_in_first / sqlite3_vtab_in_next https://sqlite.org/c3ref/vtab_in_first.html
-    */
+    #[cfg_attr(docsrs, doc(cfg(feature = "modern_sqlite")))]
+    pub fn handle_in_constraint(&self, constraint_idx: usize, handle: bool) {
+        unsafe {
+            ffi::sqlite3_vtab_in(self.0, constraint_idx as _, handle as c_int);
+        }
+    }
 }
 
 /// Iterate on index constraint and its associated usage.
@@ -747,6 +756,16 @@ impl Values<'_> {
         })
     }
 
+    /// Returns the IN values for a given value.
+    #[cfg(feature = "modern_sqlite")] // SQLite >= 3.22.0
+    #[cfg_attr(docsrs, doc(cfg(feature = "modern_sqlite")))]
+    pub fn in_values(&self, idx: usize) -> InValuesIter<'_> {
+        InValuesIter {
+            value: &self.args[idx],
+            is_first: true,
+        }
+    }
+
     // `sqlite3_value_type` returns `SQLITE_NULL` for pointer.
     // So it seems not possible to enhance `ValueRef::from_value`.
     #[cfg(feature = "array")]
@@ -773,7 +792,6 @@ impl Values<'_> {
             iter: self.args.iter(),
         }
     }
-    // TODO sqlite3_vtab_in_first / sqlite3_vtab_in_next https://sqlite.org/c3ref/vtab_in_first.html & 3.38.0
 }
 
 impl<'a> IntoIterator for &'a Values<'a> {
@@ -783,6 +801,39 @@ impl<'a> IntoIterator for &'a Values<'a> {
     #[inline]
     fn into_iter(self) -> ValueIter<'a> {
         self.iter()
+    }
+}
+
+/// [`Values`] iterator.
+pub struct InValuesIter<'a> {
+    value: &'a *mut ffi::sqlite3_value,
+    is_first: bool,
+}
+
+impl<'a> Iterator for InValuesIter<'a> {
+    type Item = ValueRef<'a>;
+
+    #[inline]
+    fn next(&mut self) -> Option<ValueRef<'a>> {
+        use libsqlite3_sys::SQLITE_OK;
+
+        let mut next = ptr::null_mut();
+        let res = if self.is_first {
+            unsafe { ffi::sqlite3_vtab_in_first(*self.value, &mut next) }
+        } else {
+            unsafe { ffi::sqlite3_vtab_in_next(*self.value, &mut next) }
+        };
+        if res == SQLITE_OK {
+            self.is_first = false;
+            Some(unsafe { ValueRef::from_value(next) })
+        } else {
+            None
+        }
+    }
+
+    #[inline]
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        (0, None)
     }
 }
 


### PR DESCRIPTION
I added support for the `sqlite_vtab_in`, `sqlite_vtab_in_first`, and `sqlite_vtab_in_next` interfaces. 

There is a current issue where the `Values` struct is being used unsafely in both the `filter` and `insert` methods, such that one might call the `sqlite_vtab_in` method incorrectly from an `insert()`, though the canonical term "Value" in sqlite refers to the Filter method, so I chose to improve that interface rather than create a new one.

The iterator of `sqlite_vtab_in_first/next` uses an iterator so remove copies, and the user must handle the values from inside that iteration themselves.

While I didn't check it in, I created this test to confirm the behavior, but it doesn't feel like a good fit to keep in the repo long term. Perhaps a better test could be written.

```rs
//! Ensure Virtual tables can be declared outside `rusqlite` crate.

#[cfg(feature = "vtab")]
#[test]
fn test_dummy_module() -> rusqlite::Result<()> {
    use rusqlite::vtab::{
        eponymous_only_module, sqlite3_vtab, sqlite3_vtab_cursor, Context, IndexInfo, VTab,
        VTabConnection, VTabCursor, Values,
    };
    use rusqlite::{version_number, Connection, Result};
    use std::marker::PhantomData;
    use std::os::raw::c_int;

    let module = eponymous_only_module::<DummyTab>();

    #[repr(C)]
    struct DummyTab {
        /// Base class. Must be first
        base: sqlite3_vtab,
    }

    unsafe impl<'vtab> VTab<'vtab> for DummyTab {
        type Aux = ();
        type Cursor = DummyTabCursor<'vtab>;

        fn connect(
            _: &mut VTabConnection,
            _aux: Option<&()>,
            _args: &[&[u8]],
        ) -> Result<(String, Self)> {
            let vtab = Self {
                base: sqlite3_vtab::default(),
            };
            Ok(("CREATE TABLE x(value)".to_owned(), vtab))
        }

        fn best_index(&self, info: &mut IndexInfo) -> Result<()> {
            // We approve the ability to use the IN constraint here
            for (i, _) in info.constraints().enumerate() {
                if info.has_in_constraint(i) {
                    info.handle_in_constraint(i, true);
                }
            }
            for (i, (_, mut u)) in info.constraints_and_usages().enumerate() {
                u.set_argv_index(i as i32 + 1);
                u.set_omit(true);
            }
            info.set_estimated_cost(1.);
            Ok(())
        }

        fn open(&'vtab mut self) -> Result<DummyTabCursor<'vtab>> {
            Ok(DummyTabCursor::default())
        }
    }

    #[derive(Default)]
    #[repr(C)]
    struct DummyTabCursor<'vtab> {
        /// Base class. Must be first
        base: sqlite3_vtab_cursor,
        /// The rowid
        row_id: i64,
        phantom: PhantomData<&'vtab DummyTab>,
    }

    unsafe impl VTabCursor for DummyTabCursor<'_> {
        fn filter(
            &mut self,
            _idx_num: c_int,
            _idx_str: Option<&str>,
            args: &Values<'_>,
        ) -> Result<()> {
            // Because we are doing an IN query where the row ids are 0,1,2, etc.,
            // we can simply assert that the value is equal to the index.
            for (i, value) in args.in_values(0).enumerate() {
                assert_eq!(i as i64, value.as_i64()?);
            }
            Ok(())
        }

        fn next(&mut self) -> Result<()> {
            self.row_id += 1;
            Ok(())
        }

        fn eof(&self) -> bool {
            self.row_id > 2
        }

        fn column(&self, ctx: &mut Context, _: c_int) -> Result<()> {
            ctx.set_result(&self.row_id)
        }

        fn rowid(&self) -> Result<i64> {
            Ok(self.row_id)
        }
    }

    let db = Connection::open_in_memory()?;

    db.create_module::<DummyTab, _>(c"dummy", module, None)?;

    let version = version_number();
    if version < 3_009_000 {
        return Ok(());
    }

    // Important: generate a sequence of 0..=2
    let mut s = db.prepare("SELECT rowid FROM dummy() WHERE rowid IN (0,1,2)")?;
    let mut dummy = s.query_map([], |row| row.get::<_, i32>(0))?;
    for i in 0..=2 {
        assert_eq!(i, dummy.next().unwrap().unwrap());
    }
    Ok(())
}
```