### PR TITLE
Fix VTab::connect

### DIFF
--- a/src/vtab/array.rs
+++ b/src/vtab/array.rs
@@ -26,6 +26,7 @@
 //! }
 //! ```
 
+use std::borrow::Cow;
 use std::ffi::{c_int, CStr};
 use std::marker::PhantomData;
 use std::rc::Rc;
@@ -81,7 +82,7 @@ unsafe impl<'vtab> VTab<'vtab> for ArrayTab {
         _database_name: &[u8],
         table_name: &[u8],
         args: &[&[u8]],
-    ) -> Result<(String, Self)> {
+    ) -> Result<(Cow<'static, CStr>, Self)> {
         debug_assert_eq!(aux, None);
         debug_assert_eq!(module_name, MODULE_NAME.to_bytes());
         debug_assert_eq!(table_name, MODULE_NAME.to_bytes());
@@ -89,7 +90,7 @@ unsafe impl<'vtab> VTab<'vtab> for ArrayTab {
         let vtab = Self {
             base: ffi::sqlite3_vtab::default(),
         };
-        Ok(("CREATE TABLE x(value,pointer hidden)".to_owned(), vtab))
+        Ok((Cow::Borrowed(c"CREATE TABLE x(value,pointer hidden)"), vtab))
     }
 
     fn best_index(&self, info: &mut IndexInfo) -> Result<bool> {

--- a/src/vtab/csvtab.rs
+++ b/src/vtab/csvtab.rs
@@ -21,7 +21,8 @@
 //!     Ok(())
 //! }
 //! ```
-use std::ffi::{c_int, CStr};
+use std::borrow::Cow;
+use std::ffi::{c_int, CStr, CString};
 use std::fs::File;
 use std::marker::PhantomData;
 use std::path::Path;
@@ -97,7 +98,7 @@ unsafe impl<'vtab> VTab<'vtab> for CsvTab {
         _database_name: &[u8],
         _table_name: &[u8],
         args: &[&[u8]],
-    ) -> Result<(String, Self)> {
+    ) -> Result<(Cow<'static, CStr>, Self)> {
         debug_assert_eq!(aux, None);
         debug_assert_eq!(module_name, MODULE_NAME.to_bytes());
         if args.is_empty() {
@@ -125,7 +126,7 @@ unsafe impl<'vtab> VTab<'vtab> for CsvTab {
                     value.clone_into(&mut vtab.filename);
                 }
                 "schema" => {
-                    schema = Some(value.to_owned());
+                    schema = Some(CString::new(value)?);
                 }
                 "columns" => {
                     if let Ok(n) = value.parse::<u16>() {
@@ -233,10 +234,10 @@ unsafe impl<'vtab> VTab<'vtab> for CsvTab {
                     sql.push_str(", ");
                 }
             }
-            schema = Some(sql);
+            schema = Some(CString::new(sql)?);
         }
         db.config(VTabConfig::DirectOnly)?;
-        Ok((schema.unwrap(), vtab))
+        Ok((Cow::Owned(schema.unwrap()), vtab))
     }
 
     // Only a forward full table scan is supported.

--- a/src/vtab/mod.rs
+++ b/src/vtab/mod.rs
@@ -285,7 +285,7 @@ pub unsafe trait VTab<'vtab>: Sized {
         database_name: &[u8],
         table_name: &[u8],
         args: &[&[u8]],
-    ) -> Result<(String, Self)>;
+    ) -> Result<(Cow<'static, CStr>, Self)>;
 
     /// Determine the best way to access the virtual table.
     /// (See [SQLite doc](https://sqlite.org/vtab.html#the_xbestindex_method))
@@ -319,7 +319,7 @@ pub trait CreateVTab<'vtab>: VTab<'vtab> {
         database_name: &[u8],
         table_name: &[u8],
         args: &[&[u8]],
-    ) -> Result<(String, Self)> {
+    ) -> Result<(Cow<'static, CStr>, Self)> {
         Self::connect(db, aux, module_name, database_name, table_name, args)
     }
 
@@ -1221,23 +1221,17 @@ where
         .map(|&cs| CStr::from_ptr(cs).to_bytes()) // FIXME .to_str() -> Result<&str, Utf8Error>
         .collect::<Vec<_>>();
     match T::create(&mut conn, aux.as_ref(), vec[0], vec[1], vec[2], &vec[3..]) {
-        Ok((sql, vtab)) => match std::ffi::CString::new(sql) {
-            Ok(c_sql) => {
-                let rc = ffi::sqlite3_declare_vtab(db, c_sql.as_ptr());
-                if rc == ffi::SQLITE_OK {
-                    let boxed_vtab: *mut T = Box::into_raw(Box::new(vtab));
-                    *pp_vtab = boxed_vtab.cast::<sqlite3_vtab>();
-                    ffi::SQLITE_OK
-                } else {
-                    let err = error_from_sqlite_code(rc, None);
-                    to_sqlite_error(&err, err_msg)
-                }
+        Ok((sql, vtab)) => {
+            let rc = ffi::sqlite3_declare_vtab(db, sql.as_ptr());
+            if rc == ffi::SQLITE_OK {
+                let boxed_vtab: *mut T = Box::into_raw(Box::new(vtab));
+                *pp_vtab = boxed_vtab.cast::<sqlite3_vtab>();
+                ffi::SQLITE_OK
+            } else {
+                let err = error_from_sqlite_code(rc, None);
+                to_sqlite_error(&err, err_msg)
             }
-            Err(err) => {
-                *err_msg = alloc(&err.to_string());
-                ffi::SQLITE_ERROR
-            }
-        },
+        }
         Err(err) => to_sqlite_error(&err, err_msg),
     }
 }
@@ -1261,23 +1255,17 @@ where
         .map(|&cs| CStr::from_ptr(cs).to_bytes()) // FIXME .to_str() -> Result<&str, Utf8Error>
         .collect::<Vec<_>>();
     match T::connect(&mut conn, aux.as_ref(), vec[0], vec[1], vec[2], &vec[3..]) {
-        Ok((sql, vtab)) => match std::ffi::CString::new(sql) {
-            Ok(c_sql) => {
-                let rc = ffi::sqlite3_declare_vtab(db, c_sql.as_ptr());
-                if rc == ffi::SQLITE_OK {
-                    let boxed_vtab: *mut T = Box::into_raw(Box::new(vtab));
-                    *pp_vtab = boxed_vtab.cast::<sqlite3_vtab>();
-                    ffi::SQLITE_OK
-                } else {
-                    let err = error_from_sqlite_code(rc, None);
-                    to_sqlite_error(&err, err_msg)
-                }
+        Ok((sql, vtab)) => {
+            let rc = ffi::sqlite3_declare_vtab(db, sql.as_ptr());
+            if rc == ffi::SQLITE_OK {
+                let boxed_vtab: *mut T = Box::into_raw(Box::new(vtab));
+                *pp_vtab = boxed_vtab.cast::<sqlite3_vtab>();
+                ffi::SQLITE_OK
+            } else {
+                let err = error_from_sqlite_code(rc, None);
+                to_sqlite_error(&err, err_msg)
             }
-            Err(err) => {
-                *err_msg = alloc(&err.to_string());
-                ffi::SQLITE_ERROR
-            }
-        },
+        }
         Err(err) => to_sqlite_error(&err, err_msg),
     }
 }

--- a/src/vtab/series.rs
+++ b/src/vtab/series.rs
@@ -3,6 +3,7 @@
 //! Port of C [generate series
 //! "function"](https://sqlite.org/src/file/ext/misc/series.c):
 //! `https://www.sqlite.org/series.html`
+use std::borrow::Cow;
 use std::ffi::{c_int, CStr};
 use std::marker::PhantomData;
 
@@ -66,7 +67,7 @@ unsafe impl<'vtab> VTab<'vtab> for SeriesTab {
         _database_name: &[u8],
         table_name: &[u8],
         _args: &[&[u8]],
-    ) -> Result<(String, Self)> {
+    ) -> Result<(Cow<'static, CStr>, Self)> {
         debug_assert_eq!(aux, None);
         debug_assert_eq!(module_name, MODULE_NAME.to_bytes());
         debug_assert_eq!(table_name, MODULE_NAME.to_bytes());
@@ -75,7 +76,7 @@ unsafe impl<'vtab> VTab<'vtab> for SeriesTab {
         };
         db.config(VTabConfig::Innocuous)?;
         Ok((
-            "CREATE TABLE x(value,start hidden,stop hidden,step hidden)".to_owned(),
+            Cow::Borrowed(c"CREATE TABLE x(value,start hidden,stop hidden,step hidden)"),
             vtab,
         ))
     }

--- a/src/vtab/vtablog.rs
+++ b/src/vtab/vtablog.rs
@@ -1,5 +1,6 @@
 //! Port of C [vtablog](https://sqlite.org/src/file/ext/misc/vtablog.c)
-use std::ffi::{c_int, CStr};
+use std::borrow::Cow;
+use std::ffi::{c_int, CStr, CString};
 use std::marker::PhantomData;
 use std::str::FromStr as _;
 use std::sync::atomic::{AtomicUsize, Ordering};
@@ -47,7 +48,7 @@ impl VTabLog {
         table_name: &[u8],
         args: &[&[u8]],
         is_create: bool,
-    ) -> Result<(String, Self)> {
+    ) -> Result<(Cow<'static, CStr>, Self)> {
         debug_assert_eq!(aux, None);
         debug_assert_eq!(module_name, MODULE_NAME.to_bytes());
         static N_INST: AtomicUsize = AtomicUsize::new(1);
@@ -72,7 +73,7 @@ impl VTabLog {
                             "more than one '{param}' parameter"
                         )));
                     }
-                    schema = Some(value.to_owned());
+                    schema = Some(CString::new(value)?);
                 }
                 "rows" => {
                     if n_row.is_some() {
@@ -101,7 +102,7 @@ impl VTabLog {
             i_inst,
             n_cursor: 0,
         };
-        Ok((schema.unwrap(), vtab))
+        Ok((Cow::Owned(schema.unwrap()), vtab))
     }
 }
 
@@ -122,7 +123,7 @@ unsafe impl<'vtab> VTab<'vtab> for VTabLog {
         database_name: &[u8],
         table_name: &[u8],
         args: &[&[u8]],
-    ) -> Result<(String, Self)> {
+    ) -> Result<(Cow<'static, CStr>, Self)> {
         Self::connect_create(db, aux, module_name, database_name, table_name, args, false)
     }
 
@@ -185,7 +186,7 @@ impl CreateVTab<'_> for VTabLog {
         database_name: &[u8],
         table_name: &[u8],
         args: &[&[u8]],
-    ) -> Result<(String, Self)> {
+    ) -> Result<(Cow<'static, CStr>, Self)> {
         Self::connect_create(db, aux, module_name, database_name, table_name, args, true)
     }
 

--- a/tests/vtab.rs
+++ b/tests/vtab.rs
@@ -10,6 +10,8 @@ fn test_dummy_module() -> rusqlite::Result<()> {
         VTabConnection, VTabCursor,
     };
     use rusqlite::{version_number, Connection, Result};
+    use std::borrow::Cow;
+    use std::ffi::CStr;
     use std::marker::PhantomData;
     use std::os::raw::c_int;
 
@@ -32,12 +34,12 @@ fn test_dummy_module() -> rusqlite::Result<()> {
             _database_name: &[u8],
             _table_name: &[u8],
             _args: &[&[u8]],
-        ) -> Result<(String, Self)> {
+        ) -> Result<(Cow<'static, CStr>, Self)> {
             debug_assert_eq!(aux, None);
             let vtab = Self {
                 base: sqlite3_vtab::default(),
             };
-            Ok(("CREATE TABLE x(value)".to_owned(), vtab))
+            Ok((Cow::Borrowed(c"CREATE TABLE x(value)"), vtab))
         }
 
         fn best_index(&self, info: &mut IndexInfo) -> Result<bool> {


### PR DESCRIPTION
Make possible to return a static string because most the time the SQL passed to `sqlite3_declare_vtab` is known at compile time.