### PR TITLE
Fix clippy error

### DIFF
--- a/src/vtab/series.rs
+++ b/src/vtab/series.rs
@@ -194,7 +194,7 @@ impl SeriesTabCursor<'_> {
         }
     }
 }
-#[expect(clippy::comparison_chain)]
+
 unsafe impl VTabCursor for SeriesTabCursor<'_> {
     fn filter(&mut self, idx_num: c_int, _idx_str: Option<&str>, args: &Filters<'_>) -> Result<()> {
         let mut idx_num = QueryPlanFlags::from_bits_truncate(idx_num);


### PR DESCRIPTION
```
error: this lint expectation is unfulfilled
   --> src/vtab/series.rs:197:10
    |
197 | #[expect(clippy::comparison_chain)]
```