### PR TITLE
sqlite3_vtab_rhs_value

### DIFF
--- a/bindings.md
+++ b/bindings.md
@@ -219,6 +219,7 @@
 - [X] `sqlite3_load_extension`
 - [X] `sqlite3_enable_load_extension`
 - [X] `sqlite3_auto_extension` (`fn` callbak with Connection ref)
+- [X] `sqlite3_cancel_auto_extension`
 - [X] `sqlite3_reset_auto_extension`
 
 - [ ] `sqlite3_create_module`
@@ -295,7 +296,7 @@
 - [ ] `sqlite3_vtab_in`
 - [ ] `sqlite3_vtab_in_first`
 - [ ] `sqlite3_vtab_in_next`
-- [ ] `sqlite3_vtab_rhs_value`
+- [X] `sqlite3_vtab_rhs_value`
 
 - [ ] `sqlite3_stmt_scanstatus`
 - [ ] `sqlite3_stmt_scanstatus_v2`
@@ -330,7 +331,7 @@
 - [X] `sqlite3session_enable`
 - [X] `sqlite3session_indirect`
 - [X] `sqlite3session_attach`
-- [X] `sqlite3session_table_filter`
+- [X] `sqlite3session_table_filter` (Boxed callback, reference kept)
 - [X] `sqlite3session_changeset`
 - [ ] `sqlite3session_changeset_size`
 - [X] `sqlite3session_diff`

--- a/src/vtab/vtablog.rs
+++ b/src/vtab/vtablog.rs
@@ -119,6 +119,16 @@ unsafe impl<'vtab> VTab<'vtab> for VTabLog {
             info.col_used(),
             info.distinct()
         );
+        for (i, constraint) in info.constraints().enumerate() {
+            println!(
+                "  constraint[{}]: col={}, usable={}, op={:?}, rhs={:?}",
+                i,
+                constraint.column(),
+                constraint.is_usable(),
+                constraint.operator(),
+                info.rhs_value(i)
+            )
+        }
         info.set_estimated_cost(500.);
         info.set_estimated_rows(500);
         info.set_idx_str("idx");


### PR DESCRIPTION
https://sqlite.org/c3ref/vtab_rhs_value.html
> If the right-hand operand is not known, then *V is set to a NULL pointer.

vs
> The sqlite3_vtab_rhs_value(P,J,V) inteface returns SQLITE_NOTFOUND if the right-hand side of the J-th constraint is not available.

- [x] Can we have a NULL pointer without any error ?