### PR TITLE
Fix constraints on VTab Aux data

### DIFF
--- a/src/vtab/mod.rs
+++ b/src/vtab/mod.rs
@@ -260,7 +260,7 @@ impl VTabConnection {
 /// (See [SQLite doc](https://sqlite.org/c3ref/vtab.html))
 pub unsafe trait VTab<'vtab>: Sized {
     /// Client data passed to [`Connection::create_module`].
-    type Aux;
+    type Aux: Send + Sync + 'static;
     /// Specific cursor implementation
     type Cursor: VTabCursor;
 


### PR DESCRIPTION
Apply same constraints as function auxiliary data.
Fix #1771