### PR TITLE
Bump litrs to 1.0.0

### DIFF
--- a/rusqlite-macros/Cargo.toml
+++ b/rusqlite-macros/Cargo.toml
@@ -14,4 +14,4 @@ proc-macro = true
 [dependencies]
 sqlite3-parser = { version = "0.15", default-features = false, features = ["YYNOERRORRECOVERY"] }
 fallible-iterator = "0.3"
-litrs = { version = "0.5", default-features = false }
+litrs = "1.0.0"


### PR DESCRIPTION
The `default-features = false` is not necessary anymore, as there are no default-features in 1.0