### PR TITLE
Bump `sqlite-wasm-rs` to 0.5.1

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -136,16 +136,8 @@ jobs:
       - uses: actions/checkout@v4
       - name: Install wasm-pack
         run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
-      - name: Install emscripten toolchains
-        run: |
-          git clone https://github.com/emscripten-core/emsdk.git
-          cd emsdk
-          ./emsdk install latest
-          ./emsdk activate latest
       - name: Test unit and integration tests
-        run: |
-          source ./emsdk/emsdk_env.sh
-          wasm-pack test --node --features modern-full
+        run: wasm-pack test --node --features modern-full
 
   sqlcipher:
     name: Test with sqlcipher

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -168,7 +168,7 @@ rusqlite-macros = { path = "rusqlite-macros", version = "0.4.1", optional = true
 libsqlite3-sys = { path = "libsqlite3-sys", version = "0.35.0" }
 
 [target.'cfg(all(target_family = "wasm", target_os = "unknown"))'.dependencies]
-sqlite-wasm-rs = { version = "0.5.0", default-features = false }
+sqlite-wasm-rs = { version = "0.5.1", default-features = false }
 chrono = { version = "0.4.38", optional = true, default-features = false, features = ["wasmbind"] }
 jiff = { version = "0.2", optional = true, default-features = false, features = ["js"] }
 time = { version = "0.3.36", optional = true, features = ["wasm-bindgen"] }


### PR DESCRIPTION
Removed emcc requirement, emscripten toolchain no longer needs to be installed.

The previous PR https://github.com/rusqlite/rusqlite/pull/1769 has not yet been released, so let's bump the version