### PR TITLE
Check Connection is owned when registering Closure as hook

### DIFF
--- a/src/inner_connection.rs
+++ b/src/inner_connection.rs
@@ -369,6 +369,14 @@ impl InnerConnection {
     pub fn is_interrupted(&self) -> bool {
         unsafe { ffi::sqlite3_is_interrupted(self.db) == 1 }
     }
+
+    #[cfg(any(feature = "hooks", feature = "preupdate_hook"))]
+    pub fn check_owned(&self) -> Result<()> {
+        if !self.owned {
+            return Err(err!(ffi::SQLITE_MISUSE, "Connection is not owned"));
+        }
+        Ok(())
+    }
 }
 
 #[inline]


### PR DESCRIPTION
If the Connection is not owned (ie Connection::from_handle), SQLite handle references dangling pointer after Connection is dropped.