### PR TITLE
Use CARGO_CFG_TARGET_FEATURE for crt-static check

### DIFF
--- a/libsqlite3-sys/build.rs
+++ b/libsqlite3-sys/build.rs
@@ -239,7 +239,10 @@ mod build_bundled {
 
         // If explicitly requested: enable static linking against the Microsoft Visual
         // C++ Runtime to avoid dependencies on vcruntime140.dll and similar libraries.
-        if cfg!(target_feature = "crt-static") && is_compiler("msvc") {
+        if env::var("CARGO_CFG_TARGET_FEATURE")
+            .is_ok_and(|v| v.split(',').any(|tf| tf == "crt-static"))
+            && is_compiler("msvc")
+        {
             cfg.static_crt(true);
         }
 


### PR DESCRIPTION
This change checks crt-static in the CARGO_CFG_TARGET_FEATURE environment variable instead of directly using the cfg!() macro. These can differ when cross-compiling from another platform.