### PR TITLE
Sqlcipher: support custom crypto provider

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ maintenance = { status = "actively-developed" }
 name = "rusqlite"
 
 [workspace]
-members = ["libsqlite3-sys"]
+members = ["libsqlite3-sys", "sqlcipher-crypto-provider"]
 
 [features]
 # if not SQLITE_OMIT_LOAD_EXTENSION
@@ -53,6 +53,7 @@ trace = []
 bundled = ["libsqlite3-sys/bundled", "modern_sqlite"]
 # Use SQLCipher instead of SQLite
 bundled-sqlcipher = ["libsqlite3-sys/bundled-sqlcipher", "bundled"]
+bundled-sqlcipher-custom-crypto = ["libsqlite3-sys/bundled-sqlcipher-custom-crypto", "bundled-sqlcipher"]
 bundled-sqlcipher-vendored-openssl = [
     "libsqlite3-sys/bundled-sqlcipher-vendored-openssl",
     "bundled-sqlcipher",

--- a/libsqlite3-sys/Cargo.toml
+++ b/libsqlite3-sys/Cargo.toml
@@ -19,6 +19,7 @@ bundled = ["cc", "bundled_bindings"]
 bundled-windows = ["cc", "bundled_bindings"]
 # Use bundled SQLCipher sources
 bundled-sqlcipher = ["bundled"]
+bundled-sqlcipher-custom-crypto = ["bundled-sqlcipher", "dep:sqlcipher-crypto-provider"]
 bundled-sqlcipher-vendored-openssl = [
     "bundled-sqlcipher",
     "openssl-sys/vendored",
@@ -47,6 +48,7 @@ wasm32-wasi-vfs = []
 
 [dependencies]
 openssl-sys = { version = "0.9.103", optional = true }
+sqlcipher-crypto-provider = { path = "../sqlcipher-crypto-provider", optional = true }
 
 [build-dependencies]
 bindgen = { version = "0.72", optional = true, default-features = false, features = [

--- a/libsqlite3-sys/build.rs
+++ b/libsqlite3-sys/build.rs
@@ -359,6 +359,8 @@ impl From<HeaderLocation> for String {
                 });
                 header.push_str(if cfg!(feature = "loadable_extension") {
                     "/sqlite3ext.h"
+                } else if cfg!(any(feature = "sqlcipher", feature = "bundled-sqlcipher")) {
+                    "/sqlcipher.h"
                 } else {
                     "/sqlite3.h"
                 });
@@ -375,6 +377,8 @@ impl From<HeaderLocation> for String {
                 path,
                 if cfg!(feature = "loadable_extension") {
                     "sqlite3ext.h"
+                } else if cfg!(any(feature = "sqlcipher", feature = "bundled-sqlcipher")) {
+                    "/sqlcipher.h"
                 } else {
                     "sqlite3.h"
                 }

--- a/libsqlite3-sys/build.rs
+++ b/libsqlite3-sys/build.rs
@@ -210,6 +210,8 @@ mod build_bundled {
                 cfg.include(env::var("DEP_OPENSSL_INCLUDE").unwrap());
                 // cargo will resolve downstream to the static lib in
                 // openssl-sys
+            } else if cfg!(feature = "bundled-sqlcipher-custom-crypto") {
+                cfg.flag("-DSQLCIPHER_CRYPTO_CUSTOM=rusqlite_custom_crypto_setup");
             } else if use_openssl {
                 cfg.include(inc_dir.to_string_lossy().as_ref());
                 let lib_name = if is_windows { "libcrypto" } else { "crypto" };
@@ -604,6 +606,9 @@ mod bindings {
         if cfg!(any(feature = "sqlcipher", feature = "bundled-sqlcipher")) {
             bindings = bindings.clang_arg("-DSQLITE_HAS_CODEC");
         }
+        if cfg!(feature = "bundled-sqlcipher-custom-crypto") {
+            bindings = bindings.clang_arg("-DSQLCIPHER_CRYPTO_CUSTOM=rusqlite_custom_crypto_setup");
+        }
         if cfg!(feature = "unlock_notify") {
             bindings = bindings.clang_arg("-DSQLITE_ENABLE_UNLOCK_NOTIFY");
         }
@@ -639,6 +644,10 @@ mod bindings {
                 .blocklist_type("va_list")
                 .blocklist_item("__.*");
         }
+
+        let bindings = bindings
+            .blocklist_item("sqlcipher_codec_pragma")
+            .blocklist_type("Parse");
 
         let bindings = bindings
             .layout_tests(false)

--- a/libsqlite3-sys/sqlcipher/bindgen_bundled_version.rs
+++ b/libsqlite3-sys/sqlcipher/bindgen_bundled_version.rs
@@ -523,6 +523,38 @@ pub const FTS5_TOKENIZE_PREFIX: i32 = 2;
 pub const FTS5_TOKENIZE_DOCUMENT: i32 = 4;
 pub const FTS5_TOKENIZE_AUX: i32 = 8;
 pub const FTS5_TOKEN_COLOCATED: i32 = 1;
+pub const SQLCIPHER_HMAC_SHA1: i32 = 0;
+pub const SQLCIPHER_HMAC_SHA1_LABEL: &::core::ffi::CStr = c"HMAC_SHA1";
+pub const SQLCIPHER_HMAC_SHA256: i32 = 1;
+pub const SQLCIPHER_HMAC_SHA256_LABEL: &::core::ffi::CStr = c"HMAC_SHA256";
+pub const SQLCIPHER_HMAC_SHA512: i32 = 2;
+pub const SQLCIPHER_HMAC_SHA512_LABEL: &::core::ffi::CStr = c"HMAC_SHA512";
+pub const SQLCIPHER_PBKDF2_HMAC_SHA1: i32 = 0;
+pub const SQLCIPHER_PBKDF2_HMAC_SHA1_LABEL: &::core::ffi::CStr = c"PBKDF2_HMAC_SHA1";
+pub const SQLCIPHER_PBKDF2_HMAC_SHA256: i32 = 1;
+pub const SQLCIPHER_PBKDF2_HMAC_SHA256_LABEL: &::core::ffi::CStr = c"PBKDF2_HMAC_SHA256";
+pub const SQLCIPHER_PBKDF2_HMAC_SHA512: i32 = 2;
+pub const SQLCIPHER_PBKDF2_HMAC_SHA512_LABEL: &::core::ffi::CStr = c"PBKDF2_HMAC_SHA512";
+pub const SQLCIPHER_MUTEX_PROVIDER: i32 = 0;
+pub const SQLCIPHER_MUTEX_PROVIDER_ACTIVATE: i32 = 1;
+pub const SQLCIPHER_MUTEX_PROVIDER_RAND: i32 = 2;
+pub const SQLCIPHER_MUTEX_RESERVED1: i32 = 3;
+pub const SQLCIPHER_MUTEX_RESERVED2: i32 = 4;
+pub const SQLCIPHER_MUTEX_RESERVED3: i32 = 5;
+pub const SQLCIPHER_MUTEX_MEM: i32 = 6;
+pub const SQLCIPHER_MUTEX_SHAREDCACHE: i32 = 7;
+pub const SQLCIPHER_MUTEX_COUNT: i32 = 8;
+pub const SQLCIPHER_LOG_NONE: i32 = 0;
+pub const SQLCIPHER_LOG_ANY: i64 = 4294967295;
+pub const SQLCIPHER_LOG_ERROR: i32 = 1;
+pub const SQLCIPHER_LOG_WARN: i32 = 2;
+pub const SQLCIPHER_LOG_INFO: i32 = 4;
+pub const SQLCIPHER_LOG_DEBUG: i32 = 8;
+pub const SQLCIPHER_LOG_TRACE: i32 = 16;
+pub const SQLCIPHER_LOG_CORE: i32 = 1;
+pub const SQLCIPHER_LOG_MEMORY: i32 = 2;
+pub const SQLCIPHER_LOG_MUTEX: i32 = 4;
+pub const SQLCIPHER_LOG_PROVIDER: i32 = 8;
 unsafe extern "C" {
     pub static sqlite3_version: [::core::ffi::c_char; 0usize];
 }
@@ -3518,4 +3550,174 @@ pub struct fts5_api {
             ppTokenizer: *mut *mut fts5_tokenizer_v2,
         ) -> ::core::ffi::c_int,
     >,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct sqlcipher_provider {
+    pub init: ::core::option::Option<unsafe extern "C" fn() -> ::core::ffi::c_int>,
+    pub shutdown: ::core::option::Option<unsafe extern "C" fn()>,
+    pub get_provider_name: ::core::option::Option<
+        unsafe extern "C" fn(ctx: *mut ::core::ffi::c_void) -> *const ::core::ffi::c_char,
+    >,
+    pub add_random: ::core::option::Option<
+        unsafe extern "C" fn(
+            ctx: *mut ::core::ffi::c_void,
+            buffer: *const ::core::ffi::c_void,
+            length: ::core::ffi::c_int,
+        ) -> ::core::ffi::c_int,
+    >,
+    pub random: ::core::option::Option<
+        unsafe extern "C" fn(
+            ctx: *mut ::core::ffi::c_void,
+            buffer: *mut ::core::ffi::c_void,
+            length: ::core::ffi::c_int,
+        ) -> ::core::ffi::c_int,
+    >,
+    pub hmac: ::core::option::Option<
+        unsafe extern "C" fn(
+            ctx: *mut ::core::ffi::c_void,
+            algorithm: ::core::ffi::c_int,
+            hmac_key: *const ::core::ffi::c_uchar,
+            key_sz: ::core::ffi::c_int,
+            in_: *const ::core::ffi::c_uchar,
+            in_sz: ::core::ffi::c_int,
+            in2: *const ::core::ffi::c_uchar,
+            in2_sz: ::core::ffi::c_int,
+            out: *mut ::core::ffi::c_uchar,
+        ) -> ::core::ffi::c_int,
+    >,
+    pub kdf: ::core::option::Option<
+        unsafe extern "C" fn(
+            ctx: *mut ::core::ffi::c_void,
+            algorithm: ::core::ffi::c_int,
+            pass: *const ::core::ffi::c_uchar,
+            pass_sz: ::core::ffi::c_int,
+            salt: *const ::core::ffi::c_uchar,
+            salt_sz: ::core::ffi::c_int,
+            workfactor: ::core::ffi::c_int,
+            key_sz: ::core::ffi::c_int,
+            key: *mut ::core::ffi::c_uchar,
+        ) -> ::core::ffi::c_int,
+    >,
+    pub cipher: ::core::option::Option<
+        unsafe extern "C" fn(
+            ctx: *mut ::core::ffi::c_void,
+            mode: ::core::ffi::c_int,
+            key: *const ::core::ffi::c_uchar,
+            key_sz: ::core::ffi::c_int,
+            iv: *const ::core::ffi::c_uchar,
+            in_: *const ::core::ffi::c_uchar,
+            in_sz: ::core::ffi::c_int,
+            out: *mut ::core::ffi::c_uchar,
+        ) -> ::core::ffi::c_int,
+    >,
+    pub get_cipher: ::core::option::Option<
+        unsafe extern "C" fn(ctx: *mut ::core::ffi::c_void) -> *const ::core::ffi::c_char,
+    >,
+    pub get_key_sz: ::core::option::Option<
+        unsafe extern "C" fn(ctx: *mut ::core::ffi::c_void) -> ::core::ffi::c_int,
+    >,
+    pub get_iv_sz: ::core::option::Option<
+        unsafe extern "C" fn(ctx: *mut ::core::ffi::c_void) -> ::core::ffi::c_int,
+    >,
+    pub get_block_sz: ::core::option::Option<
+        unsafe extern "C" fn(ctx: *mut ::core::ffi::c_void) -> ::core::ffi::c_int,
+    >,
+    pub get_hmac_sz: ::core::option::Option<
+        unsafe extern "C" fn(
+            ctx: *mut ::core::ffi::c_void,
+            algorithm: ::core::ffi::c_int,
+        ) -> ::core::ffi::c_int,
+    >,
+    pub ctx_init: ::core::option::Option<
+        unsafe extern "C" fn(ctx: *mut *mut ::core::ffi::c_void) -> ::core::ffi::c_int,
+    >,
+    pub ctx_free: ::core::option::Option<
+        unsafe extern "C" fn(ctx: *mut *mut ::core::ffi::c_void) -> ::core::ffi::c_int,
+    >,
+    pub fips_status: ::core::option::Option<
+        unsafe extern "C" fn(ctx: *mut ::core::ffi::c_void) -> ::core::ffi::c_int,
+    >,
+    pub get_provider_version: ::core::option::Option<
+        unsafe extern "C" fn(ctx: *mut ::core::ffi::c_void) -> *const ::core::ffi::c_char,
+    >,
+    pub next: *mut sqlcipher_provider,
+}
+unsafe extern "C" {
+    pub fn sqlcipher_extra_init(arg1: *const ::core::ffi::c_char) -> ::core::ffi::c_int;
+}
+unsafe extern "C" {
+    pub fn sqlcipher_extra_shutdown();
+}
+unsafe extern "C" {
+    pub fn sqlcipher_init_memmethods();
+}
+unsafe extern "C" {
+    pub fn sqlcipherCodecAttach(
+        arg1: *mut sqlite3,
+        arg2: ::core::ffi::c_int,
+        arg3: *const ::core::ffi::c_void,
+        arg4: ::core::ffi::c_int,
+    ) -> ::core::ffi::c_int;
+}
+unsafe extern "C" {
+    pub fn sqlcipherCodecGetKey(
+        arg1: *mut sqlite3,
+        arg2: ::core::ffi::c_int,
+        arg3: *mut *mut ::core::ffi::c_void,
+        arg4: *mut ::core::ffi::c_int,
+    );
+}
+unsafe extern "C" {
+    pub fn sqlcipher_find_db_index(
+        arg1: *mut sqlite3,
+        arg2: *const ::core::ffi::c_char,
+    ) -> ::core::ffi::c_int;
+}
+unsafe extern "C" {
+    pub fn sqlcipher_memset(
+        arg1: *mut ::core::ffi::c_void,
+        arg2: ::core::ffi::c_uchar,
+        arg3: sqlite_uint64,
+    ) -> *mut ::core::ffi::c_void;
+}
+unsafe extern "C" {
+    pub fn sqlcipher_ismemset(
+        arg1: *const ::core::ffi::c_void,
+        arg2: ::core::ffi::c_uchar,
+        arg3: sqlite_uint64,
+    ) -> ::core::ffi::c_int;
+}
+unsafe extern "C" {
+    pub fn sqlcipher_memcmp(
+        arg1: *const ::core::ffi::c_void,
+        arg2: *const ::core::ffi::c_void,
+        arg3: ::core::ffi::c_int,
+    ) -> ::core::ffi::c_int;
+}
+unsafe extern "C" {
+    pub fn sqlcipher_malloc(arg1: sqlite_uint64) -> *mut ::core::ffi::c_void;
+}
+unsafe extern "C" {
+    pub fn sqlcipher_free(arg1: *mut ::core::ffi::c_void, arg2: sqlite_uint64);
+}
+unsafe extern "C" {
+    pub fn sqlcipher_version() -> *mut ::core::ffi::c_char;
+}
+unsafe extern "C" {
+    pub fn sqlcipher_register_provider(arg1: *mut sqlcipher_provider) -> ::core::ffi::c_int;
+}
+unsafe extern "C" {
+    pub fn sqlcipher_get_provider() -> *mut sqlcipher_provider;
+}
+unsafe extern "C" {
+    pub fn sqlcipher_mutex(arg1: ::core::ffi::c_int) -> *mut sqlite3_mutex;
+}
+unsafe extern "C" {
+    pub fn sqlcipher_log(
+        level: ::core::ffi::c_uint,
+        source: ::core::ffi::c_uint,
+        message: *const ::core::ffi::c_char,
+        ...
+    );
 }

--- a/libsqlite3-sys/sqlcipher/ctx_free.patch
+++ b/libsqlite3-sys/sqlcipher/ctx_free.patch
@@ -1,0 +1,11 @@
+--- sqlite3.c	2026-02-25 13:22:10.080553910 +0100
++++ sqlite3.c	2026-02-26 16:32:53.212431233 +0100
+@@ -108877,7 +108877,7 @@
+     }
+   }
+ 
+-  default_provider->ctx_free(provider_ctx);
++  default_provider->ctx_free(&provider_ctx);
+ 
+   sqlcipher_init = 1;
+   sqlcipher_shutdown = 0;

--- a/libsqlite3-sys/sqlcipher/sqlcipher.h
+++ b/libsqlite3-sys/sqlcipher/sqlcipher.h
@@ -1,0 +1,161 @@
+/* 
+** SQLCipher
+** sqlcipher.h developed by Stephen Lombardo (Zetetic LLC) 
+** sjlombardo at zetetic dot net
+** http://zetetic.net
+** 
+** Copyright (c) 2008, ZETETIC LLC
+** All rights reserved.
+** 
+** Redistribution and use in source and binary forms, with or without
+** modification, are permitted provided that the following conditions are met:
+**     * Redistributions of source code must retain the above copyright
+**       notice, this list of conditions and the following disclaimer.
+**     * Redistributions in binary form must reproduce the above copyright
+**       notice, this list of conditions and the following disclaimer in the
+**       documentation and/or other materials provided with the distribution.
+**     * Neither the name of the ZETETIC LLC nor the
+**       names of its contributors may be used to endorse or promote products
+**       derived from this software without specific prior written permission.
+** 
+** THIS SOFTWARE IS PROVIDED BY ZETETIC LLC ''AS IS'' AND ANY
+** EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+** WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+** DISCLAIMED. IN NO EVENT SHALL ZETETIC LLC BE LIABLE FOR ANY
+** DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+** (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+** LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+** ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+** (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+** SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+**  
+*/
+/* BEGIN SQLCIPHER */
+#ifdef SQLITE_HAS_CODEC
+#ifndef SQLCIPHER_H
+#define SQLCIPHER_H
+
+#include "sqlite3.h"
+
+#define SQLCIPHER_HMAC_SHA1 0
+#define SQLCIPHER_HMAC_SHA1_LABEL "HMAC_SHA1"
+#define SQLCIPHER_HMAC_SHA256 1
+#define SQLCIPHER_HMAC_SHA256_LABEL "HMAC_SHA256"
+#define SQLCIPHER_HMAC_SHA512 2
+#define SQLCIPHER_HMAC_SHA512_LABEL "HMAC_SHA512"
+
+
+#define SQLCIPHER_PBKDF2_HMAC_SHA1 0
+#define SQLCIPHER_PBKDF2_HMAC_SHA1_LABEL "PBKDF2_HMAC_SHA1"
+#define SQLCIPHER_PBKDF2_HMAC_SHA256 1
+#define SQLCIPHER_PBKDF2_HMAC_SHA256_LABEL "PBKDF2_HMAC_SHA256"
+#define SQLCIPHER_PBKDF2_HMAC_SHA512 2
+#define SQLCIPHER_PBKDF2_HMAC_SHA512_LABEL "PBKDF2_HMAC_SHA512"
+
+typedef struct sqlcipher_provider sqlcipher_provider;
+struct sqlcipher_provider {
+  int (*init)(void);
+  void (*shutdown)(void);
+  const char* (*get_provider_name)(void *ctx);
+  int (*add_random)(void *ctx, const void *buffer, int length);
+  int (*random)(void *ctx, void *buffer, int length);
+  int (*hmac)(void *ctx, int algorithm,
+              const unsigned char *hmac_key, int key_sz,
+              const unsigned char *in, int in_sz,
+              const unsigned char *in2, int in2_sz,
+              unsigned char *out);
+  int (*kdf)(void *ctx, int algorithm,
+              const unsigned char *pass, int pass_sz,
+              const unsigned char* salt, int salt_sz,
+              int workfactor,
+              int key_sz, unsigned char *key);
+  int (*cipher)(void *ctx, int mode,
+              const unsigned char *key, int key_sz,
+              const unsigned char *iv,
+              const unsigned char *in, int in_sz,
+              unsigned char *out);
+  const char* (*get_cipher)(void *ctx);
+  int (*get_key_sz)(void *ctx);
+  int (*get_iv_sz)(void *ctx);
+  int (*get_block_sz)(void *ctx);
+  int (*get_hmac_sz)(void *ctx, int algorithm);
+  int (*ctx_init)(void **ctx);
+  int (*ctx_free)(void **ctx);
+  int (*fips_status)(void *ctx);
+  const char* (*get_provider_version)(void *ctx);
+  sqlcipher_provider *next;
+};
+
+/* public interfaces called externally */
+int sqlcipher_extra_init(const char*);
+void sqlcipher_extra_shutdown(void);
+void sqlcipher_init_memmethods(void);
+//int sqlcipher_codec_pragma(sqlite3*, int, Parse*, const char *, const char*);
+int sqlcipherCodecAttach(sqlite3*, int, const void *, int);
+void sqlcipherCodecGetKey(sqlite3*, int, void**, int*);
+int sqlcipher_find_db_index(sqlite3 *, const char *);
+
+/* utility functions */
+void* sqlcipher_memset(void *, unsigned char, sqlite_uint64);
+int sqlcipher_ismemset(const void *, unsigned char, sqlite_uint64);
+int sqlcipher_memcmp(const void *, const void *, int);
+void* sqlcipher_malloc(sqlite_uint64);
+void sqlcipher_free(void *, sqlite_uint64);
+char* sqlcipher_version(void);
+
+/* provider interfaces */
+int sqlcipher_register_provider(sqlcipher_provider *);
+sqlcipher_provider* sqlcipher_get_provider(void);
+
+#define SQLCIPHER_MUTEX_PROVIDER          0
+#define SQLCIPHER_MUTEX_PROVIDER_ACTIVATE 1
+#define SQLCIPHER_MUTEX_PROVIDER_RAND     2
+#define SQLCIPHER_MUTEX_RESERVED1         3
+#define SQLCIPHER_MUTEX_RESERVED2         4
+#define SQLCIPHER_MUTEX_RESERVED3         5
+#define SQLCIPHER_MUTEX_MEM               6
+#define SQLCIPHER_MUTEX_SHAREDCACHE       7
+#define SQLCIPHER_MUTEX_COUNT             8
+
+sqlite3_mutex* sqlcipher_mutex(int);
+
+#define SQLCIPHER_LOG_NONE          0
+#define SQLCIPHER_LOG_ANY           0xffffffff
+
+#define SQLCIPHER_LOG_ERROR         (1<<0)
+#define SQLCIPHER_LOG_WARN          (1<<1)
+#define SQLCIPHER_LOG_INFO          (1<<2)
+#define SQLCIPHER_LOG_DEBUG         (1<<3)
+#define SQLCIPHER_LOG_TRACE         (1<<4)
+
+#define SQLCIPHER_LOG_CORE          (1<<0)
+#define SQLCIPHER_LOG_MEMORY        (1<<1)
+#define SQLCIPHER_LOG_MUTEX         (1<<2)
+#define SQLCIPHER_LOG_PROVIDER      (1<<3)
+
+#ifdef SQLCIPHER_OMIT_LOG
+#define sqlcipher_log(level, source, message, ...)
+#else
+void sqlcipher_log(unsigned int level, unsigned int source, const char *message, ...);
+#endif
+
+#ifdef CODEC_DEBUG_PAGEDATA
+#define CODEC_HEXDUMP(DESC,BUFFER,LEN)  \
+  { \
+    int __pctr; \
+    printf(DESC); \
+    for(__pctr=0; __pctr < LEN; __pctr++) { \
+      if(__pctr % 16 == 0) printf("\n%05x: ",__pctr); \
+      printf("%02x ",((unsigned char*) BUFFER)[__pctr]); \
+    } \
+    printf("\n"); \
+    fflush(stdout); \
+  }
+#else
+#define CODEC_HEXDUMP(DESC,BUFFER,LEN)
+#endif
+
+#endif
+#endif
+/* END SQLCIPHER */
+

--- a/libsqlite3-sys/src/lib.rs
+++ b/libsqlite3-sys/src/lib.rs
@@ -4,6 +4,12 @@
 #[cfg(feature = "bundled-sqlcipher-vendored-openssl")]
 extern crate openssl_sys;
 
+#[cfg(feature = "bundled-sqlcipher-custom-crypto")]
+mod sqlcipher_custom_crypto;
+
+#[cfg(feature = "bundled-sqlcipher-custom-crypto")]
+extern crate alloc;
+
 pub use self::error::*;
 
 use core::mem;

--- a/libsqlite3-sys/src/sqlcipher_custom_crypto.rs
+++ b/libsqlite3-sys/src/sqlcipher_custom_crypto.rs
@@ -1,7 +1,9 @@
 use alloc::boxed::Box;
 use core::ffi::{c_int, c_void};
 
-use sqlcipher_crypto_provider::{RustCryptoProvider, SqlcipherCryptoProvider};
+use sqlcipher_crypto_provider::{
+    HmacAlgorithm, KdfAlgorithm, RustCryptoProvider, SqlcipherCryptoProvider,
+};
 
 use super::bindings::*;
 
@@ -13,7 +15,9 @@ pub extern "C" fn rusqlite_custom_crypto_setup(_p: *mut sqlcipher_provider) {
     // void (*shutdown)(void);
     p.shutdown = Some(shutdown);
     // const char* (*get_provider_name)(void *ctx);
+    p.get_provider_name = Some(get_provider_name);
     // int (*add_random)(void *ctx, const void *buffer, int length);
+    p.add_random = Some(add_random);
     // int (*random)(void *ctx, void *buffer, int length);
     p.random = Some(random);
     // int (*hmac)(void *ctx, int algorithm,
@@ -21,27 +25,37 @@ pub extern "C" fn rusqlite_custom_crypto_setup(_p: *mut sqlcipher_provider) {
     //             const unsigned char *in, int in_sz,
     //             const unsigned char *in2, int in2_sz,
     //             unsigned char *out);
+    p.hmac = Some(hmac);
     // int (*kdf)(void *ctx, int algorithm,
     //             const unsigned char *pass, int pass_sz,
     //             const unsigned char* salt, int salt_sz,
     //             int workfactor,
     //             int key_sz, unsigned char *key);
+    p.kdf = Some(kdf);
     // int (*cipher)(void *ctx, int mode,
     //             const unsigned char *key, int key_sz,
     //             const unsigned char *iv,
     //             const unsigned char *in, int in_sz,
     //             unsigned char *out);
+    p.cipher = Some(cipher);
     // const char* (*get_cipher)(void *ctx);
+    p.get_cipher = Some(get_cipher);
     // int (*get_key_sz)(void *ctx);
+    p.get_key_sz = Some(get_key_sz);
     // int (*get_iv_sz)(void *ctx);
+    p.get_iv_sz = Some(get_iv_sz);
     // int (*get_block_sz)(void *ctx);
+    p.get_block_sz = Some(get_block_sz);
     // int (*get_hmac_sz)(void *ctx, int algorithm);
+    p.get_hmac_sz = Some(get_hmac_sz);
     // int (*ctx_init)(void **ctx);
     p.ctx_init = Some(ctx_init);
     // int (*ctx_free)(void **ctx);
     p.ctx_free = Some(ctx_free);
     // int (*fips_status)(void *ctx);
+    p.fips_status = Some(fips_status);
     // const char* (*get_provider_version)(void *ctx);
+    p.get_provider_version = Some(get_provider_version);
     // sqlcipher_provider *next;
     p.next = core::ptr::null_mut();
 }
@@ -55,6 +69,24 @@ fn ctx_to_trait_mut<'a>(ctx: *mut c_void) -> &'a mut Box<dyn SqlcipherCryptoProv
     let obj = ctx as *mut Box<dyn SqlcipherCryptoProvider>;
 
     unsafe { obj.as_mut().expect("non-null crypto provider") }
+}
+
+fn parse_hmac_algorithm(algorithm: i32) -> HmacAlgorithm {
+    match algorithm {
+        SQLCIPHER_HMAC_SHA1 => HmacAlgorithm::HmacSha1,
+        SQLCIPHER_HMAC_SHA256 => HmacAlgorithm::HmacSha256,
+        SQLCIPHER_HMAC_SHA512 => HmacAlgorithm::HmacSha512,
+        _ => unimplemented!("unimplemented SQLCIPHER_HMAC algorithm {algorithm}"),
+    }
+}
+
+fn parse_kdf_algorithm(algorithm: i32) -> KdfAlgorithm {
+    match algorithm {
+        SQLCIPHER_PBKDF2_HMAC_SHA1 => KdfAlgorithm::Pbkdf2HmacSha1,
+        SQLCIPHER_PBKDF2_HMAC_SHA256 => KdfAlgorithm::Pbkdf2HmacSha256,
+        SQLCIPHER_PBKDF2_HMAC_SHA512 => KdfAlgorithm::Pbkdf2HmacSha512,
+        _ => unimplemented!("unimplemented SQLCIPHER KDF algorithm {algorithm}"),
+    }
 }
 
 extern "C" fn ctx_init(ctx: *mut *mut c_void) -> i32 {
@@ -77,10 +109,147 @@ extern "C" fn ctx_free(ctx: *mut *mut c_void) -> i32 {
     0
 }
 
+extern "C" fn get_key_sz(ctx: *mut c_void) -> i32 {
+    let obj = ctx_to_trait_mut(ctx);
+    obj.get_key_sz()
+}
+
+extern "C" fn get_provider_name(ctx: *mut c_void) -> *const i8 {
+    let obj = ctx_to_trait_mut(ctx);
+    obj.get_provider_name().as_ptr()
+}
+
+// int (*kdf)(void *ctx, int algorithm,
+//             const unsigned char *pass, int pass_sz,
+//             const unsigned char* salt, int salt_sz,
+//             int workfactor,
+//             int key_sz, unsigned char *key);
+
+extern "C" fn kdf(
+    ctx: *mut c_void,
+    algorithm: c_int,
+    pass: *const u8,
+    pass_sz: c_int,
+    salt: *const u8,
+    salt_sz: c_int,
+    workfactor: c_int,
+    key_sz: c_int,
+    key: *mut u8,
+) -> i32 {
+    let obj = ctx_to_trait_mut(ctx);
+    let algorithm = parse_kdf_algorithm(algorithm);
+    let pass = unsafe { core::slice::from_raw_parts(pass as *const u8, pass_sz as usize) };
+    let salt = unsafe { core::slice::from_raw_parts(salt as *const u8, salt_sz as usize) };
+    let key = unsafe { core::slice::from_raw_parts_mut(key as *mut u8, key_sz as usize) };
+
+    obj.kdf(algorithm, pass, salt, workfactor, key)
+}
+
+extern "C" fn hmac(
+    ctx: *mut c_void,
+    algorithm: c_int,
+    hmac_key: *const u8,
+    key_sz: c_int,
+    input: *const u8,
+    in_size: c_int,
+    input2: *const u8,
+    in2_size: c_int,
+    output: *mut u8,
+) -> i32 {
+    let obj = ctx_to_trait_mut(ctx);
+
+    let algorithm = parse_hmac_algorithm(algorithm);
+    let hmac_key = unsafe { core::slice::from_raw_parts(hmac_key as *const u8, key_sz as usize) };
+    let input = unsafe { core::slice::from_raw_parts(input as *const u8, in_size as usize) };
+    let input2 = if input2.is_null() {
+        None
+    } else {
+        Some(unsafe { core::slice::from_raw_parts(input2 as *const u8, in2_size as usize) })
+    };
+
+    let out = unsafe { core::slice::from_raw_parts_mut(output as *mut u8, algorithm.output_len()) };
+
+    obj.hmac(algorithm, hmac_key, input, input2, out)
+}
+
+extern "C" fn cipher(
+    ctx: *mut c_void,
+    mode: c_int,
+    key: *const u8,
+    key_sz: c_int,
+    iv: *const u8,
+    input: *const u8,
+    in_size: c_int,
+    output: *mut u8,
+) -> i32 {
+    let obj = ctx_to_trait_mut(ctx);
+    let key = unsafe { core::slice::from_raw_parts(key as *const u8, key_sz as usize) };
+    let iv = unsafe { core::slice::from_raw_parts(iv as *const u8, obj.get_iv_sz() as usize) };
+    let input = unsafe { core::slice::from_raw_parts(input as *const u8, in_size as usize) };
+
+    let out = unsafe { core::slice::from_raw_parts_mut(output as *mut u8, in_size as usize) };
+    match mode {
+        // XXX for some reason, SQLCIPHER_ENCRYPT/SQLCIPHER_DECRYPT aren't in bindings.
+        0 => {
+            // Decrypt
+            obj.decrypt(key, iv, input, out)
+        }
+        1 => {
+            // Encrypt
+            obj.encrypt(key, iv, input, out)
+        }
+        _ => {
+            unimplemented!("unsupported cipher mode")
+        }
+    }
+}
+// int (*cipher)(void *ctx, int mode,
+//             const unsigned char *key, int key_sz,
+//             const unsigned char *iv,
+//             const unsigned char *in, int in_sz,
+//             unsigned char *out);
+
+extern "C" fn get_cipher(ctx: *mut c_void) -> *const i8 {
+    let obj = ctx_to_trait_mut(ctx);
+    obj.get_cipher().as_ptr()
+}
+
+extern "C" fn get_iv_sz(ctx: *mut c_void) -> i32 {
+    let obj = ctx_to_trait_mut(ctx);
+    obj.get_iv_sz()
+}
+
+extern "C" fn get_block_sz(ctx: *mut c_void) -> i32 {
+    let obj = ctx_to_trait_mut(ctx);
+    obj.get_block_sz()
+}
+
+extern "C" fn get_hmac_sz(ctx: *mut c_void, algorithm: c_int) -> i32 {
+    let obj = ctx_to_trait_mut(ctx);
+    obj.get_hmac_sz(parse_hmac_algorithm(algorithm))
+}
+
+extern "C" fn get_provider_version(ctx: *mut c_void) -> *const i8 {
+    let obj = ctx_to_trait_mut(ctx);
+    obj.get_provider_version().as_ptr()
+}
+
+extern "C" fn fips_status(ctx: *mut c_void) -> i32 {
+    let obj = ctx_to_trait_mut(ctx);
+    obj.fips_status()
+}
+
 // int (*random)(void *ctx, void *buffer, int length);
 extern "C" fn random(ctx: *mut c_void, buffer: *mut c_void, length: c_int) -> i32 {
     let obj = ctx_to_trait_mut(ctx);
 
     let buffer = unsafe { core::slice::from_raw_parts_mut(buffer as *mut u8, length as usize) };
     obj.random(buffer)
+}
+
+extern "C" fn add_random(ctx: *mut c_void, buffer: *const c_void, length: c_int) -> i32 {
+    let obj = ctx_to_trait_mut(ctx);
+
+    let buffer = unsafe { core::slice::from_raw_parts(buffer as *mut u8, length as usize) };
+    obj.add_random(buffer)
 }

--- a/libsqlite3-sys/src/sqlcipher_custom_crypto.rs
+++ b/libsqlite3-sys/src/sqlcipher_custom_crypto.rs
@@ -1,0 +1,86 @@
+use alloc::boxed::Box;
+use core::ffi::{c_int, c_void};
+
+use sqlcipher_crypto_provider::{RustCryptoProvider, SqlcipherCryptoProvider};
+
+use super::bindings::*;
+
+#[unsafe(no_mangle)]
+pub extern "C" fn rusqlite_custom_crypto_setup(_p: *mut sqlcipher_provider) {
+    let p = unsafe { &mut *_p };
+    // int (*init)(void);
+    p.init = Some(init);
+    // void (*shutdown)(void);
+    p.shutdown = Some(shutdown);
+    // const char* (*get_provider_name)(void *ctx);
+    // int (*add_random)(void *ctx, const void *buffer, int length);
+    // int (*random)(void *ctx, void *buffer, int length);
+    p.random = Some(random);
+    // int (*hmac)(void *ctx, int algorithm,
+    //             const unsigned char *hmac_key, int key_sz,
+    //             const unsigned char *in, int in_sz,
+    //             const unsigned char *in2, int in2_sz,
+    //             unsigned char *out);
+    // int (*kdf)(void *ctx, int algorithm,
+    //             const unsigned char *pass, int pass_sz,
+    //             const unsigned char* salt, int salt_sz,
+    //             int workfactor,
+    //             int key_sz, unsigned char *key);
+    // int (*cipher)(void *ctx, int mode,
+    //             const unsigned char *key, int key_sz,
+    //             const unsigned char *iv,
+    //             const unsigned char *in, int in_sz,
+    //             unsigned char *out);
+    // const char* (*get_cipher)(void *ctx);
+    // int (*get_key_sz)(void *ctx);
+    // int (*get_iv_sz)(void *ctx);
+    // int (*get_block_sz)(void *ctx);
+    // int (*get_hmac_sz)(void *ctx, int algorithm);
+    // int (*ctx_init)(void **ctx);
+    p.ctx_init = Some(ctx_init);
+    // int (*ctx_free)(void **ctx);
+    p.ctx_free = Some(ctx_free);
+    // int (*fips_status)(void *ctx);
+    // const char* (*get_provider_version)(void *ctx);
+    // sqlcipher_provider *next;
+    p.next = core::ptr::null_mut();
+}
+
+extern "C" fn init() -> i32 {
+    0
+}
+extern "C" fn shutdown() {}
+
+fn ctx_to_trait_mut<'a>(ctx: *mut c_void) -> &'a mut Box<dyn SqlcipherCryptoProvider> {
+    let obj = ctx as *mut Box<dyn SqlcipherCryptoProvider>;
+
+    unsafe { obj.as_mut().expect("non-null crypto provider") }
+}
+
+extern "C" fn ctx_init(ctx: *mut *mut c_void) -> i32 {
+    let ctx_ref: &mut *mut c_void = unsafe { &mut *ctx };
+    let obj = Box::new(Box::new(RustCryptoProvider::default()) as Box<dyn SqlcipherCryptoProvider>);
+    let obj: *mut Box<dyn SqlcipherCryptoProvider> = Box::into_raw(obj);
+    *ctx_ref = obj as *mut c_void;
+
+    0
+}
+
+extern "C" fn ctx_free(ctx: *mut *mut c_void) -> i32 {
+    let _obj = unsafe {
+        let obj = *ctx as *mut Box<dyn SqlcipherCryptoProvider>;
+
+        Box::<_>::from_raw(obj)
+    };
+    drop(_obj);
+
+    0
+}
+
+// int (*random)(void *ctx, void *buffer, int length);
+extern "C" fn random(ctx: *mut c_void, buffer: *mut c_void, length: c_int) -> i32 {
+    let obj = ctx_to_trait_mut(ctx);
+
+    let buffer = unsafe { core::slice::from_raw_parts_mut(buffer as *mut u8, length as usize) };
+    obj.random(buffer)
+}

--- a/libsqlite3-sys/upgrade_sqlcipher.sh
+++ b/libsqlite3-sys/upgrade_sqlcipher.sh
@@ -16,7 +16,15 @@ tar xzf "v${SQLCIPHER_VERSION}.tar.gz" --strip-components=1 -C "$SCRIPT_DIR/sqlc
 cd "$SCRIPT_DIR/sqlcipher.src"
 ./configure
 make sqlite3.c
-cp sqlite3.c sqlite3.h sqlite3ext.h "$SCRIPT_DIR/sqlcipher/"
+cp sqlite3.c src/sqlcipher.h sqlite3.h sqlite3ext.h "$SCRIPT_DIR/sqlcipher/"
+# The `sqlcipher_codec_pragma` fails to parse correctly, even with
+# ```rust
+# let bindings = bindings
+#   .blocklist_item("sqlcipher_codec_pragma")
+#   .blocklist_type("Parse");
+# ```
+# This `sed` comments out that specific function.
+sed -i 's#int sqlcipher_codec_pragma#//int sqlcipher_codec_pragma#' "$SCRIPT_DIR/sqlcipher/sqlcipher.h"
 cd "$SCRIPT_DIR"
 rm -rf "v${SQLCIPHER_VERSION}.tar.gz" sqlcipher.src
 

--- a/libsqlite3-sys/upgrade_sqlcipher.sh
+++ b/libsqlite3-sys/upgrade_sqlcipher.sh
@@ -26,6 +26,11 @@ cp sqlite3.c src/sqlcipher.h sqlite3.h sqlite3ext.h "$SCRIPT_DIR/sqlcipher/"
 # This `sed` comments out that specific function.
 sed -i 's#int sqlcipher_codec_pragma#//int sqlcipher_codec_pragma#' "$SCRIPT_DIR/sqlcipher/sqlcipher.h"
 cd "$SCRIPT_DIR"
+# SQLCipher versions 4.10 and older call `ctx_free` at one point
+# with a direct pointer (`void *`), not `void **`, despite what the
+# public header declares. This is fixed in commit c89bab0b4 (SQLCipher ≥ 4.10).
+# ctx_free.patch backports this change to 4.10.0 in the amalgamation.
+patch < ctx_free.patch
 rm -rf "v${SQLCIPHER_VERSION}.tar.gz" sqlcipher.src
 
 # Regenerate bindgen file for sqlcipher

--- a/sqlcipher-crypto-provider/Cargo.toml
+++ b/sqlcipher-crypto-provider/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "sqlcipher-crypto-provider"
+version = "0.1.0"
+edition = "2024"
+
+[lib]
+crate-type = ["staticlib", "rlib"]
+
+[dependencies]
+rand = "0.10"

--- a/sqlcipher-crypto-provider/Cargo.toml
+++ b/sqlcipher-crypto-provider/Cargo.toml
@@ -8,3 +8,7 @@ crate-type = ["staticlib", "rlib"]
 
 [dependencies]
 rand = "0.10"
+pbkdf2 = "0.12"
+sha1 = "0.10"
+sha2 = "0.10"
+hmac = "0.12"

--- a/sqlcipher-crypto-provider/Cargo.toml
+++ b/sqlcipher-crypto-provider/Cargo.toml
@@ -8,6 +8,8 @@ crate-type = ["staticlib", "rlib"]
 
 [dependencies]
 rand = "0.10"
+aes = "0.8"
+cbc = "0.1"
 pbkdf2 = "0.12"
 sha1 = "0.10"
 sha2 = "0.10"

--- a/sqlcipher-crypto-provider/src/lib.rs
+++ b/sqlcipher-crypto-provider/src/lib.rs
@@ -1,6 +1,7 @@
 use core::ffi::CStr;
 
 use hmac::{Hmac, Mac};
+use pbkdf2::pbkdf2_hmac;
 use sha1::Sha1;
 use sha2::{Sha256, Sha512};
 
@@ -28,8 +29,7 @@ pub enum KdfAlgorithm {
     Pbkdf2HmacSha512,
 }
 
-impl KdfAlgorithm {
-}
+impl KdfAlgorithm {}
 
 pub trait SqlcipherCryptoProvider {
     fn get_provider_name(&self) -> &CStr;
@@ -132,13 +132,19 @@ impl SqlcipherCryptoProvider for RustCryptoProvider {
 
     fn kdf(
         &mut self,
-        _algorithm: KdfAlgorithm,
-        _pass: &[u8],
-        _salt: &[u8],
-        _workfactor: i32,
-        _key: &mut [u8],
+        algorithm: KdfAlgorithm,
+        password: &[u8],
+        salt: &[u8],
+        n: i32,
+        key: &mut [u8],
     ) -> i32 {
-        todo!()
+        match algorithm {
+            KdfAlgorithm::Pbkdf2HmacSha1 => pbkdf2_hmac::<Sha1>(password, salt, n as u32, key),
+            KdfAlgorithm::Pbkdf2HmacSha256 => pbkdf2_hmac::<Sha256>(password, salt, n as u32, key),
+            KdfAlgorithm::Pbkdf2HmacSha512 => pbkdf2_hmac::<Sha512>(password, salt, n as u32, key),
+        }
+
+        0
     }
 
     fn decrypt(

--- a/sqlcipher-crypto-provider/src/lib.rs
+++ b/sqlcipher-crypto-provider/src/lib.rs
@@ -1,0 +1,118 @@
+use core::ffi::CStr;
+
+pub trait SqlcipherCryptoProvider {
+    fn get_provider_name(&self) -> &CStr;
+
+    fn add_random(&mut self, _buffer: &[u8]) -> i32;
+    fn random(&mut self, _buffer: &mut [u8]) -> i32;
+
+    fn hmac(
+        &mut self,
+        algorithm: i32,
+        hmac_key: &[u8],
+        input1: &[u8],
+        input2: &[u8],
+        out: &mut [u8],
+    ) -> i32;
+
+    fn kdf(
+        &mut self,
+        algorithm: i32,
+        pass: &[u8],
+        salt: &[u8],
+        workfactor: i32,
+        key: &mut [u8],
+    ) -> i32;
+
+    fn cipher(&mut self, mode: i32, key: &[u8], iv: &[u8], input: &[u8], out: &mut [u8]) -> i32;
+
+    fn get_cipher(&self) -> &CStr;
+
+    fn get_key_sz(&self) -> i32;
+    fn get_iv_sz(&self) -> i32;
+    fn get_block_sz(&self) -> i32;
+    fn get_hmac_sz(&self, algorithm: i32) -> i32;
+
+    fn fips_status(&self) -> i32;
+
+    fn get_provider_version(&self) -> &CStr;
+}
+
+#[derive(Default)]
+pub struct RustCryptoProvider;
+
+impl SqlcipherCryptoProvider for RustCryptoProvider {
+    fn get_provider_name(&self) -> &CStr {
+        todo!()
+    }
+
+    fn add_random(&mut self, _buffer: &[u8]) -> i32 {
+        todo!()
+    }
+
+    fn random(&mut self, buffer: &mut [u8]) -> i32 {
+        rand::fill(buffer);
+        0
+    }
+
+    fn hmac(
+        &mut self,
+        _algorithm: i32,
+        _hmac_key: &[u8],
+        _input1: &[u8],
+        _input2: &[u8],
+        _out: &mut [u8],
+    ) -> i32 {
+        todo!()
+    }
+
+    fn kdf(
+        &mut self,
+        _algorithm: i32,
+        _pass: &[u8],
+        _salt: &[u8],
+        _workfactor: i32,
+        _key: &mut [u8],
+    ) -> i32 {
+        todo!()
+    }
+
+    fn cipher(
+        &mut self,
+        _mode: i32,
+        _key: &[u8],
+        _iv: &[u8],
+        _input: &[u8],
+        _out: &mut [u8],
+    ) -> i32 {
+        todo!()
+    }
+
+    fn get_cipher(&self) -> &CStr {
+        todo!()
+    }
+
+    fn get_key_sz(&self) -> i32 {
+        todo!()
+    }
+
+    fn get_iv_sz(&self) -> i32 {
+        todo!()
+    }
+
+    fn get_block_sz(&self) -> i32 {
+        todo!()
+    }
+
+    fn get_hmac_sz(&self, _algorithm: i32) -> i32 {
+        todo!()
+    }
+
+    fn fips_status(&self) -> i32 {
+        todo!()
+    }
+
+    fn get_provider_version(&self) -> &CStr {
+        todo!()
+    }
+}

--- a/sqlcipher-crypto-provider/src/lib.rs
+++ b/sqlcipher-crypto-provider/src/lib.rs
@@ -1,5 +1,9 @@
 use core::ffi::CStr;
 
+use hmac::{Hmac, Mac};
+use sha1::Sha1;
+use sha2::{Sha256, Sha512};
+
 #[derive(Copy, Clone, Eq, PartialEq)]
 pub enum HmacAlgorithm {
     HmacSha1,
@@ -85,13 +89,45 @@ impl SqlcipherCryptoProvider for RustCryptoProvider {
 
     fn hmac(
         &mut self,
-        _algorithm: HmacAlgorithm,
+        algorithm: HmacAlgorithm,
         _hmac_key: &[u8],
-        _input1: &[u8],
-        _input2: Option<&[u8]>,
-        _out: &mut [u8],
+        input1: &[u8],
+        input2: Option<&[u8]>,
+        out: &mut [u8],
     ) -> i32 {
-        todo!()
+        match algorithm {
+            HmacAlgorithm::HmacSha1 => {
+                let mut mac = Hmac::<Sha1>::new_from_slice(_hmac_key).expect("hmac from any size");
+                mac.update(input1);
+                if let Some(input) = input2 {
+                    mac.update(input);
+                }
+                let result = mac.finalize().into_bytes();
+                out.copy_from_slice(&result);
+            }
+            HmacAlgorithm::HmacSha256 => {
+                let mut mac =
+                    Hmac::<Sha256>::new_from_slice(_hmac_key).expect("hmac from any size");
+                mac.update(input1);
+                if let Some(input) = input2 {
+                    mac.update(input);
+                }
+                let result = mac.finalize().into_bytes();
+                out.copy_from_slice(&result);
+            }
+            HmacAlgorithm::HmacSha512 => {
+                let mut mac =
+                    Hmac::<Sha512>::new_from_slice(_hmac_key).expect("hmac from any size");
+                mac.update(input1);
+                if let Some(input) = input2 {
+                    mac.update(input);
+                }
+                let result = mac.finalize().into_bytes();
+                out.copy_from_slice(&result);
+            }
+        }
+
+        0
     }
 
     fn kdf(
@@ -137,8 +173,8 @@ impl SqlcipherCryptoProvider for RustCryptoProvider {
         todo!()
     }
 
-    fn get_hmac_sz(&self, _algorithm: HmacAlgorithm) -> i32 {
-        todo!()
+    fn get_hmac_sz(&self, algorithm: HmacAlgorithm) -> i32 {
+        algorithm.output_len() as i32
     }
 
     fn fips_status(&self) -> i32 {

--- a/sqlcipher-crypto-provider/src/lib.rs
+++ b/sqlcipher-crypto-provider/src/lib.rs
@@ -201,7 +201,7 @@ impl SqlcipherCryptoProvider for RustCryptoProvider {
     }
 
     fn fips_status(&self) -> i32 {
-        todo!()
+        -1
     }
 
     fn get_provider_version(&self) -> &CStr {

--- a/sqlcipher-crypto-provider/src/lib.rs
+++ b/sqlcipher-crypto-provider/src/lib.rs
@@ -1,9 +1,16 @@
 use core::ffi::CStr;
 
+use aes::cipher::{
+    BlockDecryptMut, BlockEncryptMut, BlockSizeUser, IvSizeUser, KeyIvInit, KeySizeUser,
+    block_padding::NoPadding,
+};
 use hmac::{Hmac, Mac};
 use pbkdf2::pbkdf2_hmac;
 use sha1::Sha1;
 use sha2::{Sha256, Sha512};
+
+type Aes256CbcEnc = cbc::Encryptor<aes::Aes256>;
+type Aes256CbcDec = cbc::Decryptor<aes::Aes256>;
 
 #[derive(Copy, Clone, Eq, PartialEq)]
 pub enum HmacAlgorithm {
@@ -32,10 +39,11 @@ pub enum KdfAlgorithm {
 impl KdfAlgorithm {}
 
 pub trait SqlcipherCryptoProvider {
+    // TODO: should the lifetime of the return value be limited to 'static?
     fn get_provider_name(&self) -> &CStr;
 
-    fn add_random(&mut self, _buffer: &[u8]) -> i32;
-    fn random(&mut self, _buffer: &mut [u8]) -> i32;
+    fn add_random(&mut self, buffer: &[u8]) -> i32;
+    fn random(&mut self, buffer: &mut [u8]) -> i32;
 
     fn hmac(
         &mut self,
@@ -58,6 +66,7 @@ pub trait SqlcipherCryptoProvider {
     fn encrypt(&mut self, key: &[u8], iv: &[u8], input: &[u8], out: &mut [u8]) -> i32;
     fn decrypt(&mut self, key: &[u8], iv: &[u8], input: &[u8], out: &mut [u8]) -> i32;
 
+    // TODO: should the lifetime of the return value be limited to 'static?
     fn get_cipher(&self) -> &CStr;
 
     fn get_key_sz(&self) -> i32;
@@ -67,6 +76,7 @@ pub trait SqlcipherCryptoProvider {
 
     fn fips_status(&self) -> i32;
 
+    // TODO: should the lifetime of the return value be limited to 'static?
     fn get_provider_version(&self) -> &CStr;
 }
 
@@ -75,11 +85,14 @@ pub struct RustCryptoProvider;
 
 impl SqlcipherCryptoProvider for RustCryptoProvider {
     fn get_provider_name(&self) -> &CStr {
-        todo!()
+        c"RustCrypto"
     }
 
     fn add_random(&mut self, _buffer: &[u8]) -> i32 {
-        todo!()
+        // We discard the randomness.
+        // `ThreadRng` from `rand` has no API to add seed data, and it's fast and secure enough on
+        // its own.
+        0
     }
 
     fn random(&mut self, buffer: &mut [u8]) -> i32 {
@@ -147,36 +160,40 @@ impl SqlcipherCryptoProvider for RustCryptoProvider {
         0
     }
 
-    fn decrypt(
-        &mut self,
-        _key: &[u8],
-        _iv: &[u8],
-        _input: &[u8],
-        _out: &mut [u8],
-    ) -> i32 {
-        todo!()
+    fn decrypt(&mut self, key: &[u8], iv: &[u8], input: &[u8], out: &mut [u8]) -> i32 {
+        let dec = Aes256CbcDec::new(key.into(), iv.into());
+        if let Err(_e) = dec.decrypt_padded_b2b_mut::<NoPadding>(input, out) {
+            out.fill(0);
+            return -1;
+        }
+
+        0
     }
 
-    fn encrypt(
-        &mut self,
-        _key: &[u8],
-        _iv: &[u8],
-        _input: &[u8],
-        _out: &mut [u8],
-    ) -> i32 {
-        todo!()
+    fn encrypt(&mut self, key: &[u8], iv: &[u8], input: &[u8], out: &mut [u8]) -> i32 {
+        let dec = Aes256CbcEnc::new(key.into(), iv.into());
+        if let Err(_e) = dec.encrypt_padded_b2b_mut::<NoPadding>(input, out) {
+            out.fill(0);
+            return -1;
+        }
+
+        0
+    }
+
+    fn get_cipher(&self) -> &CStr {
+        c"aes256-CBC"
     }
 
     fn get_key_sz(&self) -> i32 {
-        todo!()
+        Aes256CbcEnc::key_size() as i32
     }
 
     fn get_iv_sz(&self) -> i32 {
-        todo!()
+        Aes256CbcEnc::iv_size() as i32
     }
 
     fn get_block_sz(&self) -> i32 {
-        todo!()
+        Aes256CbcEnc::block_size() as i32
     }
 
     fn get_hmac_sz(&self, algorithm: HmacAlgorithm) -> i32 {
@@ -188,6 +205,7 @@ impl SqlcipherCryptoProvider for RustCryptoProvider {
     }
 
     fn get_provider_version(&self) -> &CStr {
-        todo!()
+        // env!("CARGO_PKG_VERSION").into()
+        c"0.1.0"
     }
 }

--- a/sqlcipher-crypto-provider/src/lib.rs
+++ b/sqlcipher-crypto-provider/src/lib.rs
@@ -1,5 +1,32 @@
 use core::ffi::CStr;
 
+#[derive(Copy, Clone, Eq, PartialEq)]
+pub enum HmacAlgorithm {
+    HmacSha1,
+    HmacSha256,
+    HmacSha512,
+}
+
+impl HmacAlgorithm {
+    pub const fn output_len(&self) -> usize {
+        match self {
+            HmacAlgorithm::HmacSha1 => 20,
+            HmacAlgorithm::HmacSha256 => 32,
+            HmacAlgorithm::HmacSha512 => 64,
+        }
+    }
+}
+
+#[derive(Copy, Clone, Eq, PartialEq)]
+pub enum KdfAlgorithm {
+    Pbkdf2HmacSha1,
+    Pbkdf2HmacSha256,
+    Pbkdf2HmacSha512,
+}
+
+impl KdfAlgorithm {
+}
+
 pub trait SqlcipherCryptoProvider {
     fn get_provider_name(&self) -> &CStr;
 
@@ -8,30 +35,31 @@ pub trait SqlcipherCryptoProvider {
 
     fn hmac(
         &mut self,
-        algorithm: i32,
+        algorithm: HmacAlgorithm,
         hmac_key: &[u8],
         input1: &[u8],
-        input2: &[u8],
+        input2: Option<&[u8]>,
         out: &mut [u8],
     ) -> i32;
 
     fn kdf(
         &mut self,
-        algorithm: i32,
+        algorithm: KdfAlgorithm,
         pass: &[u8],
         salt: &[u8],
         workfactor: i32,
         key: &mut [u8],
     ) -> i32;
 
-    fn cipher(&mut self, mode: i32, key: &[u8], iv: &[u8], input: &[u8], out: &mut [u8]) -> i32;
+    fn encrypt(&mut self, key: &[u8], iv: &[u8], input: &[u8], out: &mut [u8]) -> i32;
+    fn decrypt(&mut self, key: &[u8], iv: &[u8], input: &[u8], out: &mut [u8]) -> i32;
 
     fn get_cipher(&self) -> &CStr;
 
     fn get_key_sz(&self) -> i32;
     fn get_iv_sz(&self) -> i32;
     fn get_block_sz(&self) -> i32;
-    fn get_hmac_sz(&self, algorithm: i32) -> i32;
+    fn get_hmac_sz(&self, algorithm: HmacAlgorithm) -> i32;
 
     fn fips_status(&self) -> i32;
 
@@ -57,10 +85,10 @@ impl SqlcipherCryptoProvider for RustCryptoProvider {
 
     fn hmac(
         &mut self,
-        _algorithm: i32,
+        _algorithm: HmacAlgorithm,
         _hmac_key: &[u8],
         _input1: &[u8],
-        _input2: &[u8],
+        _input2: Option<&[u8]>,
         _out: &mut [u8],
     ) -> i32 {
         todo!()
@@ -68,7 +96,7 @@ impl SqlcipherCryptoProvider for RustCryptoProvider {
 
     fn kdf(
         &mut self,
-        _algorithm: i32,
+        _algorithm: KdfAlgorithm,
         _pass: &[u8],
         _salt: &[u8],
         _workfactor: i32,
@@ -77,9 +105,8 @@ impl SqlcipherCryptoProvider for RustCryptoProvider {
         todo!()
     }
 
-    fn cipher(
+    fn decrypt(
         &mut self,
-        _mode: i32,
         _key: &[u8],
         _iv: &[u8],
         _input: &[u8],
@@ -88,7 +115,13 @@ impl SqlcipherCryptoProvider for RustCryptoProvider {
         todo!()
     }
 
-    fn get_cipher(&self) -> &CStr {
+    fn encrypt(
+        &mut self,
+        _key: &[u8],
+        _iv: &[u8],
+        _input: &[u8],
+        _out: &mut [u8],
+    ) -> i32 {
         todo!()
     }
 
@@ -104,7 +137,7 @@ impl SqlcipherCryptoProvider for RustCryptoProvider {
         todo!()
     }
 
-    fn get_hmac_sz(&self, _algorithm: i32) -> i32 {
+    fn get_hmac_sz(&self, _algorithm: HmacAlgorithm) -> i32 {
         todo!()
     }
 


### PR DESCRIPTION
This PR introduces an interface to enable a custom crypto provider for Sqlcipher, and ships a simple custom crypto provider through the RustCrypto crates.

### Motivation
Sqlcipher uses OpenSSL as default crypto provider. Either it ships its own vendored OpenSSL (`bundled-sqlcipher-vendored-openssl`) or links to the system OpenSSL. Either way, it depends on OpenSSL, and may conflict with projects that use BoringSSL (exposing the same C symbols).

Second, this allows to further reduce reliance on C-based crypto implementations.

Third, custom crypto providers *technically* allow customized crypto on sqlcipher databases, although the sqlcipher interface really isn't designed to swap out primitives.

### Changes
- Added a new trait `SqlcipherCryptoProvider`, with some rough mapping to the `struct sqlcipher_provider` C-style vtable.
- Add `RustCryptoProvider`, an implementation of that trait, based on RustCrypto's AES/PBKDF2/HMAC/digest. This is compatible with the existing sqlcipher implementation.
- Hardcode the `RustCryptoProvider` when the `bundled-sqlcipher-custom-crypto` is enabled.
- Swap `sqlite3.h` out for `sqlcipher.h` in binding generation, to access the necessary interfaces.
- Backport https://github.com/sqlcipher/sqlcipher/commit/c89bab0b4 with a `.patch` in `upgrade_sqlcipher.sh`.

### Backward Compatibility
This change is fully backward-compatible. Existing code will continue to use the default provider unless explicitly overridden.

### Open Questions
- How do we test this, and keep this CI-tested? I have locally created an SQLcipher database, and tried to read it with our own interface. This works.
- We probably want to allow external implementations of the interface. SQLcipher has the infra to dynamically swap out the provider. However: it *kinda* wants a default fallback. Setting a default provider will probably also require some static RefCell. I didn't necessarily think a lot on this yet.
- Does the `rusqlite` repo actually want something like this? It's a maintenance overhead, and I don't necessarily want to burden you with it.