### PR TITLE
feat: add BorrowingStatement for zero-copy SQLITE_STATIC binds

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -225,6 +225,10 @@ harness = false
 name = "exec"
 harness = false
 
+[[bench]]
+name = "borrowing_stmt"
+harness = false
+
 [[example]]
 name = "loadable_extension"
 crate-type = ["cdylib"]

--- a/benches/borrowing_stmt.rs
+++ b/benches/borrowing_stmt.rs
@@ -1,5 +1,5 @@
 use bencher::{benchmark_group, benchmark_main, Bencher};
-use rusqlite::Connection;
+use rusqlite::{params, Connection};
 use uuid::Uuid;
 
 struct BenchData {
@@ -130,6 +130,40 @@ fn bench_borrowing(b: &mut Bencher) {
     });
 }
 
+fn bench_borrowing_one_transaction(b: &mut Bencher) {
+    let mut db = init_db();
+
+    let data = create_data();
+
+    b.iter(|| {
+        let transaction = db.transaction().unwrap();
+        let mut stmt = transaction
+            .prepare_borrowing(&make_statement_sql())
+            .unwrap();
+        for insert_chunk in data.chunks(BATCH_VALUES) {
+            for (i, row) in insert_chunk.iter().enumerate() {
+                let i = i * COLS_PER_ROW + 1;
+                stmt.raw_bind_parameter_ref(i, row.name.as_str()).unwrap();
+                stmt.raw_bind_parameter_ref(i + 1, row.uuid.as_bytes())
+                    .unwrap();
+                stmt.raw_bind_parameter_ref(i + 2, row.parent.as_bytes())
+                    .unwrap();
+                stmt.raw_bind_parameter_ref(i + 3, row.some_u64 as i64)
+                    .unwrap();
+                stmt.raw_bind_parameter_ref(i + 4, row.string_a.as_str())
+                    .unwrap();
+                stmt.raw_bind_parameter_ref(i + 5, row.string_b.as_str())
+                    .unwrap();
+                stmt.raw_bind_parameter_ref(i + 6, row.string_c.as_str())
+                    .unwrap();
+            }
+            stmt.raw_execute().unwrap();
+        }
+        drop(stmt);
+        transaction.commit().unwrap();
+    });
+}
+
 fn bench_copy(b: &mut Bencher) {
     let db = init_db();
 
@@ -161,5 +195,82 @@ fn bench_copy(b: &mut Bencher) {
     });
 }
 
-benchmark_group!(borrowing_stmt_benches, bench_borrowing, bench_copy);
+fn bench_single_rows(b: &mut Bencher) {
+    let db = init_db();
+
+    let data = create_data();
+
+    b.iter(|| {
+        let mut stmt = db.prepare("INSERT INTO bench_data (name, uuid, parent, some_u64, string_a, string_b, string_c) VALUES (?, ?, ?, ?, ?, ?, ?)").unwrap();
+        for transaction_chunk in data.chunks(TRANSACTION_SIZE) {
+            let transaction = db.unchecked_transaction().unwrap();
+            for row in transaction_chunk {
+                      stmt.execute(params![&row.name, &row.uuid.as_bytes(), &row.parent.as_bytes(), row.some_u64 as i64, &row.string_a, &row.string_b, &row.string_c]).unwrap();       }
+            transaction.commit().unwrap();
+        }
+    });
+}
+
+fn bench_single_rows_one_transaction(b: &mut Bencher) {
+    let mut db = init_db();
+
+    let data = create_data();
+
+    b.iter(|| {
+		let transaction = db.transaction().unwrap();
+		{
+			let mut stmt = transaction
+				.prepare("INSERT INTO bench_data (name, uuid, parent, some_u64, string_a, string_b, string_c) VALUES (?, ?, ?, ?, ?, ?, ?)")
+				.unwrap();
+			for row in &data {
+				stmt.execute(params![
+					&row.name,
+					&row.uuid.as_bytes(),
+					&row.parent.as_bytes(),
+					row.some_u64 as i64,
+					&row.string_a,
+					&row.string_b,
+					&row.string_c
+				])
+				.unwrap();
+			}
+		}
+
+		transaction.commit().unwrap();
+	});
+}
+
+fn bench_single_rows_no_transaction(b: &mut Bencher) {
+    let db = init_db();
+
+    let data = create_data();
+
+    b.iter(|| {
+			let mut stmt = db
+				.prepare("INSERT INTO bench_data (name, uuid, parent, some_u64, string_a, string_b, string_c) VALUES (?, ?, ?, ?, ?, ?, ?)")
+				.unwrap();
+			for row in &data {
+				stmt.execute(params![
+					&row.name,
+					&row.uuid.as_bytes(),
+					&row.parent.as_bytes(),
+					row.some_u64 as i64,
+					&row.string_a,
+					&row.string_b,
+					&row.string_c
+				])
+				.unwrap();
+			}
+	});
+}
+
+benchmark_group!(
+    borrowing_stmt_benches,
+    bench_borrowing,
+    bench_borrowing_one_transaction,
+    bench_copy,
+    bench_single_rows,
+    bench_single_rows_one_transaction,
+    bench_single_rows_no_transaction
+);
 benchmark_main!(borrowing_stmt_benches);

--- a/benches/borrowing_stmt.rs
+++ b/benches/borrowing_stmt.rs
@@ -1,0 +1,165 @@
+use bencher::{benchmark_group, benchmark_main, Bencher};
+use rusqlite::Connection;
+use uuid::Uuid;
+
+struct BenchData {
+    name: String,
+    uuid: Uuid,
+    parent: Uuid,
+
+    some_u64: u64,
+    string_a: String,
+    string_b: String,
+    string_c: String,
+}
+
+impl BenchData {
+    fn new() -> Self {
+        BenchData {
+            name: std::hint::black_box("test".to_string()),
+            uuid: Uuid::new_v4(),
+            parent: Uuid::new_v4(),
+            some_u64: 42,
+            string_a: std::hint::black_box("string_a".to_string()),
+            string_b: std::hint::black_box("string_b".to_string()),
+            string_c: std::hint::black_box("string_c".to_string()),
+        }
+    }
+}
+
+// efficiently build a SQL string for batch inserting values, e.g. "INSERT INTO table (col1, col2) VALUES (?,?),(?,?),(?,?)"
+fn build_batch_values_sql(
+    prefix: &str,
+    cols_per_row: usize,
+    n_rows: usize,
+    suffix: &str,
+) -> String {
+    let per_row = 2 + 2 * cols_per_row; // "(?,?,...)"
+    let mut sql = String::with_capacity(prefix.len() + 8 + n_rows * (per_row + 1) + suffix.len());
+
+    let capacity = sql.capacity();
+
+    sql.push_str(prefix);
+    sql.push_str(" VALUES ");
+    for i in 0..n_rows {
+        if i > 0 {
+            sql.push(',');
+        }
+        sql.push('(');
+        for j in 0..cols_per_row {
+            if j > 0 {
+                sql.push(',');
+            }
+            sql.push('?');
+        }
+        sql.push(')');
+    }
+    sql.push(' ');
+    sql.push_str(suffix);
+
+    debug_assert_eq!(capacity, sql.capacity());
+    debug_assert_eq!(capacity, sql.len());
+    sql
+}
+
+const TRANSACTION_SIZE: usize = 10_000;
+const BATCH_VALUES: usize = 200;
+const TOTAL_ITEMS: usize = 1_000_000;
+const COLS_PER_ROW: usize = 7;
+
+fn create_data() -> Vec<BenchData> {
+    (0..TOTAL_ITEMS).map(|_| BenchData::new()).collect()
+}
+
+fn init_db() -> Connection {
+    let db = Connection::open_in_memory().unwrap();
+    db.execute_batch(
+        "CREATE TABLE bench_data (
+			name TEXT,
+			uuid BLOB,
+			parent BLOB,
+			some_u64 INTEGER,
+			string_a TEXT,
+			string_b TEXT,
+			string_c TEXT
+		)",
+    )
+    .unwrap();
+    db
+}
+
+fn make_statement_sql() -> String {
+    build_batch_values_sql(
+        "INSERT INTO bench_data (name, uuid, parent, some_u64, string_a, string_b, string_c)",
+        COLS_PER_ROW,
+        BATCH_VALUES,
+        "",
+    )
+}
+
+fn bench_borrowing(b: &mut Bencher) {
+    let db = init_db();
+
+    let data = create_data();
+
+    b.iter(|| {
+        let mut stmt = db.prepare_borrowing(&make_statement_sql()).unwrap();
+        for transaction_chunk in data.chunks(TRANSACTION_SIZE) {
+            let transaction = db.unchecked_transaction().unwrap();
+            for insert_chunk in transaction_chunk.chunks(BATCH_VALUES) {
+                for (i, row) in insert_chunk.iter().enumerate() {
+                    let i = i * COLS_PER_ROW + 1;
+                    stmt.raw_bind_parameter_ref(i, row.name.as_str()).unwrap();
+                    stmt.raw_bind_parameter_ref(i + 1, row.uuid.as_bytes())
+                        .unwrap();
+                    stmt.raw_bind_parameter_ref(i + 2, row.parent.as_bytes())
+                        .unwrap();
+                    stmt.raw_bind_parameter_ref(i + 3, row.some_u64 as i64)
+                        .unwrap();
+                    stmt.raw_bind_parameter_ref(i + 4, row.string_a.as_str())
+                        .unwrap();
+                    stmt.raw_bind_parameter_ref(i + 5, row.string_b.as_str())
+                        .unwrap();
+                    stmt.raw_bind_parameter_ref(i + 6, row.string_c.as_str())
+                        .unwrap();
+                }
+                stmt.raw_execute().unwrap();
+            }
+            transaction.commit().unwrap();
+        }
+    });
+}
+
+fn bench_copy(b: &mut Bencher) {
+    let db = init_db();
+
+    let data = create_data();
+
+    b.iter(|| {
+        let mut stmt = db.prepare(&make_statement_sql()).unwrap();
+        for transaction_chunk in data.chunks(TRANSACTION_SIZE) {
+            let transaction = db.unchecked_transaction().unwrap();
+            for insert_chunk in transaction_chunk.chunks(BATCH_VALUES) {
+                for (i, row) in insert_chunk.iter().enumerate() {
+                    let i = i * COLS_PER_ROW + 1;
+                    stmt.raw_bind_parameter(i, row.name.as_str()).unwrap();
+                    stmt.raw_bind_parameter(i + 1, row.uuid.as_bytes()).unwrap();
+                    stmt.raw_bind_parameter(i + 2, row.parent.as_bytes())
+                        .unwrap();
+                    stmt.raw_bind_parameter(i + 3, row.some_u64 as i64).unwrap();
+                    stmt.raw_bind_parameter(i + 4, row.string_a.as_str())
+                        .unwrap();
+                    stmt.raw_bind_parameter(i + 5, row.string_b.as_str())
+                        .unwrap();
+                    stmt.raw_bind_parameter(i + 6, row.string_c.as_str())
+                        .unwrap();
+                }
+                stmt.raw_execute().unwrap();
+            }
+            transaction.commit().unwrap();
+        }
+    });
+}
+
+benchmark_group!(borrowing_stmt_benches, bench_borrowing, bench_copy);
+benchmark_main!(borrowing_stmt_benches);

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -1,7 +1,9 @@
 //! Prepared statements cache for faster execution.
 
 use crate::raw_statement::RawStatement;
-use crate::{Connection, PrepFlags, Result, Statement};
+use crate::statement::bind_value_ref_static;
+use crate::types::ValueRef;
+use crate::{BindIndex, Connection, PrepFlags, Result, Statement};
 use hashlink::LruCache;
 use std::cell::RefCell;
 use std::ops::{Deref, DerefMut};
@@ -70,6 +72,191 @@ unsafe impl Send for StatementCache {}
 pub struct CachedStatement<'conn> {
     stmt: Option<Statement<'conn>>,
     cache: &'conn StatementCache,
+}
+
+/// A cached prepared statement that supports zero-copy parameter binding.
+///
+/// The non-cached counterpart is [`crate::BorrowingStatement`]; see its
+/// documentation for the lifetime model and `SQLITE_STATIC` semantics.
+///
+/// When this value is dropped, the underlying [`CachedStatement`] is returned
+/// to its [`Connection`]'s cache (with bindings cleared first). Call
+/// [`CachedBorrowingStatement::discard`] to finalize it instead.
+///
+/// # Safety guarantees
+///
+/// The borrow checker rejects all of the following at compile time.
+///
+/// Dropping bound data while the wrapper is still in use:
+///
+/// ```compile_fail
+/// use rusqlite::Connection;
+/// let conn = Connection::open_in_memory().unwrap();
+/// let mut stmt = conn.prepare_cached_borrowing("SELECT ?1").unwrap();
+/// let s = String::from("data");
+/// stmt.raw_bind_parameter_ref(1, s.as_str()).unwrap();
+/// drop(s);
+/// stmt.raw_execute().unwrap();
+/// ```
+///
+/// Moving bound data:
+///
+/// ```compile_fail
+/// use rusqlite::Connection;
+/// let conn = Connection::open_in_memory().unwrap();
+/// let mut stmt = conn.prepare_cached_borrowing("SELECT ?1").unwrap();
+/// let s = String::from("data");
+/// stmt.raw_bind_parameter_ref(1, s.as_str()).unwrap();
+/// let _moved = s;
+/// stmt.raw_execute().unwrap();
+/// ```
+///
+/// Mutating bound data:
+///
+/// ```compile_fail
+/// use rusqlite::Connection;
+/// let conn = Connection::open_in_memory().unwrap();
+/// let mut stmt = conn.prepare_cached_borrowing("SELECT ?1").unwrap();
+/// let mut s = String::from("data");
+/// stmt.raw_bind_parameter_ref(1, s.as_str()).unwrap();
+/// s.push_str("more");
+/// stmt.raw_execute().unwrap();
+/// ```
+///
+/// Binding data that does not outlive the wrapper:
+///
+/// ```compile_fail
+/// use rusqlite::Connection;
+/// let conn = Connection::open_in_memory().unwrap();
+/// let mut stmt = conn.prepare_cached_borrowing("SELECT ?1").unwrap();
+/// {
+///     let local = String::from("scoped");
+///     stmt.raw_bind_parameter_ref(1, local.as_str()).unwrap();
+/// }
+/// stmt.raw_execute().unwrap();
+/// ```
+pub struct CachedBorrowingStatement<'conn, 'stmt> {
+    inner: CachedStatement<'conn>,
+    _marker: std::marker::PhantomData<&'stmt ()>,
+}
+
+impl<'conn, 'stmt> CachedBorrowingStatement<'conn, 'stmt> {
+    /// Binds a parameter by reference using `SQLITE_STATIC`.
+    /// See [`crate::BorrowingStatement::raw_bind_parameter_ref`] for details.
+    //
+    // `&mut self` is taken (rather than `&self`, which is all the inner
+    // SQLite call needs) for exclusivity with outstanding `Rows<'_>` from
+    // `raw_query` (which borrow `&mut Statement` via `DerefMut`) and with
+    // `clear_bindings` / the consuming `into_*` methods. `'stmt` is a type
+    // parameter fixed at wrapper construction, so the accepted lifetime of
+    // `param` is the same across successive calls.
+    #[inline]
+    pub fn raw_bind_parameter_ref<I, R>(&mut self, one_based_index: I, param: R) -> Result<()>
+    where
+        I: BindIndex,
+        R: Into<ValueRef<'stmt>>,
+    {
+        let stmt: &Statement<'conn> = &self.inner;
+        let ndx = one_based_index.idx(stmt)?;
+        // SAFETY: `'stmt` on the wrapper, enforced via `PhantomData<&'stmt ()>`,
+        // ties the bound data's lifetime to this wrapper. When the wrapper is
+        // dropped, the inner `CachedStatement`'s Drop returns the underlying
+        // stmt to the cache via `cache_stmt`, which calls
+        // `sqlite3_clear_bindings` *before* re-inserting. So a future cache
+        // hit gets the stmt with NULL bindings, and SQLite never reads `param`
+        // after it has been freed.
+        unsafe { bind_value_ref_static(stmt, ndx, param.into()) }
+    }
+
+    /// Clears all parameter bindings on this statement.
+    ///
+    /// After this call, every slot reads as `NULL` until re-bound. The
+    /// `'stmt` lifetime parameter on the wrapper is **not** reset — to bind
+    /// data of a shorter lifetime than the original `'stmt`, consume the
+    /// wrapper with [`into_cached_statement`](Self::into_cached_statement) and
+    /// re-wrap the returned [`CachedStatement`] with a fresh `'stmt`.
+    #[inline]
+    pub fn clear_bindings(&mut self) {
+        self.inner.stmt.as_mut().unwrap().stmt.clear_bindings();
+    }
+
+    /// Clears all parameter bindings and unwraps the inner [`CachedStatement`].
+    ///
+    /// Use this to "reset" the `'stmt` lifetime: after `sqlite3_clear_bindings`
+    /// runs, no `SQLITE_STATIC` pointer remains in SQLite, so any previously
+    /// bound borrow is safe to drop. The returned [`CachedStatement`] can then
+    /// be re-wrapped via [`CachedBorrowingStatement::from`] with a brand-new
+    /// `'stmt`, or simply dropped to return the stmt to the cache.
+    ///
+    /// # Example
+    ///
+    /// Bind to data with one lifetime, release it, then bind to data with a
+    /// shorter (incompatible) lifetime by round-tripping through the inner
+    /// [`CachedStatement`]:
+    ///
+    /// ```no_run
+    /// use rusqlite::{CachedBorrowingStatement, Connection};
+    ///
+    /// # fn run() -> rusqlite::Result<()> {
+    /// let conn = Connection::open_in_memory()?;
+    /// conn.execute("CREATE TABLE items (x TEXT)", ())?;
+    ///
+    /// let inner = {
+    ///     let first = String::from("first");
+    ///     let mut wrapper = conn.prepare_cached_borrowing("INSERT INTO items VALUES (?)")?;
+    ///     wrapper.raw_bind_parameter_ref(1, first.as_str())?;
+    ///     wrapper.raw_execute()?;
+    ///     wrapper.into_cached_statement()
+    /// }; // `first` dropped here — SQLite no longer holds the pointer.
+    ///
+    /// let mut wrapper = CachedBorrowingStatement::from(inner);
+    /// let second = String::from("second");
+    /// wrapper.raw_bind_parameter_ref(1, second.as_str())?;
+    /// wrapper.raw_execute()?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    #[inline]
+    pub fn into_cached_statement(mut self) -> CachedStatement<'conn> {
+        self.inner.stmt.as_mut().unwrap().stmt.clear_bindings();
+        self.inner
+    }
+
+    /// Discards the statement, preventing it from being returned to its
+    /// [`Connection`]'s collection of cached statements.
+    #[inline]
+    pub fn discard(self) {
+        self.inner.discard();
+    }
+}
+
+impl<'conn, 'stmt> From<CachedStatement<'conn>> for CachedBorrowingStatement<'conn, 'stmt> {
+    /// Wraps a [`CachedStatement`] so its parameters can be bound by reference
+    /// using `SQLITE_STATIC`, avoiding the data copy performed by the regular
+    /// bind API.
+    #[inline]
+    fn from(inner: CachedStatement<'conn>) -> Self {
+        Self {
+            inner,
+            _marker: std::marker::PhantomData,
+        }
+    }
+}
+
+impl<'conn> Deref for CachedBorrowingStatement<'conn, '_> {
+    type Target = CachedStatement<'conn>;
+
+    #[inline]
+    fn deref(&self) -> &CachedStatement<'conn> {
+        &self.inner
+    }
+}
+
+impl<'conn> DerefMut for CachedBorrowingStatement<'conn, '_> {
+    #[inline]
+    fn deref_mut(&mut self) -> &mut CachedStatement<'conn> {
+        &mut self.inner
+    }
 }
 
 impl<'conn> Deref for CachedStatement<'conn> {
@@ -156,6 +343,11 @@ impl StatementCache {
             return;
         }
         let mut cache = self.0.borrow_mut();
+        // Load-bearing for `CachedBorrowingStatement` soundness: any
+        // `SQLITE_STATIC` pointer bound via `raw_bind_parameter_ref` must be
+        // cleared here before the stmt re-enters the cache, so a later cache
+        // hit cannot deref the freed data. See `CachedBorrowingStatement`
+        // and `test_cached_borrowing_reuse_clears_bindings`.
         stmt.clear_bindings();
         if let Some(sql) = stmt.statement_cache_key() {
             cache.insert(sql, stmt);
@@ -346,6 +538,112 @@ mod test {
     fn test_empty_stmt() -> Result<()> {
         let conn = Connection::open_in_memory()?;
         conn.prepare_cached("")?;
+        Ok(())
+    }
+
+    #[test]
+    fn test_cached_borrowing() -> Result<()> {
+        let conn = Connection::open_in_memory()?;
+        conn.execute("CREATE TABLE items (x TEXT);", ())?;
+
+        let mut ref_stmt = conn.prepare_cached_borrowing("INSERT INTO items (x) VALUES (?)")?;
+        let x_static = "X Value";
+
+        let x_owned = x_static.to_string();
+
+        ref_stmt.raw_bind_parameter_ref(1, x_owned.as_str())?;
+        // can't drop x until after ref_stmt is executed, because it holds a reference to x
+        // drop(x);
+        ref_stmt.raw_execute()?;
+        // dropping here is fine, because ref_stmt can be dropped first
+
+        drop(x_owned);
+
+        let mut stmt = conn.prepare_cached("SELECT x FROM items")?;
+        let item: String = stmt.query_row([], |r| r.get(0))?;
+        assert_eq!(item, x_static);
+        Ok(())
+    }
+
+    #[test]
+    fn test_cached_borrowing_reuse_clears_bindings() -> Result<()> {
+        // Bind data via SQLITE_STATIC, drop the wrapper (returning the stmt
+        // to the cache), then re-prepare the same SQL. The cache must hand
+        // back the stmt with bindings cleared so the prior dangling pointer
+        // can never be read.
+        let conn = Connection::open_in_memory()?;
+
+        let sql = "SELECT ?1";
+        {
+            let owned = String::from("transient text");
+            let mut ref_stmt = conn.prepare_cached_borrowing(sql)?;
+            ref_stmt.raw_bind_parameter_ref(1, owned.as_str())?;
+            // wrapper Drop runs cache_stmt -> clear_bindings before reinsertion
+        }
+
+        // Re-prepare the same SQL: cache hit. With bindings cleared, slot 1
+        // is NULL, so `SELECT ?1` returns NULL. `raw_query` uses the current
+        // bindings as-is rather than re-binding from `[]`.
+        let mut stmt = conn.prepare_cached(sql)?;
+        let mut rows = stmt.raw_query();
+        let row = rows.next()?.expect("one row");
+        let value: Option<String> = row.get(0)?;
+        assert_eq!(value, None);
+        Ok(())
+    }
+
+    #[test]
+    fn test_cached_borrowing_discard() -> Result<()> {
+        // After discard, the stmt must not be returned to the cache. We can't
+        // observe that directly without poking the private cache field, so
+        // verify the next prepare_cached returns a usable (freshly-prepared)
+        // stmt and that bindings are clean.
+        let conn = Connection::open_in_memory()?;
+
+        let sql = "SELECT ?1";
+        {
+            let mut stmt = conn.prepare_cached_borrowing(sql)?;
+            let owned = String::from("transient");
+            stmt.raw_bind_parameter_ref(1, owned.as_str())?;
+            stmt.discard();
+        }
+
+        let mut stmt = conn.prepare_cached(sql)?;
+        let mut rows = stmt.raw_query();
+        let row = rows.next()?.expect("one row");
+        let value: Option<String> = row.get(0)?;
+        assert_eq!(value, None, "freshly prepared stmt must have no bindings");
+        Ok(())
+    }
+
+    #[test]
+    fn test_cached_borrowing_into_cached_statement() -> Result<()> {
+        // Bind to short-lived data, clear-and-unwrap to release the
+        // SQLITE_STATIC pointer, then re-wrap and bind to different
+        // short-lived data.
+        let conn = Connection::open_in_memory()?;
+        conn.execute("CREATE TABLE items (x TEXT)", ())?;
+
+        let inner = {
+            let first = String::from("first");
+            let mut wrapper = conn.prepare_cached_borrowing("INSERT INTO items VALUES (?)")?;
+            wrapper.raw_bind_parameter_ref(1, first.as_str())?;
+            wrapper.raw_execute()?;
+            wrapper.into_cached_statement()
+        };
+
+        let mut wrapper = super::CachedBorrowingStatement::from(inner);
+        let second = String::from("second");
+        wrapper.raw_bind_parameter_ref(1, second.as_str())?;
+        wrapper.raw_execute()?;
+        drop(wrapper);
+        drop(second);
+
+        let rows: Vec<String> = conn
+            .prepare("SELECT x FROM items ORDER BY rowid")?
+            .query_map([], |r| r.get::<_, String>(0))?
+            .collect::<Result<_>>()?;
+        assert_eq!(rows, vec!["first".to_owned(), "second".to_owned()]);
         Ok(())
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -88,7 +88,7 @@ use crate::types::ValueRef;
 
 pub use crate::bind::BindIndex;
 #[cfg(feature = "cache")]
-pub use crate::cache::CachedStatement;
+pub use crate::cache::{CachedBorrowingStatement, CachedStatement};
 #[cfg(feature = "column_decltype")]
 pub use crate::column::Column;
 #[cfg(feature = "column_metadata")]
@@ -99,7 +99,7 @@ pub use crate::ffi::ErrorCode;
 pub use crate::load_extension_guard::LoadExtensionGuard;
 pub use crate::params::{params_from_iter, Params, ParamsFromIter};
 pub use crate::row::{AndThenRows, Map, MappedRows, Row, RowIndex, Rows};
-pub use crate::statement::{Statement, StatementStatus};
+pub use crate::statement::{BorrowingStatement, Statement, StatementStatus};
 #[cfg(feature = "modern_sqlite")]
 pub use crate::transaction::TransactionState;
 pub use crate::transaction::{DropBehavior, Savepoint, Transaction, TransactionBehavior};
@@ -318,6 +318,7 @@ fn str_to_cstring(s: &str) -> Result<util::SmallCString> {
 /// The `sqlite3_destructor_type` item is always `SQLITE_TRANSIENT` unless
 /// the string was empty (in which case it's `SQLITE_STATIC`, and the ptr is
 /// static).
+#[cfg(any(feature = "functions", feature = "vtab"))]
 fn str_for_sqlite(
     s: &[u8],
 ) -> (
@@ -795,6 +796,31 @@ impl Connection {
         } else {
             Ok(stmt)
         }
+    }
+
+    /// Prepare a SQL statement and wrap it as a [`BorrowingStatement`] so its
+    /// parameters can be bound by reference using `SQLITE_STATIC`.
+    ///
+    /// See [`BorrowingStatement`] for the lifetime model and safety
+    /// guarantees.
+    #[inline]
+    pub fn prepare_borrowing<'conn, 'stmt>(
+        &'conn self,
+        sql: &str,
+    ) -> Result<BorrowingStatement<'conn, 'stmt>> {
+        self.prepare(sql).map(BorrowingStatement::from)
+    }
+
+    /// Like [`prepare_cached`](Self::prepare_cached), but returns a
+    /// [`CachedBorrowingStatement`] for zero-copy parameter binding via
+    /// `SQLITE_STATIC`.
+    #[cfg(feature = "cache")]
+    #[inline]
+    pub fn prepare_cached_borrowing<'conn, 'stmt>(
+        &'conn self,
+        sql: &str,
+    ) -> Result<CachedBorrowingStatement<'conn, 'stmt>> {
+        self.prepare_cached(sql).map(CachedBorrowingStatement::from)
     }
 
     /// Close the SQLite connection.

--- a/src/statement.rs
+++ b/src/statement.rs
@@ -1,9 +1,9 @@
-use std::ffi::{c_int, c_void};
+use std::ffi::{c_char, c_int, c_void};
+use std::ops::{Deref, DerefMut};
 use std::slice::from_raw_parts;
 use std::{fmt, mem, ptr, str};
 
 use super::ffi;
-use super::str_for_sqlite;
 use super::{
     AndThenRows, Connection, Error, MappedRows, Params, RawStatement, Result, Row, Rows, ValueRef,
 };
@@ -14,6 +14,253 @@ use crate::types::{ToSql, ToSqlOutput};
 pub struct Statement<'conn> {
     pub(crate) conn: &'conn Connection,
     pub(crate) stmt: RawStatement,
+}
+
+/// A prepared statement that supports zero-copy parameter binding.
+///
+/// The regular [`Statement::raw_bind_parameter`] API binds data using
+/// `SQLITE_TRANSIENT`, which causes SQLite to copy the bound bytes.
+/// `BorrowingStatement` instead passes a raw pointer to SQLite using
+/// `SQLITE_STATIC`, so no copy occurs. The `'stmt` lifetime parameter ties
+/// any bound data to the wrapper, and the borrow checker prevents accessing
+/// the statement after the data has been dropped.
+///
+/// For cached statements, see [`crate::CachedBorrowingStatement`] (requires
+/// the `cache` feature).
+///
+/// # Restriction
+///
+/// All parameters bound on a single wrapper share one `'stmt` lifetime. Once
+/// the lifetime is fixed by the first bind, every subsequent bind must use
+/// data that lives at least as long. Re-binding a slot to shorter-lived data
+/// after the original has been dropped is rejected by the borrow checker even
+/// when it would be safe at runtime.
+///
+/// # Safety guarantees
+///
+/// The borrow checker rejects all of the following at compile time:
+///
+/// Dropping bound data while the wrapper is still in use:
+///
+/// ```compile_fail
+/// use rusqlite::Connection;
+/// let conn = Connection::open_in_memory().unwrap();
+/// let mut stmt = conn.prepare_borrowing("SELECT ?1").unwrap();
+/// let s = String::from("data");
+/// stmt.raw_bind_parameter_ref(1, s.as_str()).unwrap();
+/// drop(s);
+/// stmt.raw_execute().unwrap();
+/// ```
+///
+/// Moving bound data:
+///
+/// ```compile_fail
+/// use rusqlite::Connection;
+/// let conn = Connection::open_in_memory().unwrap();
+/// let mut stmt = conn.prepare_borrowing("SELECT ?1").unwrap();
+/// let s = String::from("data");
+/// stmt.raw_bind_parameter_ref(1, s.as_str()).unwrap();
+/// let _moved = s;
+/// stmt.raw_execute().unwrap();
+/// ```
+///
+/// Mutating bound data:
+///
+/// ```compile_fail
+/// use rusqlite::Connection;
+/// let conn = Connection::open_in_memory().unwrap();
+/// let mut stmt = conn.prepare_borrowing("SELECT ?1").unwrap();
+/// let mut s = String::from("data");
+/// stmt.raw_bind_parameter_ref(1, s.as_str()).unwrap();
+/// s.push_str("more");
+/// stmt.raw_execute().unwrap();
+/// ```
+///
+/// Binding data that does not outlive the wrapper:
+///
+/// ```compile_fail
+/// use rusqlite::Connection;
+/// let conn = Connection::open_in_memory().unwrap();
+/// let mut stmt = conn.prepare_borrowing("SELECT ?1").unwrap();
+/// {
+///     let local = String::from("scoped");
+///     stmt.raw_bind_parameter_ref(1, local.as_str()).unwrap();
+/// }
+/// stmt.raw_execute().unwrap();
+/// ```
+pub struct BorrowingStatement<'conn, 'stmt> {
+    pub(crate) inner: Statement<'conn>,
+    pub(crate) _marker: core::marker::PhantomData<&'stmt ()>,
+}
+
+impl<'conn, 'stmt> BorrowingStatement<'conn, 'stmt> {
+    /// Binds a parameter by reference using `SQLITE_STATIC`.
+    ///
+    /// Unlike [`Statement::raw_bind_parameter`] which binds with
+    /// `SQLITE_TRANSIENT` (causing SQLite to copy the data), this passes the
+    /// data by pointer. The `'stmt` lifetime parameter on the wrapper
+    /// guarantees the pointed-to data outlives any subsequent SQLite call
+    /// that could read the binding.
+    ///
+    /// In general, statements bound this way should be executed via
+    /// [`Statement::raw_execute`] / [`Statement::raw_query`], the same as for
+    /// [`Statement::raw_bind_parameter`].
+    //
+    // `&mut self` is taken (rather than `&self`, which is all the inner
+    // SQLite call needs) for exclusivity with outstanding `Rows<'_>` from
+    // `raw_query` (which borrow `&mut Statement` via `DerefMut`) and with
+    // `clear_bindings` / the consuming `into_*` methods. `'stmt` is a type
+    // parameter fixed at wrapper construction, so the accepted lifetime of
+    // `param` is the same across successive calls.
+    #[inline]
+    pub fn raw_bind_parameter_ref<I, R>(&mut self, one_based_index: I, param: R) -> Result<()>
+    where
+        I: BindIndex,
+        R: Into<ValueRef<'stmt>>,
+    {
+        let ndx = one_based_index.idx(&self.inner)?;
+        // SAFETY: `'stmt` on the wrapper, enforced via `PhantomData<&'stmt ()>`,
+        // ties the bound data's lifetime to this wrapper. While the wrapper
+        // exists, the borrow checker forbids dropping or mutating the data.
+        // When the wrapper is dropped, the inner `Statement` is finalized via
+        // `sqlite3_finalize`, which does not read bindings. So SQLite never
+        // reads the data after it has been freed.
+        unsafe { bind_value_ref_static(&self.inner, ndx, param.into()) }
+    }
+
+    /// Clears all parameter bindings on this statement.
+    ///
+    /// After this call, every slot reads as `NULL` until re-bound. The
+    /// `'stmt` lifetime parameter on the wrapper is **not** reset — to bind
+    /// data of a shorter lifetime than the original `'stmt`, consume the
+    /// wrapper with [`into_statement`](Self::into_statement) and re-wrap the
+    /// returned [`Statement`] with a fresh `'stmt`.
+    #[inline]
+    pub fn clear_bindings(&mut self) {
+        self.inner.stmt.clear_bindings();
+    }
+
+    /// Clears all parameter bindings and unwraps the inner [`Statement`].
+    ///
+    /// Use this to "reset" the `'stmt` lifetime: after `sqlite3_clear_bindings`
+    /// runs, no `SQLITE_STATIC` pointer remains in SQLite, so any previously
+    /// bound borrow is safe to drop. The returned [`Statement`] can then be
+    /// re-wrapped via `BorrowingStatement::from` with a brand-new `'stmt`.
+    #[inline]
+    pub fn into_statement(mut self) -> Statement<'conn> {
+        self.inner.stmt.clear_bindings();
+        self.inner
+    }
+}
+
+impl<'conn, 'stmt> From<Statement<'conn>> for BorrowingStatement<'conn, 'stmt> {
+    /// Wraps a [`Statement`] so its parameters can be bound by reference
+    /// using `SQLITE_STATIC`, avoiding the data copy performed by the regular
+    /// bind API.
+    #[inline]
+    fn from(inner: Statement<'conn>) -> Self {
+        Self {
+            inner,
+            _marker: core::marker::PhantomData,
+        }
+    }
+}
+
+impl<'conn> Deref for BorrowingStatement<'conn, '_> {
+    type Target = Statement<'conn>;
+
+    #[inline]
+    fn deref(&self) -> &Statement<'conn> {
+        &self.inner
+    }
+}
+
+impl<'conn> DerefMut for BorrowingStatement<'conn, '_> {
+    #[inline]
+    fn deref_mut(&mut self) -> &mut Statement<'conn> {
+        &mut self.inner
+    }
+}
+
+/// Binds a [`ValueRef`] to a prepared statement using `SQLITE_STATIC` for
+/// `Text` and `Blob` arms.
+///
+/// # Safety
+///
+/// `SQLITE_STATIC` tells SQLite *not* to copy or take ownership of the data,
+/// so the caller must guarantee the bytes referenced by `value` remain valid
+/// for as long as SQLite might read them — i.e. until the binding is
+/// overwritten, `sqlite3_clear_bindings` is called, or the statement is
+/// finalized. The [`BorrowingStatement`] / [`crate::CachedBorrowingStatement`]
+/// wrappers establish this guarantee via their `'stmt` lifetime parameter
+/// and Drop chain; do not call this helper from anywhere else.
+#[inline]
+pub(crate) unsafe fn bind_value_ref_static(
+    stmt: &Statement<'_>,
+    ndx: usize,
+    value: ValueRef<'_>,
+) -> Result<()> {
+    // SAFETY: forwarded to the caller of `bind_value_ref_static`.
+    unsafe { bind_value_ref_inner(stmt, ndx, value, ffi::SQLITE_STATIC(), ffi::SQLITE_STATIC()) }
+}
+
+/// Inner binding helper shared by [`Statement::bind_parameter`] (with
+/// `SQLITE_TRANSIENT`) and [`bind_value_ref_static`] (with `SQLITE_STATIC`).
+///
+/// # Safety
+///
+/// If `text_dtor` or `blob_dtor` is `SQLITE_STATIC`, the corresponding bytes
+/// in `value` must outlive every subsequent SQLite call that could read the
+/// binding. With `SQLITE_TRANSIENT` SQLite copies eagerly, so this is
+/// trivially satisfied. The caller chooses the destructor and is responsible
+/// for the lifetime contract.
+#[inline]
+unsafe fn bind_value_ref_inner(
+    stmt: &Statement<'_>,
+    ndx: usize,
+    value: ValueRef<'_>,
+    text_dtor: ffi::sqlite3_destructor_type,
+    blob_dtor: ffi::sqlite3_destructor_type,
+) -> Result<()> {
+    let ptr = unsafe { stmt.stmt.ptr() };
+    stmt.conn.decode_result(match value {
+        ValueRef::Null => unsafe { ffi::sqlite3_bind_null(ptr, ndx as c_int) },
+        ValueRef::Integer(i) => unsafe { ffi::sqlite3_bind_int64(ptr, ndx as c_int, i) },
+        ValueRef::Real(r) => unsafe { ffi::sqlite3_bind_double(ptr, ndx as c_int, r) },
+        ValueRef::Text(s) => unsafe {
+            // For empty text, SQLite ignores the data pointer; force
+            // `SQLITE_STATIC` so we don't pay for a no-op transient copy and
+            // (defensively) hand SQLite a pointer that lives forever.
+            let len = s.len();
+            let (cstr, dtor) = if len == 0 {
+                ("".as_ptr().cast::<c_char>(), ffi::SQLITE_STATIC())
+            } else {
+                (s.as_ptr().cast::<c_char>(), text_dtor)
+            };
+            ffi::sqlite3_bind_text64(
+                ptr,
+                ndx as c_int,
+                cstr,
+                len as ffi::sqlite3_uint64,
+                dtor,
+                ffi::SQLITE_UTF8 as _, // TODO SQLITE_UTF8_ZT
+            )
+        },
+        ValueRef::Blob(b) => unsafe {
+            let length = b.len();
+            if length == 0 {
+                ffi::sqlite3_bind_zeroblob(ptr, ndx as c_int, 0)
+            } else {
+                ffi::sqlite3_bind_blob64(
+                    ptr,
+                    ndx as c_int,
+                    b.as_ptr().cast::<c_void>(),
+                    length as ffi::sqlite3_uint64,
+                    blob_dtor,
+                )
+            }
+        },
+    })
 }
 
 impl Statement<'_> {
@@ -614,13 +861,13 @@ impl Statement<'_> {
     fn bind_parameter<P: ?Sized + ToSql>(&self, param: &P, ndx: usize) -> Result<()> {
         let value = param.to_sql()?;
 
-        let ptr = unsafe { self.stmt.ptr() };
         let value = match value {
             ToSqlOutput::Borrowed(v) => v,
             ToSqlOutput::Owned(ref v) => ValueRef::from(v),
 
             #[cfg(feature = "blob")]
             ToSqlOutput::ZeroBlob(len) => {
+                let ptr = unsafe { self.stmt.ptr() };
                 // TODO sqlite3_bind_zeroblob64 // 3.8.11
                 return self
                     .conn
@@ -632,41 +879,23 @@ impl Statement<'_> {
             }
             #[cfg(feature = "pointer")]
             ToSqlOutput::Pointer(p) => {
+                let ptr = unsafe { self.stmt.ptr() };
                 return self.conn.decode_result(unsafe {
                     ffi::sqlite3_bind_pointer(ptr, ndx as c_int, p.0 as _, p.1.as_ptr(), p.2)
                 });
             }
         };
-        self.conn.decode_result(match value {
-            ValueRef::Null => unsafe { ffi::sqlite3_bind_null(ptr, ndx as c_int) },
-            ValueRef::Integer(i) => unsafe { ffi::sqlite3_bind_int64(ptr, ndx as c_int, i) },
-            ValueRef::Real(r) => unsafe { ffi::sqlite3_bind_double(ptr, ndx as c_int, r) },
-            ValueRef::Text(s) => unsafe {
-                let (c_str, len, destructor) = str_for_sqlite(s);
-                ffi::sqlite3_bind_text64(
-                    ptr,
-                    ndx as c_int,
-                    c_str,
-                    len,
-                    destructor,
-                    ffi::SQLITE_UTF8 as _, // TODO SQLITE_UTF8_ZT
-                )
-            },
-            ValueRef::Blob(b) => unsafe {
-                let length = b.len();
-                if length == 0 {
-                    ffi::sqlite3_bind_zeroblob(ptr, ndx as c_int, 0)
-                } else {
-                    ffi::sqlite3_bind_blob64(
-                        ptr,
-                        ndx as c_int,
-                        b.as_ptr().cast::<c_void>(),
-                        length as ffi::sqlite3_uint64,
-                        ffi::SQLITE_TRANSIENT(),
-                    )
-                }
-            },
-        })
+        // SAFETY: `SQLITE_TRANSIENT` causes SQLite to copy eagerly, so the
+        // lifetime contract on `bind_value_ref_inner` is trivially satisfied.
+        unsafe {
+            bind_value_ref_inner(
+                self,
+                ndx,
+                value,
+                ffi::SQLITE_TRANSIENT(),
+                ffi::SQLITE_TRANSIENT(),
+            )
+        }
     }
 
     #[inline]
@@ -903,7 +1132,7 @@ mod test {
     use wasm_bindgen_test::wasm_bindgen_test as test;
 
     use crate::types::ToSql;
-    use crate::{params_from_iter, Connection, Error, Result};
+    use crate::{params_from_iter, BorrowingStatement, Connection, Error, Result};
 
     #[test]
     fn test_execute_named() -> Result<()> {
@@ -1391,6 +1620,145 @@ mod test {
             }
             err => panic!("Unexpected error {err}"),
         }
+        Ok(())
+    }
+
+    #[test]
+    fn test_borrowing_stmt() -> Result<()> {
+        let conn = Connection::open_in_memory()?;
+        conn.execute("CREATE TABLE items (x TEXT);", ())?;
+
+        let mut ref_stmt = conn.prepare_borrowing("INSERT INTO items (x) VALUES (?)")?;
+        let x_static = "X Value";
+
+        let x_owned = x_static.to_string();
+
+        ref_stmt.raw_bind_parameter_ref(1, x_owned.as_str())?;
+        // can't drop x until after ref_stmt is executed, because it holds a reference to x
+        // drop(x);
+        ref_stmt.raw_execute()?;
+        // dropping here is fine, because ref_stmt can be dropped first
+        drop(x_owned);
+
+        let item: String = conn.query_row("SELECT x FROM items", [], |r| r.get(0))?;
+        assert_eq!(item, x_static);
+        Ok(())
+    }
+
+    #[test]
+    fn test_borrowing_stmt_all_value_types() -> Result<()> {
+        let conn = Connection::open_in_memory()?;
+        conn.execute("CREATE TABLE items (n INTEGER, r REAL, t TEXT, b BLOB)", ())?;
+
+        let text = String::from("hello");
+        let blob = vec![0u8, 1, 2, 3, 4];
+
+        let mut ref_stmt = conn.prepare_borrowing("INSERT INTO items VALUES (?, ?, ?, ?)")?;
+        ref_stmt.raw_bind_parameter_ref(1, 42i64)?;
+        ref_stmt.raw_bind_parameter_ref(2, std::f64::consts::PI)?;
+        ref_stmt.raw_bind_parameter_ref(3, text.as_str())?;
+        ref_stmt.raw_bind_parameter_ref(4, blob.as_slice())?;
+        ref_stmt.raw_execute()?;
+        drop(ref_stmt);
+
+        let (n, r, t, b): (i64, f64, String, Vec<u8>) =
+            conn.query_row("SELECT n, r, t, b FROM items", [], |row| {
+                Ok((row.get(0)?, row.get(1)?, row.get(2)?, row.get(3)?))
+            })?;
+        assert_eq!(n, 42);
+        assert!((r - std::f64::consts::PI).abs() < f64::EPSILON);
+        assert_eq!(t, text);
+        assert_eq!(b, blob);
+
+        // Null type via the Null marker.
+        let mut ref_stmt = conn.prepare_borrowing("INSERT INTO items (n) VALUES (?)")?;
+        ref_stmt.raw_bind_parameter_ref(1, crate::types::Null)?;
+        ref_stmt.raw_execute()?;
+        Ok(())
+    }
+
+    #[test]
+    fn test_borrowing_stmt_empty_text_and_blob() -> Result<()> {
+        let conn = Connection::open_in_memory()?;
+        conn.execute("CREATE TABLE items (t TEXT, b BLOB)", ())?;
+
+        let empty_text = String::new();
+        let empty_blob: Vec<u8> = Vec::new();
+
+        let mut ref_stmt = conn.prepare_borrowing("INSERT INTO items VALUES (?, ?)")?;
+        ref_stmt.raw_bind_parameter_ref(1, empty_text.as_str())?;
+        ref_stmt.raw_bind_parameter_ref(2, empty_blob.as_slice())?;
+        ref_stmt.raw_execute()?;
+        drop(ref_stmt);
+
+        let (t, b): (String, Vec<u8>) = conn.query_row("SELECT t, b FROM items", [], |row| {
+            Ok((row.get(0)?, row.get(1)?))
+        })?;
+        assert_eq!(t, "");
+        assert_eq!(b, Vec::<u8>::new());
+        Ok(())
+    }
+
+    #[test]
+    fn test_borrowing_stmt_rebind_after_execute() -> Result<()> {
+        let conn = Connection::open_in_memory()?;
+        conn.execute("CREATE TABLE items (x TEXT)", ())?;
+
+        let a = String::from("first");
+        let b = String::from("second");
+
+        let mut ref_stmt = conn.prepare_borrowing("INSERT INTO items VALUES (?)")?;
+        ref_stmt.raw_bind_parameter_ref(1, a.as_str())?;
+        ref_stmt.raw_execute()?;
+        // raw_execute resets the statement internally; rebinding overwrites
+        // the previous SQLITE_STATIC pointer in slot 1.
+        ref_stmt.raw_bind_parameter_ref(1, b.as_str())?;
+        ref_stmt.raw_execute()?;
+        drop(ref_stmt);
+
+        let mut stmt = conn.prepare("SELECT x FROM items ORDER BY rowid")?;
+        let rows: Vec<String> = stmt
+            .query_map([], |r| r.get::<_, String>(0))?
+            .collect::<Result<_>>()?;
+        assert_eq!(rows, vec!["first".to_owned(), "second".to_owned()]);
+        Ok(())
+    }
+
+    #[test]
+    fn test_borrowing_stmt_into_statement() -> Result<()> {
+        // Bind to data with a short lifetime, clear-and-unwrap to release
+        // the SQLITE_STATIC pointer, then re-wrap and bind to data with a
+        // different (incompatible) short lifetime.
+        let conn = Connection::open_in_memory()?;
+        conn.execute("CREATE TABLE items (x TEXT)", ())?;
+
+        let stmt = conn.prepare("INSERT INTO items VALUES (?)")?;
+        let inner = {
+            let first = String::from("first");
+            let mut wrapper = BorrowingStatement::from(stmt);
+            wrapper.raw_bind_parameter_ref(1, first.as_str())?;
+            wrapper.raw_execute()?;
+            // `first` would be tied to the wrapper's `'stmt` if we just
+            // dropped `wrapper`. Instead clear bindings and unwrap, which
+            // returns a plain `Statement` with no `'stmt` constraint.
+            wrapper.into_statement()
+            // `first` is dropped here, after SQLite no longer holds the ptr.
+        };
+
+        // Re-wrap with a fresh `'stmt`. Binding `second.as_str()` here would
+        // not have type-checked through the original wrapper.
+        let mut wrapper = BorrowingStatement::from(inner);
+        let second = String::from("second");
+        wrapper.raw_bind_parameter_ref(1, second.as_str())?;
+        wrapper.raw_execute()?;
+        drop(wrapper);
+        drop(second);
+
+        let rows: Vec<String> = conn
+            .prepare("SELECT x FROM items ORDER BY rowid")?
+            .query_map([], |r| r.get::<_, String>(0))?
+            .collect::<Result<_>>()?;
+        assert_eq!(rows, vec!["first".to_owned(), "second".to_owned()]);
         Ok(())
     }
 }

--- a/src/types/value_ref.rs
+++ b/src/types/value_ref.rs
@@ -1,3 +1,5 @@
+use std::borrow::Cow;
+
 use super::{Type, Value};
 use crate::types::{FromSqlError, FromSqlResult};
 
@@ -173,6 +175,83 @@ impl<'a> From<&'a [u8]> for ValueRef<'a> {
     #[inline]
     fn from(s: &[u8]) -> ValueRef<'_> {
         ValueRef::Blob(s)
+    }
+}
+
+impl<'a> From<&'a Cow<'_, str>> for ValueRef<'a> {
+    #[inline]
+    fn from(s: &'a Cow<'_, str>) -> ValueRef<'a> {
+        ValueRef::Text(s.as_bytes())
+    }
+}
+
+impl<'a> From<&'a Cow<'_, [u8]>> for ValueRef<'a> {
+    #[inline]
+    fn from(b: &'a Cow<'_, [u8]>) -> ValueRef<'a> {
+        ValueRef::Blob(b)
+    }
+}
+
+impl<'a, const N: usize> From<&'a [u8; N]> for ValueRef<'a> {
+    #[inline]
+    fn from(b: &'a [u8; N]) -> ValueRef<'a> {
+        ValueRef::Blob(b)
+    }
+}
+
+impl From<crate::types::Null> for ValueRef<'_> {
+    #[inline]
+    fn from(_: crate::types::Null) -> Self {
+        ValueRef::Null
+    }
+}
+
+/// Stores the UUID as a 16-byte `Blob`, matching `From<Uuid> for Value`.
+#[cfg(feature = "uuid")]
+impl<'a> From<&'a uuid::Uuid> for ValueRef<'a> {
+    #[inline]
+    fn from(id: &'a uuid::Uuid) -> Self {
+        Self::Blob(id.as_bytes())
+    }
+}
+
+macro_rules! from_via_i64(
+    ($t:ty) => (
+        impl From<$t> for ValueRef<'_> {
+            #[inline]
+            fn from(i: $t) -> Self {
+                ValueRef::Integer(i64::from(i))
+            }
+        }
+    )
+);
+
+from_via_i64!(bool);
+from_via_i64!(i8);
+from_via_i64!(i16);
+from_via_i64!(i32);
+from_via_i64!(u8);
+from_via_i64!(u16);
+from_via_i64!(u32);
+
+impl From<i64> for ValueRef<'_> {
+    #[inline]
+    fn from(i: i64) -> Self {
+        Self::Integer(i)
+    }
+}
+
+impl From<f32> for ValueRef<'_> {
+    #[inline]
+    fn from(f: f32) -> Self {
+        Self::Real(f64::from(f))
+    }
+}
+
+impl From<f64> for ValueRef<'_> {
+    #[inline]
+    fn from(f: f64) -> Self {
+        Self::Real(f)
     }
 }
 


### PR DESCRIPTION
Would close #164 by adding 2 new statement variants that expose `raw_bind_parameter_ref` to bind parameters with a lifetime longer than the lifetime of the statements allowing for the use of SQLITE_STATIC lifetime when binding.

This also includes a bit of a refactor to prevent code duplication with `raw_bind_parameter`, and From<&'a X> impls for ValueRef<'a>.

I wanted to make this PR as I saw significant improvements (~25% faster) with large SQLITE insertions (~3 million rows) that were already optimized by using outer transactions and bulk insert statements, obviously this performance improvement will vary depending on situation, but this is a relatively simple change that will improve performance in large insertions.

In my opinion, this would be a good intermediary step to slowly integrate these lifetimes into the core `Statement` and `CachedStatement` structs, so that in the long term this performance could be offered for 'free', but at least for now it would be great to have it be available to people who want to and are able to use it at all.