### PR TITLE
Remove shell scripts from the published package

### DIFF
--- a/libsqlite3-sys/Cargo.toml
+++ b/libsqlite3-sys/Cargo.toml
@@ -10,6 +10,7 @@ links = "sqlite3"
 build = "build.rs"
 keywords = ["sqlite", "sqlcipher", "ffi"]
 categories = ["external-ffi-bindings"]
+exclude = ["**/*.sh"]
 
 [features]
 default = ["min_sqlite_version_3_14_0"]


### PR DESCRIPTION
This commit removes shell scripts from the published package. These were reported by cargo denys `bans.build.interpreted` setting and they seem to be not required for building the crate.