### PR TITLE
remove `#[cfg(feature = "modern_sqlite")]` before `Updates::no_change()`

### DIFF
--- a/src/vtab/mod.rs
+++ b/src/vtab/mod.rs
@@ -1023,7 +1023,6 @@ impl Updates<'_> {
     /// - and if and the prior [`VTabCursor::column`] method call that was invoked to extracted the value for that column returned without setting a result.
     #[inline]
     #[must_use]
-    #[cfg(feature = "modern_sqlite")] // SQLite >= 3.22.0
     pub fn no_change(&self, idx: usize) -> bool {
         unsafe { ffi::sqlite3_value_nochange(self.values.args[idx]) != 0 }
     }


### PR DESCRIPTION
this is safe since `sqlite3_value_nochange` and `sqlite3_vtab_nochange` were introduced in the same [version](https://sqlite.org/releaselog/3_22_0.html) and `Context::no_change` also doesn't have a feature gate since 02164d5.