### PR TITLE
fix: changed `restore` fn `progress` arg to a concrete type

### DIFF
--- a/src/backup.rs
+++ b/src/backup.rs
@@ -99,11 +99,11 @@ impl Connection {
     ///
     /// Will return `Err` if the destination path cannot be opened
     /// or if the restore fails.
-    pub fn restore<N: Name, P: AsRef<Path>, F: Fn(Progress)>(
+    pub fn restore<N: Name, P: AsRef<Path>>(
         &mut self,
         name: N,
         src_path: P,
-        progress: Option<F>,
+        progress: Option<fn(Progress)>,
     ) -> Result<()> {
         use self::StepResult::{Busy, Done, Locked, More};
         let src = Self::open(src_path)?;


### PR DESCRIPTION
Before, in order to use the `restore` fn with a `None` `progress` argument, a concrete type should be specified with turbofish. e.g.

```rust

conn.restore::<&CStr, PathBuf, fn(backup::Progress)>(MAIN_DB, path, None).unwrap();

```

This changes the `progress` argument to be a concrete type, just like in the `backup` fn, making less verbose to call `restore`

```rust

conn.restore(MAIN_DB, path, None).unwrap();

```