### PR TITLE
Don't enable SQLITE_ENABLE_MEMORY_MANAGEMENT in the bundled build

### DIFF
--- a/libsqlite3-sys/build.rs
+++ b/libsqlite3-sys/build.rs
@@ -163,7 +163,6 @@ mod build_bundled {
             .flag("-DSQLITE_ENABLE_FTS5")
             .flag("-DSQLITE_ENABLE_JSON1")
             .flag("-DSQLITE_ENABLE_LOAD_EXTENSION=1")
-            .flag("-DSQLITE_ENABLE_MEMORY_MANAGEMENT")
             .flag("-DSQLITE_ENABLE_RTREE")
             .flag("-DSQLITE_ENABLE_STAT4")
             .flag("-DSQLITE_SOUNDEX")


### PR DESCRIPTION
Updated to take @gwenn's suggestion: no feature flag, just drop the define from the bundled build.

The flag has been hardcoded since the flag list was first put together in 2016 (#197), where it was copied over from other SQLite bindings. It has a real runtime cost (memory accounting overhead, and it forces the unified page cache), and since #1608 nothing in rusqlite itself needs it: `Connection::release_memory` uses `sqlite3_db_release_memory`, which works either way, and `sqlite3_release_memory` is only reachable through raw ffi.

Anyone who still wants it can pass `LIBSQLITE3_FLAGS="-DSQLITE_ENABLE_MEMORY_MANAGEMENT"`.