### PR TITLE
Fix warnings

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,6 @@ rust-version = "1.88.0"
 description = "Ergonomic wrapper for SQLite"
 repository = "https://github.com/rusqlite/rusqlite"
 documentation = "https://docs.rs/rusqlite/"
-readme = "README.md"
 keywords = ["sqlite", "database", "ffi"]
 license = "MIT"
 categories = ["database"]

--- a/libsqlite3-sys/Cargo.toml
+++ b/libsqlite3-sys/Cargo.toml
@@ -66,3 +66,6 @@ syn = { version = "3.0.1", optional = true, features = [
     "extra-traits",
     "visit-mut",
 ] }
+
+[lints]
+workspace = true

--- a/rusqlite-macros/Cargo.toml
+++ b/rusqlite-macros/Cargo.toml
@@ -15,3 +15,6 @@ proc-macro = true
 sqlite3-parser = { version = "0.17", default-features = false, features = ["YYNOERRORRECOVERY"] }
 fallible-iterator = "0.3"
 litrs = "1.0.0"
+
+[lints]
+workspace = true

--- a/rusqlite-macros/src/lib.rs
+++ b/rusqlite-macros/src/lib.rs
@@ -3,10 +3,10 @@
 use litrs::StringLit;
 use proc_macro::{Delimiter, Group, Literal, Span, TokenStream, TokenTree};
 
-use fallible_iterator::FallibleIterator;
+use fallible_iterator::FallibleIterator as _;
 use sqlite3_parser::Bump;
 use sqlite3_parser::ast::ParameterInfo;
-use sqlite3_parser::ast::fmt::ToTokens;
+use sqlite3_parser::ast::fmt::ToTokens as _;
 use sqlite3_parser::lexer::sql::Parser;
 
 // https://internals.rust-lang.org/t/custom-error-diagnostics-with-procedural-macros-on-almost-stable-rust/8113
@@ -101,7 +101,7 @@ fn respan(ts: TokenStream, span: Span) -> TokenStream {
             }
             _ => tt,
         };
-        res.extend(Some(tt))
+        res.extend(Some(tt));
     }
     res
 }


### PR DESCRIPTION
explicit `package.readme` can be inferred
missing `[lints]` to inherit `[workspace.lints]`