### PR TITLE
Disable u64, usize ToSql/FromSql impl by default

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -66,8 +66,8 @@ jobs:
         if: matrix.os == 'windows-latest'
         run: echo "C:\msys64\mingw64\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
 
-      - run: cargo test --features 'bundled-full session buildtime_bindgen preupdate_hook' --all-targets --workspace --verbose
-      - run: cargo test --features 'bundled-full session buildtime_bindgen preupdate_hook' --doc --workspace --verbose
+      - run: cargo test --features 'bundled-full session buildtime_bindgen fallible_uint preupdate_hook' --all-targets --workspace --verbose
+      - run: cargo test --features 'bundled-full session buildtime_bindgen fallible_uint preupdate_hook' --doc --workspace --verbose
 
       - name: loadable extension
         run: |
@@ -227,7 +227,7 @@ jobs:
         run: |
           cargo test --verbose
           cargo test --features="bundled-full" --verbose
-          cargo test --features="bundled-full session buildtime_bindgen preupdate_hook load_extension" --all --all-targets --verbose
+          cargo test --features="bundled-full session buildtime_bindgen fallible_uint preupdate_hook load_extension" --all --all-targets --verbose
           cargo test --features="bundled-sqlcipher-vendored-openssl" --verbose
         env:
           RUSTFLAGS: -Cinstrument-coverage

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -208,7 +208,7 @@ jobs:
       - uses: hecrj/setup-rust-action@v2
       - uses: Swatinem/rust-cache@v2
         with: { shared-key: fullBuild }
-      - run: cargo doc --features 'bundled-full session buildtime_bindgen preupdate_hook' --no-deps
+      - run: cargo doc --features 'bundled-full session buildtime_bindgen fallible_uint preupdate_hook' --no-deps
         env: { RUSTDOCFLAGS: -Dwarnings }
 
   codecov:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,6 +57,8 @@ loadable_extension = ["libsqlite3-sys/loadable_extension"]
 hooks = []
 # if SQLITE_ENABLE_PREUPDATE_HOOK
 preupdate_hook = ["libsqlite3-sys/preupdate_hook", "hooks"]
+# u64, usize, NonZeroU64, NonZeroUsize
+fallible_uint = []
 i128_blob = []
 sqlcipher = ["libsqlite3-sys/sqlcipher"]
 # SQLITE_ENABLE_UNLOCK_NOTIFY

--- a/README.md
+++ b/README.md
@@ -132,6 +132,7 @@ features](https://doc.rust-lang.org/cargo/reference/manifest.html#the-features-s
 * `series` exposes [`generate_series(...)`](https://www.sqlite.org/series.html) Table-Valued Function. (Implies `vtab`.)
 * [`csvtab`](https://sqlite.org/csv.html), CSV virtual table written in Rust. (Implies `vtab`.)
 * [`array`](https://sqlite.org/carray.html), The `rarray()` Table-Valued Function. (Implies `vtab`.)
+* `fallible_uint` allows storing values of type `u64`, `usize`, `NonZeroU64`, `NonZeroUsize` but only if <= `i64::MAX`.
 * `i128_blob` allows storing values of type `i128` type in SQLite databases. Internally, the data is stored as a 16 byte big-endian blob, with the most significant bit flipped, which allows ordering and comparison between different blobs storing i128s to work as expected.
 * `uuid` allows storing and retrieving `Uuid` values from the [`uuid`](https://docs.rs/uuid/) crate using blobs.
 * [`session`](https://sqlite.org/sessionintro.html), Session module extension. Requires `buildtime_bindgen` feature. (Implies `hooks`.)

--- a/src/functions.rs
+++ b/src/functions.rs
@@ -1179,18 +1179,20 @@ mod test {
 
     #[test]
     fn test_blob() -> Result<()> {
-        fn test_len(ctx: &Context<'_>) -> Result<usize> {
+        fn test_len(ctx: &Context<'_>) -> Result<u32> {
             let blob = ctx.get_raw(0);
-            Ok(blob.as_bytes_or_null()?.map_or(0, |b| b.len()))
+            Ok(blob
+                .as_bytes_or_null()?
+                .map_or(0, |b| b.len().try_into().unwrap()))
         }
         let db = Connection::open_in_memory()?;
         db.create_scalar_function("test_len", 1, FunctionFlags::SQLITE_DETERMINISTIC, test_len)?;
         assert_eq!(
             6,
-            db.one_column::<usize, _>("SELECT test_len(X'53514C697465');", [])?
+            db.one_column::<u32, _>("SELECT test_len(X'53514C697465');", [])?
         );
-        assert_eq!(0, db.one_column::<usize, _>("SELECT test_len(X'');", [])?);
-        assert_eq!(0, db.one_column::<usize, _>("SELECT test_len(NULL);", [])?);
+        assert_eq!(0, db.one_column::<u32, _>("SELECT test_len(X'');", [])?);
+        assert_eq!(0, db.one_column::<u32, _>("SELECT test_len(NULL);", [])?);
         Ok(())
     }
 }

--- a/src/types/from_sql.rs
+++ b/src/types/from_sql.rs
@@ -127,7 +127,9 @@ from_sql_integral!(isize);
 from_sql_integral!(u8);
 from_sql_integral!(u16);
 from_sql_integral!(u32);
+#[cfg(feature = "fallible_uint")]
 from_sql_integral!(u64);
+#[cfg(feature = "fallible_uint")]
 from_sql_integral!(usize);
 
 from_sql_integral!(non_zero std::num::NonZeroIsize, isize);
@@ -138,10 +140,12 @@ from_sql_integral!(non_zero std::num::NonZeroI64, i64);
 #[cfg(feature = "i128_blob")]
 from_sql_integral!(non_zero std::num::NonZeroI128, i128);
 
+#[cfg(feature = "fallible_uint")]
 from_sql_integral!(non_zero std::num::NonZeroUsize, usize);
 from_sql_integral!(non_zero std::num::NonZeroU8, u8);
 from_sql_integral!(non_zero std::num::NonZeroU16, u16);
 from_sql_integral!(non_zero std::num::NonZeroU32, u32);
+#[cfg(feature = "fallible_uint")]
 from_sql_integral!(non_zero std::num::NonZeroU64, u64);
 // std::num::NonZeroU128 is not supported since u128 isn't either
 
@@ -394,11 +398,13 @@ mod test {
             &[0, -2, -1, 4_294_967_296],
             &[1, 4_294_967_295]
         );
+        #[cfg(feature = "fallible_uint")]
         check_ranges!(
             std::num::NonZeroU64,
             &[0, -2, -1, -4_294_967_296],
             &[1, 4_294_967_295, i64::MAX as u64]
         );
+        #[cfg(feature = "fallible_uint")]
         check_ranges!(
             std::num::NonZeroUsize,
             &[0, -2, -1, -4_294_967_296],

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -412,12 +412,18 @@ mod test {
         test_conversion!(db_etc, 200u8, u8, expect 200u8);
         test_conversion!(db_etc, 100u16, i8, expect 100i8);
         test_conversion!(db_etc, 200u16, u8, expect 200u8);
+        #[cfg(feature = "fallible_uint")]
         test_conversion!(db_etc, u32::MAX, u64, expect u32::MAX as u64);
+
         test_conversion!(db_etc, i64::MIN, i64, expect i64::MIN);
         test_conversion!(db_etc, i64::MAX, i64, expect i64::MAX);
+        #[cfg(feature = "fallible_uint")]
         test_conversion!(db_etc, i64::MAX, u64, expect i64::MAX as u64);
+        #[cfg(feature = "fallible_uint")]
         test_conversion!(db_etc, 100usize, usize, expect 100usize);
+        #[cfg(feature = "fallible_uint")]
         test_conversion!(db_etc, 100u64, u64, expect 100u64);
+        #[cfg(feature = "fallible_uint")]
         test_conversion!(db_etc, i64::MAX as u64, u64, expect i64::MAX as u64);
 
         // Out-of-range integral conversions.
@@ -425,9 +431,13 @@ mod test {
         test_conversion!(db_etc, 400u16, i8, expect_from_sql_error);
         test_conversion!(db_etc, 400u16, u8, expect_from_sql_error);
         test_conversion!(db_etc, -1i8, u8, expect_from_sql_error);
+        #[cfg(feature = "fallible_uint")]
         test_conversion!(db_etc, i64::MIN, u64, expect_from_sql_error);
+        #[cfg(feature = "fallible_uint")]
         test_conversion!(db_etc, u64::MAX, i64, expect_to_sql_error);
+        #[cfg(feature = "fallible_uint")]
         test_conversion!(db_etc, u64::MAX, u64, expect_to_sql_error);
+        #[cfg(feature = "fallible_uint")]
         test_conversion!(db_etc, i64::MAX as u64 + 1, u64, expect_to_sql_error);
 
         // FromSql integer to float, always works.

--- a/src/types/to_sql.rs
+++ b/src/types/to_sql.rs
@@ -1,7 +1,9 @@
 use super::{Null, Value, ValueRef};
 #[cfg(feature = "array")]
 use crate::vtab::array::Array;
-use crate::{Error, Result};
+#[cfg(feature = "fallible_uint")]
+use crate::Error;
+use crate::Result;
 use std::borrow::Cow;
 
 /// `ToSqlOutput` represents the possible output types for implementers of the
@@ -202,6 +204,7 @@ to_sql_self!(std::num::NonZeroI128);
 #[cfg(feature = "uuid")]
 to_sql_self!(uuid::Uuid);
 
+#[cfg(feature = "fallible_uint")]
 macro_rules! to_sql_self_fallible(
     ($t:ty) => (
         impl ToSql for $t {
@@ -232,9 +235,13 @@ macro_rules! to_sql_self_fallible(
 );
 
 // Special implementations for usize and u64 because these conversions can fail.
+#[cfg(feature = "fallible_uint")]
 to_sql_self_fallible!(u64);
+#[cfg(feature = "fallible_uint")]
 to_sql_self_fallible!(usize);
+#[cfg(feature = "fallible_uint")]
 to_sql_self_fallible!(non_zero std::num::NonZeroU64);
+#[cfg(feature = "fallible_uint")]
 to_sql_self_fallible!(non_zero std::num::NonZeroUsize);
 
 impl<T: ?Sized> ToSql for &'_ T
@@ -329,7 +336,9 @@ mod test {
         is_to_sql::<u8>();
         is_to_sql::<u16>();
         is_to_sql::<u32>();
+        #[cfg(feature = "fallible_uint")]
         is_to_sql::<u64>();
+        #[cfg(feature = "fallible_uint")]
         is_to_sql::<usize>();
     }
 
@@ -343,7 +352,9 @@ mod test {
         is_to_sql::<std::num::NonZeroU8>();
         is_to_sql::<std::num::NonZeroU16>();
         is_to_sql::<std::num::NonZeroU32>();
+        #[cfg(feature = "fallible_uint")]
         is_to_sql::<std::num::NonZeroU64>();
+        #[cfg(feature = "fallible_uint")]
         is_to_sql::<std::num::NonZeroUsize>();
     }
 

--- a/src/types/to_sql.rs
+++ b/src/types/to_sql.rs
@@ -116,7 +116,7 @@ impl ToSql for ToSqlOutput<'_> {
 }
 
 /// A trait for types that can be converted into SQLite values. Returns
-/// [`Error::ToSqlConversionFailure`] if the conversion fails.
+/// [`crate::Error::ToSqlConversionFailure`] if the conversion fails.
 pub trait ToSql {
     /// Converts Rust value to SQLite value
     fn to_sql(&self) -> Result<ToSqlOutput<'_>>;


### PR DESCRIPTION
Use `fallible_uint` feature to have them back
Fix #1722