### PR TITLE
create_aggregate_function / create_window_function are missing a `Send` bound

### DIFF
--- a/src/functions.rs
+++ b/src/functions.rs
@@ -513,8 +513,8 @@ impl Connection {
         aggr: D,
     ) -> Result<()>
     where
-        A: RefUnwindSafe + UnwindSafe,
-        D: Aggregate<A, T> + 'static,
+        A: RefUnwindSafe + UnwindSafe + Send,
+        D: Aggregate<A, T> + Send + 'static,
         T: SqlFnOutput,
     {
         self.db
@@ -537,8 +537,8 @@ impl Connection {
         aggr: W,
     ) -> Result<()>
     where
-        A: RefUnwindSafe + UnwindSafe,
-        W: WindowAggregate<A, T> + 'static,
+        A: RefUnwindSafe + UnwindSafe + Send,
+        W: WindowAggregate<A, T> + Send + 'static,
         T: SqlFnOutput,
     {
         self.db
@@ -645,8 +645,8 @@ impl InnerConnection {
         aggr: D,
     ) -> Result<()>
     where
-        A: RefUnwindSafe + UnwindSafe,
-        D: Aggregate<A, T> + 'static,
+        A: RefUnwindSafe + UnwindSafe + Send,
+        D: Aggregate<A, T> + Send + 'static,
         T: SqlFnOutput,
     {
         let boxed_aggr: *mut D = Box::into_raw(Box::new(aggr));
@@ -676,8 +676,8 @@ impl InnerConnection {
         aggr: W,
     ) -> Result<()>
     where
-        A: RefUnwindSafe + UnwindSafe,
-        W: WindowAggregate<A, T> + 'static,
+        A: RefUnwindSafe + UnwindSafe + Send,
+        W: WindowAggregate<A, T> + Send + 'static,
         T: SqlFnOutput,
     {
         let boxed_aggr: *mut W = Box::into_raw(Box::new(aggr));


### PR DESCRIPTION
Fix issue reported by @marius-momeu :
> I'm reporting another soundness bug that lets safe code produce a data race from concurrent threads.
`Connection` is `Send`, and while all callback registrars are bound accordingly, the two aggregate constructors `Connection::create_aggregate_function` and `Connection::create_window_function` are not, thus allowing safe code to move aggregate implementations holding `!Send` handles, such as `Rc<Cell<u64>>`, into `Connection`, while still keeping a handle on the current thread.
>
> I have a reproducer that triggers `TSan` on a concurrent access inflicted by the affected path; I can provide it on request.
The suggested fix is to add `+ Send` on both aggregate bounds.
>
> Found by [Crustify](https://github.com/crustify-rs/crustify), an experimental UB/soundness auditing agent developed at UC Berkeley and running on claude-opus-5, then manually reviewed and independently reproduced.