### PR TITLE
Allow opting out of using sqlite-wasm-rs on wasm32-unknown-unknown

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,28 +50,28 @@ functions = []
 # sqlite3_log / sqlite3_trace_v2
 trace = []
 # Use bundled SQLite sources (instead of the one provided by your OS / distribution)
-bundled = ["libsqlite3-sys/bundled", "modern_sqlite"]
+bundled = ["libsqlite3-sys?/bundled", "modern_sqlite"]
 # Use SQLCipher instead of SQLite
-bundled-sqlcipher = ["libsqlite3-sys/bundled-sqlcipher", "bundled"]
+bundled-sqlcipher = ["libsqlite3-sys?/bundled-sqlcipher", "bundled"]
 bundled-sqlcipher-vendored-openssl = [
-    "libsqlite3-sys/bundled-sqlcipher-vendored-openssl",
+    "libsqlite3-sys?/bundled-sqlcipher-vendored-openssl",
     "bundled-sqlcipher",
 ]
-buildtime_bindgen = ["libsqlite3-sys/buildtime_bindgen", "sqlite-wasm-rs/bindgen"]
+buildtime_bindgen = ["libsqlite3-sys?/buildtime_bindgen", "sqlite-wasm-rs?/bindgen"]
 # sqlite3_limit
 limits = []
 # Used to generate a cdylib
-loadable_extension = ["libsqlite3-sys/loadable_extension"]
+loadable_extension = ["libsqlite3-sys?/loadable_extension"]
 # sqlite3_commit_hook, sqlite3_rollback_hook, ...
 hooks = []
 # if SQLITE_ENABLE_PREUPDATE_HOOK
-preupdate_hook = ["libsqlite3-sys/preupdate_hook", "hooks"]
+preupdate_hook = ["libsqlite3-sys?/preupdate_hook", "hooks"]
 # u64, usize, NonZeroU64, NonZeroUsize
 fallible_uint = []
 i128_blob = []
-sqlcipher = ["libsqlite3-sys/sqlcipher"]
+sqlcipher = ["libsqlite3-sys?/sqlcipher"]
 # SQLITE_ENABLE_UNLOCK_NOTIFY
-unlock_notify = ["libsqlite3-sys/unlock_notify"]
+unlock_notify = ["libsqlite3-sys?/unlock_notify"]
 # if not SQLITE_OMIT_VIRTUALTABLE
 # sqlite3_vtab
 vtab = []
@@ -80,7 +80,7 @@ csvtab = ["csv", "vtab"]
 array = ["vtab", "pointer"]
 # if SQLITE_ENABLE_SESSION
 # session extension
-session = ["libsqlite3-sys/session", "hooks"]
+session = ["libsqlite3-sys?/session", "hooks"]
 # if not SQLITE_OMIT_WINDOWFUNC
 # sqlite3_create_window_function
 window = ["functions"]
@@ -89,20 +89,22 @@ series = ["vtab"]
 # check for invalid query.
 extra_check = []
 # ]3.34.1, last]
-modern_sqlite = ["libsqlite3-sys/bundled_bindings"]
-in_gecko = ["modern_sqlite", "libsqlite3-sys/in_gecko"]
-bundled-windows = ["libsqlite3-sys/bundled-windows"]
+modern_sqlite = ["libsqlite3-sys?/bundled_bindings"]
+in_gecko = ["modern_sqlite", "libsqlite3-sys?/in_gecko"]
+bundled-windows = ["libsqlite3-sys?/bundled-windows"]
 # Build bundled sqlite with -fsanitize=address
-with-asan = ["libsqlite3-sys/with-asan"]
+with-asan = ["libsqlite3-sys?/with-asan"]
 # if SQLITE_ENABLE_COLUMN_METADATA
-column_metadata = ["libsqlite3-sys/column_metadata"]
+column_metadata = ["libsqlite3-sys?/column_metadata"]
 # if not SQLITE_OMIT_DECLTYPE
 column_decltype = []
-wasm32-wasi-vfs = ["libsqlite3-sys/wasm32-wasi-vfs"]
+wasm32-wasi-vfs = ["libsqlite3-sys?/wasm32-wasi-vfs"]
 # if not SQLITE_OMIT_DESERIALIZE
 serialize = []
 # pointer passing interfaces: 3.20.0
 pointer = []
+# On wasm32-unknown-unknown builds use the sqlite-wasm-rs crate instead of libsqlite3-sys
+ffi-sqlite-wasm-rs = ["dep:sqlite-wasm-rs"]
 
 # Helper feature for enabling most non-build-related optional features
 # or dependencies (except `session`). This is useful for running tests / clippy
@@ -138,7 +140,7 @@ modern-full = [
 ]
 
 bundled-full = ["modern-full", "bundled"]
-default = ["cache"]
+default = ["cache", "ffi-sqlite-wasm-rs"]
 
 [dependencies]
 # Jiff Date/Time/Timestamp persistence
@@ -176,7 +178,8 @@ rusqlite-macros = { path = "rusqlite-macros", version = "0.4.2", optional = true
 libsqlite3-sys = { path = "libsqlite3-sys", version = "0.37.0" }
 
 [target.'cfg(all(target_family = "wasm", target_os = "unknown"))'.dependencies]
-sqlite-wasm-rs = { version = "0.5.1", default-features = false }
+libsqlite3-sys = { path = "libsqlite3-sys", version = "0.37.0", optional = true }
+sqlite-wasm-rs = { version = "0.5.1", default-features = false, optional = true }
 chrono = { version = "0.4.42", optional = true, default-features = false, features = ["wasmbind"] }
 jiff = { version = "0.2", optional = true, default-features = false, features = ["js"] }
 time = { version = "0.3.47", optional = true, features = ["wasm-bindgen"] }
@@ -184,6 +187,7 @@ uuid = { version = "1.0", optional = true, features = ["js"] }
 
 [target.'cfg(all(target_family = "wasm", target_os = "unknown"))'.dev-dependencies]
 # Something is dependent on them, we use feature to override it.
+sqlite-wasm-rs = { version = "0.5.1", default-features = false }
 uuid = { version = "1.0", features = ["js"] }
 getrandom = { version = "0.4", features = ["wasm_js"] }
 wasm-bindgen-test = "0.3.54"

--- a/README.md
+++ b/README.md
@@ -143,6 +143,9 @@ features](https://doc.rust-lang.org/cargo/reference/manifest.html#the-features-s
 * `rusqlite-macros` enables the use of the [`prepare_and_bind`](https://docs.rs/rusqlite/~0/rusqlite/macro.prepare_and_bind.html)
   and [`prepare_cached_and_bind`](https://docs.rs/rusqlite/~0/rusqlite/macro.prepare_cached_and_bind.html)
   procedural macros, which allow capturing identifiers in SQL statements.
+* `ffi-sqlite-wasm-rs` switches to using the `sqlite-wasm-rs` crate (instead of
+  `libsqlite3-sys`) on `wasm32-unknown-unknown` builds. This is enabled by
+  default and can be opted out by setting `default-features = false`.
 
 
 ## Notes on building rusqlite and libsqlite3-sys

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -57,9 +57,17 @@
 pub use fallible_iterator;
 pub use fallible_streaming_iterator;
 
-#[cfg(not(all(target_family = "wasm", target_os = "unknown")))]
+#[cfg(not(all(
+    target_family = "wasm",
+    target_os = "unknown",
+    any(test, feature = "ffi-sqlite-wasm-rs")
+)))]
 pub use libsqlite3_sys as ffi;
-#[cfg(all(target_family = "wasm", target_os = "unknown"))]
+#[cfg(all(
+    target_family = "wasm",
+    target_os = "unknown",
+    any(test, feature = "ffi-sqlite-wasm-rs")
+))]
 pub use sqlite_wasm_rs as ffi;
 
 use std::cell::RefCell;


### PR DESCRIPTION
This is an attempt to address https://github.com/rusqlite/rusqlite/issues/1828 by leaning into cargo feature flags and target dependencies.

Note: this will technically be a breaking change for anyone building for `wasm32-unknown-unknown` with `rusqlite = { default-features = false }` as they will now need to opt into `rusqlite/ffi-sqlite-wasm-rs`. Though this seemed like a better tradeoff than making `ffi-sqlite-wasm-rs` a non-default feature and requiring _everyone_ who currently builds for `wasm32-unknown-unknown` to then have to enable `rusqlite/ffi-sqlite-wasm-rs`.

Please let me know if you'd prefer I take a different direction!