### PR TITLE
use-after-free from safe code in trace_v2 / busy_handler / ...

### DIFF
--- a/src/busy.rs
+++ b/src/busy.rs
@@ -52,7 +52,7 @@ impl Connection {
     /// Newly created connections default to a
     /// [`busy_timeout()`](Connection::busy_timeout) handler with a timeout
     /// of 5000ms, although this is subject to change.
-    pub fn busy_handler<F>(&self, callback: Option<F>) -> Result<()>
+    pub fn busy_handler<F>(&mut self, callback: Option<F>) -> Result<()>
     where
         F: FnMut(i32) -> bool + Send + 'static,
     {
@@ -72,8 +72,10 @@ impl Connection {
         }
         let x = callback.as_ref().map(|_| busy_handler_callback::<F> as _);
         let mut c = self.db.borrow_mut();
-        let bh = c.set_clientdata(c"sqlite3_busy_handler", callback)?;
-        c.decode_result(unsafe { ffi::sqlite3_busy_handler(c.db(), x, bh.cast()) })
+        c.set_clientdata(c"sqlite3_busy_handler", callback, |db, bh| unsafe {
+            ffi::sqlite3_busy_handler(db, x, bh)
+        })?;
+        Ok(())
     }
 }
 
@@ -83,7 +85,9 @@ impl InnerConnection {
         let r = unsafe { ffi::sqlite3_busy_timeout(self.db, timeout) };
         let res = self.decode_result(r);
         if res.is_ok() {
-            self.set_clientdata(c"sqlite3_busy_handler", None::<c_void>)?;
+            self.set_clientdata(c"sqlite3_busy_handler", None::<c_void>, |_, _| {
+                ffi::SQLITE_OK
+            })?;
         }
         res
     }
@@ -135,9 +139,9 @@ mod test {
         let temp_dir = tempfile::tempdir().unwrap();
         let path = temp_dir.path().join("busy-handler.db3");
 
-        let db1 = Connection::open(&path)?;
+        let mut db1 = Connection::open(&path)?;
         db1.execute_batch("CREATE TABLE IF NOT EXISTS t(a)")?;
-        let db2 = Connection::open(&path)?;
+        let mut db2 = Connection::open(&path)?;
         db2.busy_handler(Some(busy_handler))?;
         db1.execute_batch("BEGIN EXCLUSIVE")?;
         let err = db2.prepare("SELECT * FROM t").unwrap_err();

--- a/src/hooks/mod.rs
+++ b/src/hooks/mod.rs
@@ -344,7 +344,7 @@ impl Connection {
     ///
     /// The callback returns `true` to rollback.
     #[inline]
-    pub fn commit_hook<F>(&self, hook: Option<F>) -> Result<()>
+    pub fn commit_hook<F>(&mut self, hook: Option<F>) -> Result<()>
     where
         F: FnMut() -> bool + Send + 'static,
     {
@@ -354,7 +354,7 @@ impl Connection {
     /// Register a callback function to be invoked whenever
     /// a transaction is rolled back.
     #[inline]
-    pub fn rollback_hook<F>(&self, hook: Option<F>) -> Result<()>
+    pub fn rollback_hook<F>(&mut self, hook: Option<F>) -> Result<()>
     where
         F: FnMut() + Send + 'static,
     {
@@ -372,7 +372,7 @@ impl Connection {
     /// - the name of the table that is updated,
     /// - the ROWID of the row that is updated.
     #[inline]
-    pub fn update_hook<F>(&self, hook: Option<F>) -> Result<()>
+    pub fn update_hook<F>(&mut self, hook: Option<F>) -> Result<()>
     where
         F: FnMut(Action, &str, &str, i64) + Send + 'static,
     {
@@ -385,7 +385,7 @@ impl Connection {
     /// Calling `wal_hook` replaces any previously registered write-ahead log callback.
     /// Note that the `sqlite3_wal_autocheckpoint()` interface and the `wal_autocheckpoint` pragma
     /// both invoke `sqlite3_wal_hook()` and will overwrite any prior `sqlite3_wal_hook()` settings.
-    pub fn wal_hook<F>(&self, hook: Option<F>) -> Result<()>
+    pub fn wal_hook<F>(&mut self, hook: Option<F>) -> Result<()>
     where
         F: FnMut(&Wal, c_int) -> Result<()> + Send + 'static,
     {
@@ -414,10 +414,10 @@ impl Connection {
         }
         let x = hook.as_ref().map(|_| wal_hook_callback::<F> as _);
         let mut c = self.db.borrow_mut();
-        let bh = c.set_clientdata(c"sqlite3_wal_hook", hook)?;
-        unsafe {
-            ffi::sqlite3_wal_hook(c.db(), x, bh.cast());
-        }
+        c.set_clientdata(c"sqlite3_wal_hook", hook, |db, bh| unsafe {
+            ffi::sqlite3_wal_hook(db, x, bh);
+            ffi::SQLITE_OK
+        })?;
         Ok(())
     }
 
@@ -429,7 +429,7 @@ impl Connection {
     /// is disabled.
     ///
     /// If the progress callback returns `true`, the operation is interrupted.
-    pub fn progress_handler<F>(&self, num_ops: c_int, handler: Option<F>) -> Result<()>
+    pub fn progress_handler<F>(&mut self, num_ops: c_int, handler: Option<F>) -> Result<()>
     where
         F: FnMut() -> bool + Send + 'static,
     {
@@ -439,7 +439,7 @@ impl Connection {
     /// Register an authorizer callback that's invoked
     /// as a statement is being prepared.
     #[inline]
-    pub fn authorizer<F>(&self, hook: Option<F>) -> Result<()>
+    pub fn authorizer<F>(&mut self, hook: Option<F>) -> Result<()>
     where
         F: for<'r> FnMut(AuthContext<'r>) -> Authorization + Send + 'static,
     {
@@ -507,7 +507,7 @@ impl InnerConnection {
     /// ```compile_fail
     /// use rusqlite::{Connection, Result};
     /// fn main() -> Result<()> {
-    ///     let db = Connection::open_in_memory()?;
+    ///     let mut db = Connection::open_in_memory()?;
     ///     {
     ///         let mut called = std::sync::atomic::AtomicBool::new(false);
     ///         db.commit_hook(Some(|| {
@@ -542,15 +542,17 @@ impl InnerConnection {
             }
         }
         let x = hook.as_ref().map(|_| call_boxed_closure::<F> as _);
-        let bh = self.set_clientdata(c"sqlite3_commit_hook", hook)?;
-        unsafe { ffi::sqlite3_commit_hook(self.db(), x, bh.cast()) };
+        self.set_clientdata(c"sqlite3_commit_hook", hook, |db, bh| unsafe {
+            ffi::sqlite3_commit_hook(db, x, bh);
+            ffi::SQLITE_OK
+        })?;
         Ok(())
     }
 
     /// ```compile_fail
     /// use rusqlite::{Connection, Result};
     /// fn main() -> Result<()> {
-    ///     let db = Connection::open_in_memory()?;
+    ///     let mut db = Connection::open_in_memory()?;
     ///     {
     ///         let mut called = std::sync::atomic::AtomicBool::new(false);
     ///         db.rollback_hook(Some(|| {
@@ -584,15 +586,17 @@ impl InnerConnection {
         }
 
         let x = hook.as_ref().map(|_| call_boxed_closure::<F> as _);
-        let bh = self.set_clientdata(c"sqlite3_rollback_hook", hook)?;
-        unsafe { ffi::sqlite3_rollback_hook(self.db(), x, bh.cast()) };
+        self.set_clientdata(c"sqlite3_rollback_hook", hook, |db, bh| unsafe {
+            ffi::sqlite3_rollback_hook(db, x, bh);
+            ffi::SQLITE_OK
+        })?;
         Ok(())
     }
 
     /// ```compile_fail
     /// use rusqlite::{Connection, Result};
     /// fn main() -> Result<()> {
-    ///     let db = Connection::open_in_memory()?;
+    ///     let mut db = Connection::open_in_memory()?;
     ///     {
     ///         let mut called = std::sync::atomic::AtomicBool::new(false);
     ///         db.update_hook(Some(|_, _: &str, _: &str, _| {
@@ -630,15 +634,17 @@ impl InnerConnection {
         }
 
         let x = hook.as_ref().map(|_| call_boxed_closure::<F> as _);
-        let bh = self.set_clientdata(c"sqlite3_update_hook", hook)?;
-        unsafe { ffi::sqlite3_update_hook(self.db(), x, bh.cast()) };
+        self.set_clientdata(c"sqlite3_update_hook", hook, |db, bh| unsafe {
+            ffi::sqlite3_update_hook(db, x, bh);
+            ffi::SQLITE_OK
+        })?;
         Ok(())
     }
 
     /// ```compile_fail
     /// use rusqlite::{Connection, Result};
     /// fn main() -> Result<()> {
-    ///     let db = Connection::open_in_memory()?;
+    ///     let mut db = Connection::open_in_memory()?;
     ///     {
     ///         let mut called = std::sync::atomic::AtomicBool::new(false);
     ///         db.progress_handler(
@@ -673,17 +679,17 @@ impl InnerConnection {
         }
 
         let x = handler.as_ref().map(|_| call_boxed_closure::<F> as _);
-        let bh = self.set_clientdata(c"sqlite3_progress_handler", handler)?;
-        unsafe {
-            ffi::sqlite3_progress_handler(self.db(), num_ops, x, bh.cast());
-        };
+        self.set_clientdata(c"sqlite3_progress_handler", handler, |db, bh| unsafe {
+            ffi::sqlite3_progress_handler(db, num_ops, x, bh);
+            ffi::SQLITE_OK
+        })?;
         Ok(())
     }
 
     /// ```compile_fail
     /// use rusqlite::{Connection, Result};
     /// fn main() -> Result<()> {
-    ///     let db = Connection::open_in_memory()?;
+    ///     let mut db = Connection::open_in_memory()?;
     ///     {
     ///         let mut called = std::sync::atomic::AtomicBool::new(false);
     ///         db.authorizer(Some(|_: rusqlite::hooks::AuthContext<'_>| {
@@ -737,21 +743,10 @@ impl InnerConnection {
         let x_auth = authorizer
             .as_ref()
             .map(|_| call_boxed_closure::<'c, F> as _);
-        let bh = self.set_clientdata(c"sqlite3_set_authorizer", authorizer)?;
-
-        match unsafe { ffi::sqlite3_set_authorizer(self.db(), x_auth, bh.cast()) } {
-            ffi::SQLITE_OK => Ok(()),
-            err_code => {
-                // The only error that `sqlite3_set_authorizer` returns is `SQLITE_MISUSE`
-                // when compiled with `ENABLE_API_ARMOR` and the db pointer is invalid.
-                // This library does not allow constructing a null db ptr, so if this branch
-                // is hit, something very bad has happened. Panicking instead of returning
-                // `Result` keeps this hook's API consistent with the others.
-                panic!("unexpectedly failed to set_authorizer: {}", unsafe {
-                    crate::error::error_from_handle(self.db(), err_code)
-                });
-            }
-        }
+        self.set_clientdata(c"sqlite3_set_authorizer", authorizer, |db, bh| unsafe {
+            ffi::sqlite3_set_authorizer(db, x_auth, bh)
+        })?;
+        Ok(())
     }
 }
 
@@ -788,7 +783,7 @@ mod test {
 
     #[test]
     fn test_commit_hook() -> Result<()> {
-        let db = Connection::open_in_memory()?;
+        let mut db = Connection::open_in_memory()?;
 
         static CALLED: AtomicBool = AtomicBool::new(false);
         db.commit_hook(Some(|| {
@@ -802,7 +797,7 @@ mod test {
 
     #[test]
     fn test_fn_commit_hook() -> Result<()> {
-        let db = Connection::open_in_memory()?;
+        let mut db = Connection::open_in_memory()?;
 
         fn hook() -> bool {
             true
@@ -816,7 +811,7 @@ mod test {
 
     #[test]
     fn test_rollback_hook() -> Result<()> {
-        let db = Connection::open_in_memory()?;
+        let mut db = Connection::open_in_memory()?;
 
         static CALLED: AtomicBool = AtomicBool::new(false);
         db.rollback_hook(Some(|| {
@@ -829,7 +824,7 @@ mod test {
 
     #[test]
     fn test_update_hook() -> Result<()> {
-        let db = Connection::open_in_memory()?;
+        let mut db = Connection::open_in_memory()?;
 
         static CALLED: AtomicBool = AtomicBool::new(false);
         db.update_hook(Some(|action, db: &str, tbl: &str, row_id| {
@@ -847,7 +842,7 @@ mod test {
 
     #[test]
     fn test_progress_handler() -> Result<()> {
-        let db = Connection::open_in_memory()?;
+        let mut db = Connection::open_in_memory()?;
 
         static CALLED: AtomicBool = AtomicBool::new(false);
         db.progress_handler(
@@ -864,7 +859,7 @@ mod test {
 
     #[test]
     fn test_progress_handler_interrupt() -> Result<()> {
-        let db = Connection::open_in_memory()?;
+        let mut db = Connection::open_in_memory()?;
 
         fn handler() -> bool {
             true
@@ -880,7 +875,7 @@ mod test {
     fn test_authorizer() -> Result<()> {
         use super::{AuthAction, AuthContext, Authorization};
 
-        let db = Connection::open_in_memory()?;
+        let mut db = Connection::open_in_memory()?;
         db.execute_batch("CREATE TABLE foo (public TEXT, private TEXT)")?;
 
         let authorizer = move |ctx: AuthContext<'_>| match ctx.action {
@@ -919,7 +914,7 @@ mod test {
         let temp_dir = tempfile::tempdir().unwrap();
         let path = temp_dir.path().join("wal-hook.db3");
 
-        let db = Connection::open(&path)?;
+        let mut db = Connection::open(&path)?;
         let journal_mode: String =
             db.pragma_update_and_check(None, "journal_mode", "wal", |row| row.get(0))?;
         assert_eq!(journal_mode, "wal");
@@ -948,7 +943,7 @@ mod test {
 
     #[test]
     fn test_non_owning_hooks_cleanup() -> Result<()> {
-        let conn = Connection::open_in_memory()?;
+        let mut conn = Connection::open_in_memory()?;
 
         static CALLED: AtomicBool = AtomicBool::new(false);
         CALLED.store(false, Ordering::Relaxed);

--- a/src/hooks/preupdate_hook.rs
+++ b/src/hooks/preupdate_hook.rs
@@ -129,7 +129,7 @@ impl Connection {
     /// - a variant of the PreUpdateCase enum which allows access to extra functions depending
     ///   on whether it's an update, delete or insert.
     #[inline]
-    pub fn preupdate_hook<F>(&self, hook: Option<F>) -> Result<()>
+    pub fn preupdate_hook<F>(&mut self, hook: Option<F>) -> Result<()>
     where
         F: FnMut(Action, &str, &str, &PreUpdateCase) + Send + 'static,
     {
@@ -204,8 +204,10 @@ impl InnerConnection {
         }
 
         let x_pre_update = hook.as_ref().map(|_| call_boxed_closure::<F> as _);
-        let bh = self.set_clientdata(c"sqlite3_preupdate_hook", hook)?;
-        unsafe { ffi::sqlite3_preupdate_hook(self.db(), x_pre_update, bh as *mut _) };
+        self.set_clientdata(c"sqlite3_preupdate_hook", hook, |db, bh| unsafe {
+            ffi::sqlite3_preupdate_hook(db, x_pre_update, bh);
+            ffi::SQLITE_OK
+        })?;
         Ok(())
     }
 }
@@ -223,7 +225,7 @@ mod test {
 
     #[test]
     fn test_preupdate_hook_insert() -> Result<()> {
-        let db = Connection::open_in_memory()?;
+        let mut db = Connection::open_in_memory()?;
 
         static CALLED: AtomicBool = AtomicBool::new(false);
 
@@ -256,7 +258,7 @@ mod test {
 
     #[test]
     fn test_preupdate_hook_delete() -> Result<()> {
-        let db = Connection::open_in_memory()?;
+        let mut db = Connection::open_in_memory()?;
 
         static CALLED: AtomicBool = AtomicBool::new(false);
 
@@ -292,7 +294,7 @@ mod test {
 
     #[test]
     fn test_preupdate_hook_update() -> Result<()> {
-        let db = Connection::open_in_memory()?;
+        let mut db = Connection::open_in_memory()?;
 
         static CALLED: AtomicBool = AtomicBool::new(false);
 

--- a/src/inner_connection.rs
+++ b/src/inner_connection.rs
@@ -337,13 +337,25 @@ impl InnerConnection {
         crate::error::check(unsafe { ffi::sqlite3_file_control(self.db, cn, op, arg) })
     }
 
-    pub fn set_clientdata<T: Send + 'static, N: Name>(
+    pub fn set_clientdata<
+        T: Send + 'static,
+        N: Name,
+        F: Fn(*mut ffi::sqlite3, *mut c_void) -> c_int,
+    >(
         &mut self,
         name: N,
         data: Option<T>,
+        preset: F,
     ) -> Result<*mut T> {
         let name = name.as_cstr()?;
         let ptr = data.map_or(ptr::null_mut(), |d| Box::into_raw(Box::new(d)));
+        let res = self.decode_result(preset(self.db, ptr.cast()));
+        if res.is_err() {
+            if !ptr.is_null() {
+                unsafe { crate::util::free_boxed_value::<T>(ptr.cast()) };
+            }
+            res?;
+        }
         self.decode_result(unsafe {
             ffi::sqlite3_set_clientdata(
                 self.db,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1117,7 +1117,9 @@ impl Connection {
         name: N,
         data: Option<T>,
     ) -> Result<*mut T> {
-        self.db.borrow_mut().set_clientdata(name, data)
+        self.db
+            .borrow_mut()
+            .set_clientdata(name, data, |_, _| ffi::SQLITE_OK)
     }
     /// Retrieve client data
     ///

--- a/src/trace.rs
+++ b/src/trace.rs
@@ -158,7 +158,7 @@ impl ConnRef<'_> {
 
 impl Connection {
     /// Register or clear a trace callback function
-    pub fn trace_v2<F>(&self, mask: TraceEventCodes, trace_fn: Option<F>) -> Result<()>
+    pub fn trace_v2<F>(&mut self, mask: TraceEventCodes, trace_fn: Option<F>) -> Result<()>
     where
         F: FnMut(TraceEvent<'_>) + Send + 'static,
     {
@@ -208,10 +208,10 @@ impl Connection {
         }
         let mut c = self.db.borrow_mut();
         let x = trace_fn.as_ref().map(|_| trace_callback::<F> as _);
-        let bh = c.set_clientdata(c"sqlite3_trace_v2", trace_fn)?;
-        unsafe {
-            ffi::sqlite3_trace_v2(c.db(), mask.bits(), x, bh.cast());
-        }
+        c.set_clientdata(c"sqlite3_trace_v2", trace_fn, |db, bh| unsafe {
+            ffi::sqlite3_trace_v2(db, mask.bits(), x, bh);
+            ffi::SQLITE_OK
+        })?;
         Ok(())
     }
 }
@@ -231,7 +231,7 @@ mod test {
         use std::borrow::Borrow as _;
         use std::cmp::Ordering;
 
-        let db = Connection::open_in_memory()?;
+        let mut db = Connection::open_in_memory()?;
         db.trace_v2(
             TraceEventCodes::all(),
             Some(|e: TraceEvent<'_>| match e {
@@ -265,14 +265,14 @@ mod test {
         db.one_column::<u32, _>("PRAGMA user_version", [])?;
         drop(db);
 
-        let db = Connection::open_in_memory()?;
+        let mut db = Connection::open_in_memory()?;
         db.trace_v2(TraceEventCodes::empty(), None::<fn(TraceEvent<'_>)>)
     }
 
     #[test]
     #[cfg(feature = "blob")]
     pub fn null_sql() -> Result<()> {
-        let db = Connection::open_in_memory()?;
+        let mut db = Connection::open_in_memory()?;
         let sql = "CREATE TABLE test (content BLOB);
                    INSERT INTO test VALUES (ZEROBLOB(10));";
         db.execute_batch(sql)?;

--- a/src/trace.rs
+++ b/src/trace.rs
@@ -218,6 +218,7 @@ impl Connection {
 
 #[cfg(all(test, not(miri)))]
 mod test {
+    use std::cell::RefCell;
     #[cfg(all(target_family = "wasm", target_os = "unknown"))]
     use wasm_bindgen_test::wasm_bindgen_test as test;
 
@@ -289,5 +290,42 @@ mod test {
         db.blob_open(crate::MAIN_DB, c"test", c"content", rowid, true)?;
 
         Ok(())
+    }
+
+    #[test]
+    #[cfg_attr(all(target_family = "wasm", target_os = "unknown"), ignore)]
+    pub fn already_borrowed() {
+        thread_local! {
+            static CONN: RefCell<Option<Connection>> = const { RefCell::new(None) };
+        }
+        CONN.with_borrow_mut(|c| c.replace(Connection::open_in_memory().unwrap()));
+        let budget: Vec<u8> = vec![0];
+        CONN.with_borrow_mut(|c| {
+            c.as_mut()
+                .unwrap()
+                .trace_v2(
+                    TraceEventCodes::SQLITE_TRACE_STMT,
+                    Some(move |e: TraceEvent<'_>| {
+                        if let TraceEvent::Stmt(_, sql) = e {
+                            println!("{}", sql);
+                        }
+                        CONN.with_borrow_mut(|c| {
+                            c.as_mut()
+                                .unwrap()
+                                .trace_v2(
+                                    TraceEventCodes::SQLITE_TRACE_STMT,
+                                    None::<fn(TraceEvent)>,
+                                )
+                                .unwrap();
+                        });
+                        println!("{}", budget[0]);
+                    }),
+                )
+                .unwrap();
+            c.as_ref()
+                .unwrap()
+                .query_one("SELECT 1;", [], |r| r.get::<_, bool>(0))
+                .unwrap();
+        });
     }
 }


### PR DESCRIPTION
Fix issue reported by @marius-momeu :
> While auditing rusqlite for memory-safety issues reachable from safe code, we
found a use-after-free introduced on `master` by PR #1791
("sqlite3_set_clientdata / sqlite3_get_clientdata"), commits 36f3b84 (trace) and
9900bd6 (busy). Released 0.40.1 is not affected: there those callbacks were
still plain `fn` pointers. We found more similar issues, this is just the first one
that we're reporting. Let me know if you'd like them reported the same way.
>
> Issue
> -----
> `Connection::trace_v2` (src/trace.rs:211) and `Connection::busy_handler`
(src/busy.rs:75) box the user closure and store it with
`sqlite3_set_clientdata`. That C function unconditionally runs the previous
entry's destructor (sqlite3.c, `if( p->xDestructor ) p->xDestructor(p->pData);`)
— it has no "in use" guard, unlike `sqlite3_create_function*` /
`sqlite3_create_collation*`, which return SQLITE_BUSY while `db->nVdbeActive`.
> 
> Both callbacks fire inside `sqlite3_step()`, where rusqlite holds no RefCell
borrow on the connection. So if the callback re-registers itself — the natural
"trace N events then stop", or "retry twice then uninstall the busy handler" —
rusqlite drops the `Box<F>` while `trace_callback::<F>` is still executing
`(*trace_fn)(...)` inside it. Everything the closure captured is freed and the
`&mut F` goes dangling. No unsafe, no panic, API returns Ok(()).
```rust
    conn.trace_v2(TraceEventCodes::SQLITE_TRACE_ROW, Some(move |_e| {
        budget[0] -= 1;                       // Vec<u8> captured by the closure
        if budget[0] == 0 {
            conn.trace_v2(TraceEventCodes::empty(), None::<fn(TraceEvent<'_>)>).unwrap();
        }
        println!("{}", budget[0]);            // <-- read of freed memory
    }))?;
```
> 
> AddressSanitizer (nightly, `-Zsanitizer=address`, bundled SQLite 3.53.4):
```
    ERROR: AddressSanitizer: heap-use-after-free ... READ of size 8
      #7  <closure> src/main.rs:39
      #8  rusqlite::Connection::trace_v2::trace_callback  src/trace.rs:193
      #14 sqlite3VdbeExec / sqlite3_step
    freed by thread T0 here:
      #8  rusqlite::util::free_boxed_value  src/util/mod.rs:12
      #9  sqlite3_set_clientdata            sqlite3.c:191298
      #11 rusqlite::Connection::trace_v2    src/trace.rs:211
```
> 
> Without a sanitizer it segfaults. An equivalent reproducer exists for
`busy_handler` (also `busy_timeout`, src/busy.rs:86).
>
> Scope
> -----
> The same shape exists for every `set_clientdata`-backed callback:
`hooks/mod.rs` (commit/rollback/update/wal hooks, progress_handler, authorizer)
and `hooks/preupdate_hook.rs`. We reproduced only trace and busy.
`create_scalar_function` / `create_collation` are safe — SQLite's own
SQLITE_BUSY guard blocks the re-entrant replacement.
> 
> Fix direction: do not let SQLite free the old box eagerly (keep it owned by the
connection / defer the drop), or reject re-entrant registration.
>
> Reproducers available on request. We are only disclosing; no patch is attached.
> Found by [Crustify](https://github.com/crustify-rs/crustify-audit), an
experimental UB/soundness auditing agent developed at UC Berkeley and running on
claude-opus-5, then manually reviewed and independently reproduced.
