### PR TITLE
Add `FromSqlError::other` convenience conversion

### DIFF
--- a/src/types/chrono.rs
+++ b/src/types/chrono.rs
@@ -20,10 +20,7 @@ impl FromSql for NaiveDate {
     fn column_result(value: ValueRef<'_>) -> FromSqlResult<Self> {
         value
             .as_str()
-            .and_then(|s| match Self::parse_from_str(s, "%F") {
-                Ok(dt) => Ok(dt),
-                Err(err) => Err(FromSqlError::Other(Box::new(err))),
-            })
+            .and_then(|s| Self::parse_from_str(s, "%F").map_err(FromSqlError::other))
     }
 }
 
@@ -45,10 +42,7 @@ impl FromSql for NaiveTime {
                 8 => "%T",
                 _ => "%T%.f",
             };
-            match Self::parse_from_str(s, fmt) {
-                Ok(dt) => Ok(dt),
-                Err(err) => Err(FromSqlError::Other(Box::new(err))),
-            }
+            Self::parse_from_str(s, fmt).map_err(FromSqlError::other)
         })
     }
 }
@@ -75,10 +69,7 @@ impl FromSql for NaiveDateTime {
                 "%F %T%.f"
             };
 
-            match Self::parse_from_str(s, fmt) {
-                Ok(dt) => Ok(dt),
-                Err(err) => Err(FromSqlError::Other(Box::new(err))),
-            }
+            Self::parse_from_str(s, fmt).map_err(FromSqlError::other)
         })
     }
 }
@@ -152,7 +143,7 @@ impl FromSql for DateTime<FixedOffset> {
         let s = String::column_result(value)?;
         Self::parse_from_rfc3339(s.as_str())
             .or_else(|_| Self::parse_from_str(s.as_str(), "%F %T%.f%:z"))
-            .map_err(|e| FromSqlError::Other(Box::new(e)))
+            .map_err(FromSqlError::other)
     }
 }
 

--- a/src/types/from_sql.rs
+++ b/src/types/from_sql.rs
@@ -28,6 +28,18 @@ pub enum FromSqlError {
     Other(Box<dyn Error + Send + Sync + 'static>),
 }
 
+impl FromSqlError {
+    /// Converts an arbitrary error type to [`FromSqlError`].
+    ///
+    /// This is a convenience function that boxes and unsizes the error type. It's main purpose is
+    /// to be usable in the `map_err` method. So instead of
+    /// `result.map_err(|error| FromSqlError::Other(Box::new(error))` you can write
+    /// `result.map_err(FromSqlError::other)`.
+    pub fn other<E: Error + Send + Sync + 'static>(error: E) -> Self {
+        Self::Other(Box::new(error))
+    }
+}
+
 impl PartialEq for FromSqlError {
     fn eq(&self, other: &Self) -> bool {
         match (self, other) {

--- a/src/types/jiff.rs
+++ b/src/types/jiff.rs
@@ -4,7 +4,6 @@ use jiff::{
     civil::{Date, DateTime, Time},
     Timestamp,
 };
-use std::str::FromStr;
 
 use crate::types::{FromSql, FromSqlError, FromSqlResult, ToSql, ToSqlOutput, ValueRef};
 use crate::Result;
@@ -22,10 +21,9 @@ impl ToSql for Date {
 impl FromSql for Date {
     #[inline]
     fn column_result(value: ValueRef<'_>) -> FromSqlResult<Self> {
-        value.as_str().and_then(|s| match Self::from_str(s) {
-            Ok(d) => Ok(d),
-            Err(err) => Err(FromSqlError::Other(Box::new(err))),
-        })
+        value
+            .as_str()
+            .and_then(|s| s.parse().map_err(FromSqlError::other))
     }
 }
 /// time => "HH:MM:SS.SSS"
@@ -40,10 +38,9 @@ impl ToSql for Time {
 /// "HH:MM:SS.SSS" => time.
 impl FromSql for Time {
     fn column_result(value: ValueRef<'_>) -> FromSqlResult<Self> {
-        value.as_str().and_then(|s| match Self::from_str(s) {
-            Ok(t) => Ok(t),
-            Err(err) => Err(FromSqlError::Other(Box::new(err))),
-        })
+        value
+            .as_str()
+            .and_then(|s| s.parse().map_err(FromSqlError::other))
     }
 }
 
@@ -59,10 +56,9 @@ impl ToSql for DateTime {
 /// "YYYY-MM-DDTHH:MM:SS.SSS" => Gregorian datetime.
 impl FromSql for DateTime {
     fn column_result(value: ValueRef<'_>) -> FromSqlResult<Self> {
-        value.as_str().and_then(|s| match Self::from_str(s) {
-            Ok(dt) => Ok(dt),
-            Err(err) => Err(FromSqlError::Other(Box::new(err))),
-        })
+        value
+            .as_str()
+            .and_then(|s| s.parse().map_err(FromSqlError::other))
     }
 }
 
@@ -81,7 +77,7 @@ impl FromSql for Timestamp {
         value
             .as_str()?
             .parse::<Timestamp>()
-            .map_err(|err| FromSqlError::Other(Box::new(err)))
+            .map_err(FromSqlError::other)
     }
 }
 

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -52,7 +52,7 @@ impl FromSql for DateTimeSql {
         i64::column_result(value).and_then(|as_i64| {
             time::OffsetDateTime::from_unix_timestamp(as_i64)
             .map(|odt| DateTimeSql(odt))
-            .map_err(|err| FromSqlError::Other(Box::new(err)))
+            .map_err(FromSqlError::other)
         })
     }
 }

--- a/src/types/serde_json.rs
+++ b/src/types/serde_json.rs
@@ -56,7 +56,7 @@ impl FromSql for Value {
             }
             ValueRef::Null => Ok(Self::Null),
         }
-        .map_err(|err| FromSqlError::Other(Box::new(err)))
+        .map_err(FromSqlError::other)
     }
 }
 

--- a/src/types/time.rs
+++ b/src/types/time.rs
@@ -69,18 +69,16 @@ impl FromSql for OffsetDateTime {
         value.as_str().and_then(|s| {
             if let Some(b' ') = s.as_bytes().get(23) {
                 // legacy
-                return Self::parse(s, &LEGACY_DATE_TIME_FORMAT)
-                    .map_err(|err| FromSqlError::Other(Box::new(err)));
+                return Self::parse(s, &LEGACY_DATE_TIME_FORMAT).map_err(FromSqlError::other);
             }
             if s[8..].contains('+') || s[8..].contains('-') {
                 // Formats 2-7 with timezone
-                return Self::parse(s, &OFFSET_DATE_TIME_FORMAT)
-                    .map_err(|err| FromSqlError::Other(Box::new(err)));
+                return Self::parse(s, &OFFSET_DATE_TIME_FORMAT).map_err(FromSqlError::other);
             }
             // Formats 2-7 without timezone
             PrimitiveDateTime::parse(s, &UTC_DATE_TIME_FORMAT)
                 .map(|p| p.assume_utc())
-                .map_err(|err| FromSqlError::Other(Box::new(err)))
+                .map_err(FromSqlError::other)
         })
     }
 }

--- a/src/types/url.rs
+++ b/src/types/url.rs
@@ -17,8 +17,8 @@ impl FromSql for Url {
     fn column_result(value: ValueRef<'_>) -> FromSqlResult<Self> {
         match value {
             ValueRef::Text(s) => {
-                let s = std::str::from_utf8(s).map_err(|e| FromSqlError::Other(Box::new(e)))?;
-                Self::parse(s).map_err(|e| FromSqlError::Other(Box::new(e)))
+                let s = std::str::from_utf8(s).map_err(FromSqlError::other)?;
+                Self::parse(s).map_err(FromSqlError::other)
             }
             _ => Err(FromSqlError::InvalidType),
         }

--- a/src/types/value_ref.rs
+++ b/src/types/value_ref.rs
@@ -84,9 +84,7 @@ impl<'a> ValueRef<'a> {
     #[inline]
     pub fn as_str(&self) -> FromSqlResult<&'a str> {
         match *self {
-            ValueRef::Text(t) => {
-                std::str::from_utf8(t).map_err(|e| FromSqlError::Other(Box::new(e)))
-            }
+            ValueRef::Text(t) => std::str::from_utf8(t).map_err(FromSqlError::other),
             _ => Err(FromSqlError::InvalidType),
         }
     }
@@ -99,7 +97,7 @@ impl<'a> ValueRef<'a> {
         match *self {
             ValueRef::Null => Ok(None),
             ValueRef::Text(t) => std::str::from_utf8(t)
-                .map_err(|e| FromSqlError::Other(Box::new(e)))
+                .map_err(FromSqlError::other)
                 .map(Some),
             _ => Err(FromSqlError::InvalidType),
         }


### PR DESCRIPTION
When implementing `FromSql` it is common (as demonstrated by this commit diff) to call into a lower-level parsing function (such as `str::from_utf8`) and then convert the returned error to `FromSqlError::Other`. However this required manual boxing and unsizing which made the code a bit annoying. Thus this commit introduces an `other` generic method intentionally named after the `Other` variant. This method performs the boxing and unsizing so that callers can use it instead of writing a closure with `Box::new` (if `map_err` is used).

This commit also replaces all such occurrences in the `rusqlite`'s code which not only simplifies the code but also demonstrates the usefulness of the method. Incidentally, the change also simplifies manual `match`es to use `map_err` instead as well as replaces `FromStr` with the more idiomatic `parse` method in the those places.