### PR TITLE
Clear hooks only for owning connections

### DIFF
--- a/src/inner_connection.rs
+++ b/src/inner_connection.rs
@@ -140,8 +140,10 @@ impl InnerConnection {
         if self.db.is_null() {
             return Ok(());
         }
-        self.remove_hooks();
-        self.remove_preupdate_hook();
+        if self.owned {
+            self.remove_hooks();
+            self.remove_preupdate_hook();
+        }
         let mut shared_handle = self.interrupt_lock.lock().unwrap();
         assert!(
             !self.owned || !shared_handle.is_null(),


### PR DESCRIPTION
This add a guard to clear hooks only for owning connections, now that non-owning ones can't register them anymore (#1764).

See #1784