### PR TITLE
Fix VTab::connect / create

### DIFF
--- a/src/vtab/array.rs
+++ b/src/vtab/array.rs
@@ -74,10 +74,18 @@ unsafe impl<'vtab> VTab<'vtab> for ArrayTab {
     type Aux = ();
     type Cursor = ArrayTabCursor<'vtab>;
 
-    fn connect(_: &mut VTabConnection, aux: Option<&()>, args: &[&[u8]]) -> Result<(String, Self)> {
+    fn connect(
+        _: &mut VTabConnection,
+        aux: Option<&()>,
+        module_name: &[u8],
+        _database_name: &[u8],
+        table_name: &[u8],
+        args: &[&[u8]],
+    ) -> Result<(String, Self)> {
         debug_assert_eq!(aux, None);
-        debug_assert_eq!(args.len(), 3);
-        debug_assert_eq!(args[0], MODULE_NAME.to_bytes());
+        debug_assert_eq!(module_name, MODULE_NAME.to_bytes());
+        debug_assert_eq!(table_name, MODULE_NAME.to_bytes());
+        debug_assert_eq!(args.len(), 0);
         let vtab = Self {
             base: ffi::sqlite3_vtab::default(),
         };

--- a/src/vtab/csvtab.rs
+++ b/src/vtab/csvtab.rs
@@ -93,11 +93,14 @@ unsafe impl<'vtab> VTab<'vtab> for CsvTab {
     fn connect(
         db: &mut VTabConnection,
         aux: Option<&()>,
+        module_name: &[u8],
+        _database_name: &[u8],
+        _table_name: &[u8],
         args: &[&[u8]],
     ) -> Result<(String, Self)> {
         debug_assert_eq!(aux, None);
-        debug_assert_eq!(args[0], MODULE_NAME.to_bytes());
-        if args.len() < 4 {
+        debug_assert_eq!(module_name, MODULE_NAME.to_bytes());
+        if args.is_empty() {
             return Err(Error::ModuleError("no CSV file specified".to_owned()));
         }
 
@@ -112,7 +115,6 @@ unsafe impl<'vtab> VTab<'vtab> for CsvTab {
         let mut schema = None;
         let mut n_col = None;
 
-        let args = &args[3..];
         for c_slice in args {
             let (param, value) = super::parameter(c_slice)?;
             match param {

--- a/src/vtab/mod.rs
+++ b/src/vtab/mod.rs
@@ -281,6 +281,9 @@ pub unsafe trait VTab<'vtab>: Sized {
     fn connect(
         db: &mut VTabConnection,
         aux: Option<&Self::Aux>,
+        module_name: &[u8],
+        database_name: &[u8],
+        table_name: &[u8],
         args: &[&[u8]],
     ) -> Result<(String, Self)>;
 
@@ -312,9 +315,12 @@ pub trait CreateVTab<'vtab>: VTab<'vtab> {
     fn create(
         db: &mut VTabConnection,
         aux: Option<&Self::Aux>,
+        module_name: &[u8],
+        database_name: &[u8],
+        table_name: &[u8],
         args: &[&[u8]],
     ) -> Result<(String, Self)> {
-        Self::connect(db, aux, args)
+        Self::connect(db, aux, module_name, database_name, table_name, args)
     }
 
     /// Destroy the underlying table implementation. This method undoes the work
@@ -1214,7 +1220,7 @@ where
         .iter()
         .map(|&cs| CStr::from_ptr(cs).to_bytes()) // FIXME .to_str() -> Result<&str, Utf8Error>
         .collect::<Vec<_>>();
-    match T::create(&mut conn, aux.as_ref(), &vec[..]) {
+    match T::create(&mut conn, aux.as_ref(), vec[0], vec[1], vec[2], &vec[3..]) {
         Ok((sql, vtab)) => match std::ffi::CString::new(sql) {
             Ok(c_sql) => {
                 let rc = ffi::sqlite3_declare_vtab(db, c_sql.as_ptr());
@@ -1254,7 +1260,7 @@ where
         .iter()
         .map(|&cs| CStr::from_ptr(cs).to_bytes()) // FIXME .to_str() -> Result<&str, Utf8Error>
         .collect::<Vec<_>>();
-    match T::connect(&mut conn, aux.as_ref(), &vec[..]) {
+    match T::connect(&mut conn, aux.as_ref(), vec[0], vec[1], vec[2], &vec[3..]) {
         Ok((sql, vtab)) => match std::ffi::CString::new(sql) {
             Ok(c_sql) => {
                 let rc = ffi::sqlite3_declare_vtab(db, c_sql.as_ptr());

--- a/src/vtab/series.rs
+++ b/src/vtab/series.rs
@@ -62,10 +62,14 @@ unsafe impl<'vtab> VTab<'vtab> for SeriesTab {
     fn connect(
         db: &mut VTabConnection,
         aux: Option<&()>,
-        args: &[&[u8]],
+        module_name: &[u8],
+        _database_name: &[u8],
+        table_name: &[u8],
+        _args: &[&[u8]],
     ) -> Result<(String, Self)> {
         debug_assert_eq!(aux, None);
-        debug_assert_eq!(args[0], MODULE_NAME.to_bytes());
+        debug_assert_eq!(module_name, MODULE_NAME.to_bytes());
+        debug_assert_eq!(table_name, MODULE_NAME.to_bytes());
         let vtab = Self {
             base: ffi::sqlite3_vtab::default(),
         };

--- a/src/vtab/vtablog.rs
+++ b/src/vtab/vtablog.rs
@@ -42,24 +42,27 @@ impl VTabLog {
     fn connect_create(
         db: &mut VTabConnection,
         aux: Option<&()>,
+        module_name: &[u8],
+        database_name: &[u8],
+        table_name: &[u8],
         args: &[&[u8]],
         is_create: bool,
     ) -> Result<(String, Self)> {
         debug_assert_eq!(aux, None);
-        debug_assert_eq!(args[0], MODULE_NAME.to_bytes());
-        debug_assert!(args.len() >= 3);
+        debug_assert_eq!(module_name, MODULE_NAME.to_bytes());
         static N_INST: AtomicUsize = AtomicUsize::new(1);
         let i_inst = N_INST.fetch_add(1, Ordering::SeqCst);
         println!(
-            "VTabLog::{}(tab={}, args={:?}):",
+            "VTabLog::{}(tab={}, database_name={}, table_name={}, args={:?}):",
             if is_create { "create" } else { "connect" },
             i_inst,
+            str::from_utf8(database_name)?,
+            str::from_utf8(table_name)?,
             args.iter().map(|b| str::from_utf8(b)).collect::<Vec<_>>(),
         );
         let mut schema = None;
         let mut n_row = None;
 
-        let args = &args[3..];
         for c_slice in args {
             let (param, value) = super::parameter(c_slice)?;
             match param {
@@ -115,9 +118,12 @@ unsafe impl<'vtab> VTab<'vtab> for VTabLog {
     fn connect(
         db: &mut VTabConnection,
         aux: Option<&Self::Aux>,
+        module_name: &[u8],
+        database_name: &[u8],
+        table_name: &[u8],
         args: &[&[u8]],
     ) -> Result<(String, Self)> {
-        Self::connect_create(db, aux, args, false)
+        Self::connect_create(db, aux, module_name, database_name, table_name, args, false)
     }
 
     fn best_index(&self, info: &mut IndexInfo) -> Result<bool> {
@@ -175,9 +181,12 @@ impl CreateVTab<'_> for VTabLog {
     fn create(
         db: &mut VTabConnection,
         aux: Option<&Self::Aux>,
+        module_name: &[u8],
+        database_name: &[u8],
+        table_name: &[u8],
         args: &[&[u8]],
     ) -> Result<(String, Self)> {
-        Self::connect_create(db, aux, args, true)
+        Self::connect_create(db, aux, module_name, database_name, table_name, args, true)
     }
 
     fn destroy(&self) -> Result<()> {

--- a/tests/vtab.rs
+++ b/tests/vtab.rs
@@ -27,9 +27,13 @@ fn test_dummy_module() -> rusqlite::Result<()> {
 
         fn connect(
             _: &mut VTabConnection,
-            _aux: Option<&()>,
+            aux: Option<&()>,
+            _module_name: &[u8],
+            _database_name: &[u8],
+            _table_name: &[u8],
             _args: &[&[u8]],
         ) -> Result<(String, Self)> {
+            debug_assert_eq!(aux, None);
             let vtab = Self {
                 base: sqlite3_vtab::default(),
             };


### PR DESCRIPTION
https://sqlite.org/vtab.html#the_xcreate_method
- The first string, argv[0], is the name of the module being invoked.
- The second, argv[1], is the name of the database in which the new virtual table is being created.
- The third element of the array, argv[2], is the name of the new virtual table